### PR TITLE
Add Foundation Model extraction and OGP site_name

### DIFF
--- a/MangaLauncher.xcodeproj/project.pbxproj
+++ b/MangaLauncher.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		07DC3626A7CCE68BC3104819 /* MangaExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B138E27E85232B142C3EE04 /* MangaExtractor.swift */; };
 		0AD569E2465106D7BC72914B /* PlatformHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDD9A4D8748B9496E85A2A67 /* PlatformHelpers.swift */; };
 		0F66A6093327A5A5BD16B10F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E7D977DE254FB1F216740BE6 /* Foundation.framework */; };
 		125D8CEEBC201DD7B9C5BCE3 /* ShareExtensionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 358605C94F78CC23682FF911 /* ShareExtensionView.swift */; };
@@ -31,6 +32,7 @@
 		A1000005 /* EditEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000005 /* EditEntryView.swift */; };
 		A1000006 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A2000006 /* Assets.xcassets */; };
 		A1A8B2ACB18D6E541985F304 /* MasonryLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96C7D9E283FFCADD60181726 /* MasonryLayout.swift */; };
+		AA1A443BC272B614249A8616 /* MangaExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B138E27E85232B142C3EE04 /* MangaExtractor.swift */; };
 		B26E164ECFAC0FC6A4B39CC6 /* SharedModelContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C7FA9735199D021E15CEED8 /* SharedModelContainer.swift */; };
 		BA7DD3DF9519EF632F306D36 /* OGPImageFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9992960F4542D9303A849505 /* OGPImageFetcher.swift */; };
 		C6C5CFFF9326B9E91FED309D /* OGPImageFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9992960F4542D9303A849505 /* OGPImageFetcher.swift */; };
@@ -87,6 +89,7 @@
 		501DFBA332C24E2F563C81D7 /* MangaWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = MangaWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		68E247987CED890FF8E2D6A1 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		7EFDC883F33BA3C119960C0B /* MangaWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MangaWidget.swift; sourceTree = "<group>"; };
+		8B138E27E85232B142C3EE04 /* MangaExtractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MangaExtractor.swift; sourceTree = "<group>"; };
 		90F26F2E86530882A39954F6 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		96C7D9E283FFCADD60181726 /* MasonryLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MasonryLayout.swift; sourceTree = "<group>"; };
 		9992960F4542D9303A849505 /* OGPImageFetcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OGPImageFetcher.swift; sourceTree = "<group>"; };
@@ -157,6 +160,7 @@
 			isa = PBXGroup;
 			children = (
 				9992960F4542D9303A849505 /* OGPImageFetcher.swift */,
+				8B138E27E85232B142C3EE04 /* MangaExtractor.swift */,
 			);
 			name = Services;
 			path = Services;
@@ -419,6 +423,7 @@
 				63696DAFAE55A61EC72070CA /* MangaEntry.swift in Sources */,
 				45F5A38A61E6E779064A1E6F /* PlatformHelpers.swift in Sources */,
 				B26E164ECFAC0FC6A4B39CC6 /* SharedModelContainer.swift in Sources */,
+				AA1A443BC272B614249A8616 /* MangaExtractor.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -439,6 +444,7 @@
 				3E27882FDDEB43FF0F253020 /* BackupData.swift in Sources */,
 				A1A8B2ACB18D6E541985F304 /* MasonryLayout.swift in Sources */,
 				BA7DD3DF9519EF632F306D36 /* OGPImageFetcher.swift in Sources */,
+				07DC3626A7CCE68BC3104819 /* MangaExtractor.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MangaLauncher/Services/MangaExtractor.swift
+++ b/MangaLauncher/Services/MangaExtractor.swift
@@ -1,0 +1,45 @@
+import Foundation
+import FoundationModels
+
+@Generable
+struct ExtractedMangaInfo {
+    @Guide(description: "メインの固有名詞。サービス名とは異なるもの。")
+    var title: String
+
+    @Guide(description: "URL")
+    var url: String
+
+    @Guide(description: "サービス名やプラットフォーム名")
+    var publisher: String
+}
+
+enum MangaExtractor {
+    struct ExtractionResult {
+        var title: String
+        var url: String
+        var publisher: String
+        var method: String
+    }
+
+    static func extract(sharedText: String, sharedURL: String) async -> ExtractionResult {
+        let model = SystemLanguageModel.default
+
+        guard model.isAvailable else {
+            return ExtractionResult(title: "", url: sharedURL, publisher: "", method: "unavailable")
+        }
+
+        do {
+            let session = LanguageModelSession()
+            let prompt = """
+            以下のテキストから2つの異なる固有名詞を抽出してください。
+
+            \(sharedText)
+            """
+            let response = try await session.respond(to: prompt, generating: ExtractedMangaInfo.self)
+            let info = response.content
+            return ExtractionResult(title: info.title, url: info.url, publisher: info.publisher, method: "ai")
+        } catch {
+            return ExtractionResult(title: "", url: sharedURL, publisher: "", method: "error: \(error)")
+        }
+    }
+}

--- a/MangaLauncher/Services/OGPImageFetcher.swift
+++ b/MangaLauncher/Services/OGPImageFetcher.swift
@@ -1,34 +1,52 @@
 import Foundation
 
-enum OGPImageFetcher {
-    static func fetchOGPImageData(from urlString: String) async -> Data? {
-        guard let url = URL(string: urlString) else { return nil }
+struct OGPResult {
+    var imageData: Data?
+    var siteName: String?
+    var title: String?
+}
+
+enum OGPFetcher {
+    static func fetch(from urlString: String) async -> OGPResult {
+        guard let url = URL(string: urlString) else { return OGPResult() }
         do {
             let (data, _) = try await URLSession.shared.data(from: url)
-            guard let html = String(data: data, encoding: .utf8) else { return nil }
-            guard let imageURLString = extractOGPImageURL(from: html, baseURL: url) else { return nil }
-            guard let imageURL = URL(string: imageURLString) else { return nil }
-            let (imageData, _) = try await URLSession.shared.data(from: imageURL)
-            return downsizedJPEGData(imageData, maxDimension: 600)
+            guard let html = String(data: data, encoding: .utf8) else { return OGPResult() }
+
+            let siteName = extractMetaContent(from: html, property: "og:site_name")
+            let ogTitle = extractMetaContent(from: html, property: "og:title")
+
+            var imageData: Data?
+            if let imageURLString = extractMetaContent(from: html, property: "og:image") {
+                let resolvedURL: String
+                if imageURLString.hasPrefix("http") {
+                    resolvedURL = imageURLString
+                } else {
+                    resolvedURL = URL(string: imageURLString, relativeTo: url)?.absoluteString ?? imageURLString
+                }
+                if let imageURL = URL(string: resolvedURL),
+                   let (imgData, _) = try? await URLSession.shared.data(from: imageURL) {
+                    imageData = downsizedJPEGData(imgData, maxDimension: 600)
+                }
+            }
+
+            return OGPResult(imageData: imageData, siteName: siteName, title: ogTitle)
         } catch {
-            return nil
+            return OGPResult()
         }
     }
 
-    private static func extractOGPImageURL(from html: String, baseURL: URL) -> String? {
-        // Try pattern: <meta property="og:image" content="...">
+    private static func extractMetaContent(from html: String, property: String) -> String? {
         let patterns = [
-            #/<meta[^>]*property\s*=\s*"og:image"[^>]*content\s*=\s*"([^"]+)"/#,
-            #/<meta[^>]*content\s*=\s*"([^"]+)"[^>]*property\s*=\s*"og:image"/#
+            "property\\s*=\\s*\"\(property)\"[^>]*content\\s*=\\s*\"([^\"]+)\"",
+            "content\\s*=\\s*\"([^\"]+)\"[^>]*property\\s*=\\s*\"\(property)\""
         ]
-        for pattern in patterns {
-            if let match = html.firstMatch(of: pattern) {
-                let urlString = String(match.1)
-                if urlString.hasPrefix("http") {
-                    return urlString
-                }
-                // Handle relative URLs
-                return URL(string: urlString, relativeTo: baseURL)?.absoluteString
+        for patternString in patterns {
+            guard let regex = try? NSRegularExpression(pattern: patternString) else { continue }
+            let range = NSRange(html.startIndex..., in: html)
+            if let match = regex.firstMatch(in: html, range: range),
+               let captureRange = Range(match.range(at: 1), in: html) {
+                return String(html[captureRange])
             }
         }
         return nil

--- a/MangaShareExtension/ShareExtensionView.swift
+++ b/MangaShareExtension/ShareExtensionView.swift
@@ -6,6 +6,7 @@ struct ShareExtensionView: View {
     let extensionContext: NSExtensionContext?
 
     @State private var isLoading = true
+    @State private var aiExtracted = false
     @State private var name = ""
     @State private var url = ""
     @State private var publisher = ""
@@ -51,7 +52,7 @@ struct ShareExtensionView: View {
                 }
             } else {
                 Form {
-                    Section("基本情報") {
+                    Section {
                         TextField("名前", text: $name)
                             .textInputAutocapitalization(.never)
                         TextField("URL", text: $url)
@@ -65,6 +66,12 @@ struct ShareExtensionView: View {
                         }
                         TextField("掲載誌", text: $publisher)
                             .textInputAutocapitalization(.never)
+                    } header: {
+                        Text("基本情報")
+                    } footer: {
+                        if aiExtracted {
+                            Text("名前はAIによる推定です。内容を確認してください。")
+                        }
                     }
 
                     Section("画像") {
@@ -197,12 +204,28 @@ struct ShareExtensionView: View {
             }
         }
 
-        // Set URL
         url = sharedURL
 
-        // Fetch OGP image
-        if !url.isEmpty {
-            imageData = await OGPImageFetcher.fetchOGPImageData(from: url)
+        // Fetch OGP data (image, site_name)
+        if !sharedURL.isEmpty {
+            let ogp = await OGPFetcher.fetch(from: sharedURL)
+            imageData = ogp.imageData
+            if let siteName = ogp.siteName, !siteName.isEmpty {
+                publisher = siteName
+            }
+        }
+
+        // Extract manga title using Foundation Model
+        let result = await MangaExtractor.extract(sharedText: sharedText, sharedURL: sharedURL)
+
+        // Only use AI results if title and publisher are different
+        if result.method == "ai" && !result.title.isEmpty && !result.publisher.isEmpty && result.title != result.publisher {
+            name = result.title
+            // AI publisher overrides OGP site_name only if publisher is still empty
+            if publisher.isEmpty {
+                publisher = result.publisher
+            }
+            aiExtracted = true
         }
 
         isLoading = false


### PR DESCRIPTION
## Summary
- Foundation Modelで共有テキストからマンガタイトルを抽出
- guardrailViolationや抽出失敗時はタイトルを空にしてユーザーに手入力を委ねる
- OGPの`og:site_name`から掲載誌を自動補完
- AI抽出成功時は「名前はAIによる推定です」と注意文を表示
- OCRアプローチは精度不足のため削除

## Test plan
- [x] Foundation Modelでタイトル抽出が成功するケースを確認
- [x] guardrailViolation時にタイトルが空になることを確認
- [x] og:site_nameから掲載誌が補完されることを確認
- [x] AI注意文が適切に表示/非表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)