### PR TITLE
Fix data not refreshing after share extension save

### DIFF
--- a/MangaLauncher/MangaLauncherApp.swift
+++ b/MangaLauncher/MangaLauncherApp.swift
@@ -54,6 +54,7 @@ struct MangaLauncherApp: App {
                 .onChange(of: scenePhase) { _, newPhase in
                     if newPhase == .active {
                         checkPendingIntent()
+                        NotificationCenter.default.post(name: .mangaDataDidChange, object: nil)
                     }
                 }
         }

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -10,7 +10,7 @@ final class MangaViewModel {
     var selectedDay: DayOfWeek = .today
     private(set) var refreshCounter = 0
 
-    private var modelContext: ModelContext
+    private(set) var modelContext: ModelContext
 
     init(modelContext: ModelContext) {
         self.modelContext = modelContext
@@ -138,6 +138,7 @@ final class MangaViewModel {
     }
 
     func refresh() {
+        modelContext = ModelContext(modelContext.container)
         refreshCounter += 1
     }
 


### PR DESCRIPTION
## Summary
- フォアグラウンド復帰時に`mangaDataDidChange`通知を発行し、データを再読み込み
- `MangaViewModel.refresh()`でModelContextを新規作成し、Share Extensionが別プロセスで書き込んだデータを反映

## Test plan
- [x] 共有シートからマンガデータを保存
- [x] アプリに戻った際にデータが更新されていることを確認
- [x] アプリ内での通常の登録・編集・削除が引き続き正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)