### PR TITLE
Add App Intent for Shortcuts integration

### DIFF
--- a/MangaLauncher.xcodeproj/project.pbxproj
+++ b/MangaLauncher.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		A1A8B2ACB18D6E541985F304 /* MasonryLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96C7D9E283FFCADD60181726 /* MasonryLayout.swift */; };
 		AA1A443BC272B614249A8616 /* MangaExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B138E27E85232B142C3EE04 /* MangaExtractor.swift */; };
 		B26E164ECFAC0FC6A4B39CC6 /* SharedModelContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C7FA9735199D021E15CEED8 /* SharedModelContainer.swift */; };
+		B31B9EA2FE243CD2D6209258 /* AddMangaIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55D3FF44BE586A52AAF2B43 /* AddMangaIntent.swift */; };
 		BA7DD3DF9519EF632F306D36 /* OGPImageFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9992960F4542D9303A849505 /* OGPImageFetcher.swift */; };
 		C6C5CFFF9326B9E91FED309D /* OGPImageFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9992960F4542D9303A849505 /* OGPImageFetcher.swift */; };
 		D43D0695E7E3840F3142A594 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDE508C489E5FAA3881A522 /* SettingsView.swift */; };
@@ -102,6 +103,7 @@
 		A2000005 /* EditEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditEntryView.swift; sourceTree = "<group>"; };
 		A2000006 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		A3000001 /* MangaLauncher.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MangaLauncher.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		A55D3FF44BE586A52AAF2B43 /* AddMangaIntent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AddMangaIntent.swift; sourceTree = "<group>"; };
 		A576F9BEFBD3B37AA9275FAB /* MangaWidget.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = MangaWidget.entitlements; sourceTree = "<group>"; };
 		BB770326E8D34706AF8B81EC /* UniformTypeIdentifiers.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UniformTypeIdentifiers.framework; path = System/Library/Frameworks/UniformTypeIdentifiers.framework; sourceTree = SDKROOT; };
 		BC0276ADB2A6EFEC185148CA /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -194,6 +196,15 @@
 			path = MangaShareExtension;
 			sourceTree = "<group>";
 		};
+		873452A3D59E456024C0BC36 /* Intents */ = {
+			isa = PBXGroup;
+			children = (
+				A55D3FF44BE586A52AAF2B43 /* AddMangaIntent.swift */,
+			);
+			name = Intents;
+			path = Intents;
+			sourceTree = "<group>";
+		};
 		A5000001 = {
 			isa = PBXGroup;
 			children = (
@@ -219,6 +230,7 @@
 				F75AA6830F31ABE5BD81DE01 /* MangaLauncherDebug.entitlements */,
 				1C15BF6E9DE64673E7194826 /* Services */,
 				9E18CC353D62E01CB4A12BC8 /* Info.plist */,
+				873452A3D59E456024C0BC36 /* Intents */,
 			);
 			path = MangaLauncher;
 			sourceTree = "<group>";
@@ -445,6 +457,7 @@
 				A1A8B2ACB18D6E541985F304 /* MasonryLayout.swift in Sources */,
 				BA7DD3DF9519EF632F306D36 /* OGPImageFetcher.swift in Sources */,
 				07DC3626A7CCE68BC3104819 /* MangaExtractor.swift in Sources */,
+				B31B9EA2FE243CD2D6209258 /* AddMangaIntent.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MangaLauncher/Intents/AddMangaIntent.swift
+++ b/MangaLauncher/Intents/AddMangaIntent.swift
@@ -1,0 +1,107 @@
+import AppIntents
+import SwiftData
+
+enum DayOfWeekAppEnum: String, AppEnum {
+    case sunday, monday, tuesday, wednesday, thursday, friday, saturday
+
+    static var typeDisplayRepresentation: TypeDisplayRepresentation {
+        "曜日"
+    }
+
+    static var caseDisplayRepresentations: [DayOfWeekAppEnum: DisplayRepresentation] {
+        [
+            .sunday: "日曜日",
+            .monday: "月曜日",
+            .tuesday: "火曜日",
+            .wednesday: "水曜日",
+            .thursday: "木曜日",
+            .friday: "金曜日",
+            .saturday: "土曜日",
+        ]
+    }
+
+    var toDayOfWeek: DayOfWeek {
+        switch self {
+        case .sunday: .sunday
+        case .monday: .monday
+        case .tuesday: .tuesday
+        case .wednesday: .wednesday
+        case .thursday: .thursday
+        case .friday: .friday
+        case .saturday: .saturday
+        }
+    }
+}
+
+enum IconColorAppEnum: String, AppEnum {
+    case red, orange, yellow, green, blue, purple, pink, teal
+
+    static var typeDisplayRepresentation: TypeDisplayRepresentation {
+        "アイコンカラー"
+    }
+
+    static var caseDisplayRepresentations: [IconColorAppEnum: DisplayRepresentation] {
+        [
+            .red: "赤",
+            .orange: "オレンジ",
+            .yellow: "黄",
+            .green: "緑",
+            .blue: "青",
+            .purple: "紫",
+            .pink: "ピンク",
+            .teal: "ティール",
+        ]
+    }
+}
+
+// MARK: - Full registration intent (from Shortcuts app)
+
+struct AddMangaIntent: AppIntent {
+    static var title: LocalizedStringResource = "マンガを登録"
+    static var description: IntentDescription = "マンガ曜日に新しいマンガを登録します"
+    static var openAppWhenRun = true
+
+    @Parameter(title: "名前")
+    var name: String
+
+    @Parameter(title: "URL")
+    var url: String
+
+    @Parameter(title: "曜日")
+    var dayOfWeek: DayOfWeekAppEnum
+
+    @Parameter(title: "掲載誌", default: "")
+    var publisher: String?
+
+    @Parameter(title: "アイコンカラー", default: .blue)
+    var iconColor: IconColorAppEnum?
+
+    func perform() async throws -> some IntentResult {
+        let defaults = UserDefaults(suiteName: SharedModelContainer.appGroupIdentifier)
+        let intentData: [String: String] = [
+            "name": name,
+            "url": url,
+            "dayOfWeek": String(dayOfWeek.toDayOfWeek.rawValue),
+            "publisher": publisher ?? "",
+            "iconColor": (iconColor ?? .blue).rawValue,
+        ]
+        defaults?.set(intentData, forKey: "pendingIntentData")
+        return .result()
+    }
+}
+
+// MARK: - App Shortcuts
+
+struct MangaShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: AddMangaIntent(),
+            phrases: [
+                "マンガを\(.applicationName)に登録",
+                "\(.applicationName)にマンガを追加",
+            ],
+            shortTitle: "マンガを登録",
+            systemImageName: "plus.circle"
+        )
+    }
+}

--- a/MangaLauncher/MangaLauncherApp.swift
+++ b/MangaLauncher/MangaLauncherApp.swift
@@ -1,9 +1,24 @@
 import SwiftUI
 import SwiftData
 
+extension Notification.Name {
+    static let mangaDataDidChange = Notification.Name("mangaDataDidChange")
+}
+
+struct IntentPrefill: Identifiable {
+    let id = UUID()
+    let name: String
+    let url: String
+    let dayOfWeek: DayOfWeek
+    let publisher: String
+    let iconColor: String
+}
+
 @main
 struct MangaLauncherApp: App {
     let container: ModelContainer
+    @Environment(\.scenePhase) private var scenePhase
+    @State private var intentPrefill: IntentPrefill?
 
     init() {
         DataMigration.migrateToAppGroupIfNeeded()
@@ -20,8 +35,44 @@ struct MangaLauncherApp: App {
                 .onOpenURL { url in
                     handleDeepLink(url)
                 }
+                .sheet(item: $intentPrefill, onDismiss: {
+                    // Force refresh ContentView after intent registration
+                    NotificationCenter.default.post(name: .mangaDataDidChange, object: nil)
+                }) { prefill in
+                    EditEntryView(
+                        viewModel: MangaViewModel(modelContext: container.mainContext),
+                        prefilledName: prefill.name,
+                        prefilledURL: prefill.url,
+                        prefilledDay: prefill.dayOfWeek,
+                        prefilledPublisher: prefill.publisher,
+                        prefilledColor: prefill.iconColor
+                    )
+                }
+                .onAppear {
+                    checkPendingIntent()
+                }
+                .onChange(of: scenePhase) { _, newPhase in
+                    if newPhase == .active {
+                        checkPendingIntent()
+                    }
+                }
         }
         .modelContainer(container)
+    }
+
+    private func checkPendingIntent() {
+        let defaults = UserDefaults(suiteName: SharedModelContainer.appGroupIdentifier)
+        guard let data = defaults?.dictionary(forKey: "pendingIntentData") as? [String: String] else { return }
+        defaults?.removeObject(forKey: "pendingIntentData")
+
+        let dayRaw = Int(data["dayOfWeek"] ?? "") ?? DayOfWeek.today.rawValue
+        intentPrefill = IntentPrefill(
+            name: data["name"] ?? "",
+            url: data["url"] ?? "",
+            dayOfWeek: DayOfWeek(rawValue: dayRaw) ?? .today,
+            publisher: data["publisher"] ?? "",
+            iconColor: data["iconColor"] ?? "blue"
+        )
     }
 
     private func handleDeepLink(_ url: URL) {

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -137,6 +137,10 @@ final class MangaViewModel {
         return try? modelContext.fetch(descriptor).first
     }
 
+    func refresh() {
+        refreshCounter += 1
+    }
+
     private func save() {
         try? modelContext.save()
         refreshCounter += 1

--- a/MangaLauncher/Views/ContentView.swift
+++ b/MangaLauncher/Views/ContentView.swift
@@ -104,6 +104,9 @@ struct ContentView: View {
                 viewModel = MangaViewModel(modelContext: modelContext)
             }
         }
+        .onReceive(NotificationCenter.default.publisher(for: .mangaDataDidChange)) { _ in
+            viewModel?.refresh()
+        }
     }
 
     @ViewBuilder

--- a/MangaLauncher/Views/EditEntryView.swift
+++ b/MangaLauncher/Views/EditEntryView.swift
@@ -45,6 +45,17 @@ struct EditEntryView: View {
         _selectedDay = State(initialValue: day)
     }
 
+    init(viewModel: MangaViewModel, prefilledName: String, prefilledURL: String, prefilledDay: DayOfWeek, prefilledPublisher: String, prefilledColor: String, prefilledImageData: Data? = nil) {
+        self.viewModel = viewModel
+        self.entry = nil
+        _name = State(initialValue: prefilledName)
+        _url = State(initialValue: prefilledURL)
+        _selectedDay = State(initialValue: prefilledDay)
+        _publisher = State(initialValue: prefilledPublisher)
+        _selectedColor = State(initialValue: prefilledColor)
+        _imageData = State(initialValue: prefilledImageData)
+    }
+
     var body: some View {
         NavigationStack {
             Form {


### PR DESCRIPTION
## Summary
- iOSショートカットから「マンガを登録」アクションを追加
- ショートカット実行でアプリが起動し、入力内容がプリフィルされた新規登録画面を表示
- 登録後のContentView画面更新を修正

## Test plan
- [x] ショートカットアプリで「マンガを登録」アクションが表示されること
- [x] 名前、URL、曜日、掲載誌、カラーを入力して実行するとアプリが起動すること
- [x] 新規登録画面に入力内容がプリフィルされていること
- [x] 保存後にContentViewのリストが更新されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)