### PR TITLE
Hide ChangeDayIntent from Shortcuts app

### DIFF
--- a/MangaWidget/ChangeDayIntent.swift
+++ b/MangaWidget/ChangeDayIntent.swift
@@ -3,6 +3,7 @@ import WidgetKit
 
 struct ChangeDayIntent: AppIntent {
     static var title: LocalizedStringResource = "曜日を変更"
+    static var isDiscoverable = false
 
     @Parameter(title: "Direction")
     var direction: Int // -1 = prev, 1 = next, 0 = reset to today


### PR DESCRIPTION
## Summary
- ウィジェット専用の「曜日を変更」IntentにisDiscoverable = falseを設定
- ショートカットアプリの一覧から非表示にし、ウィジェット内では引き続き動作

## Test plan
- [x] ショートカットアプリで「マンガ」を検索し、「曜日を変更」が表示されないことを確認
- [x] ウィジェットの曜日切り替えボタンが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)