### PR TITLE
Add Mantis license notice to settings

### DIFF
--- a/MangaLauncher/Views/SettingsView.swift
+++ b/MangaLauncher/Views/SettingsView.swift
@@ -69,34 +69,9 @@ struct SettingsView: View {
                     Text("バックアップはJSON形式で保存されます。インポート時、同じIDのエントリはスキップされます。")
                 }
 
-                Section("ライセンス") {
-                    NavigationLink("Mantis") {
-                        LicenseDetailView(
-                            name: "Mantis",
-                            licenseText: """
-                            MIT License
-
-                            Copyright (c) 2018 Yingtao Guo
-
-                            Permission is hereby granted, free of charge, to any person obtaining a copy \
-                            of this software and associated documentation files (the "Software"), to deal \
-                            in the Software without restriction, including without limitation the rights \
-                            to use, copy, modify, merge, publish, distribute, sublicense, and/or sell \
-                            copies of the Software, and to permit persons to whom the Software is \
-                            furnished to do so, subject to the following conditions:
-
-                            The above copyright notice and this permission notice shall be included in all \
-                            copies or substantial portions of the Software.
-
-                            THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR \
-                            IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, \
-                            FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE \
-                            AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER \
-                            LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, \
-                            OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE \
-                            SOFTWARE.
-                            """
-                        )
+                Section {
+                    NavigationLink("ライセンス") {
+                        LicenseListView()
                     }
                 }
 
@@ -169,19 +144,53 @@ struct SettingsView: View {
         return BackupDocument(data: data)
     }
 
-    private struct LicenseDetailView: View {
-        let name: String
-        let licenseText: String
+    private struct LicenseListView: View {
+        private let licenses: [(name: String, text: String)] = [
+            (
+                "Mantis",
+                """
+                MIT License
+
+                Copyright (c) 2018 Yingtao Guo
+
+                Permission is hereby granted, free of charge, to any person obtaining a copy \
+                of this software and associated documentation files (the "Software"), to deal \
+                in the Software without restriction, including without limitation the rights \
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell \
+                copies of the Software, and to permit persons to whom the Software is \
+                furnished to do so, subject to the following conditions:
+
+                The above copyright notice and this permission notice shall be included in all \
+                copies or substantial portions of the Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR \
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, \
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE \
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER \
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, \
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE \
+                SOFTWARE.
+                """
+            ),
+        ]
 
         var body: some View {
-            ScrollView {
-                Text(licenseText)
-                    .font(.caption)
-                    .monospaced()
-                    .padding()
-                    .frame(maxWidth: .infinity, alignment: .leading)
+            List(licenses, id: \.name) { license in
+                NavigationLink(license.name) {
+                    ScrollView {
+                        Text(license.text)
+                            .font(.caption)
+                            .monospaced()
+                            .padding()
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .navigationTitle(license.name)
+                    #if os(iOS) || os(visionOS)
+                    .navigationBarTitleDisplayMode(.inline)
+                    #endif
+                }
             }
-            .navigationTitle(name)
+            .navigationTitle("ライセンス")
             #if os(iOS) || os(visionOS)
             .navigationBarTitleDisplayMode(.inline)
             #endif


### PR DESCRIPTION
## Summary
- 設定画面に「ライセンス」セクションを追加
- MantisライブラリのMITライセンス全文を表示する詳細画面を追加

## Test plan
- [x] 設定画面に「ライセンス」セクションが表示されることを確認
- [x] 「Mantis」をタップするとライセンス全文が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)