### PR TITLE
Fix fields resetting when changing publisher

### DIFF
--- a/MangaLauncher/Views/EditEntryView.swift
+++ b/MangaLauncher/Views/EditEntryView.swift
@@ -21,6 +21,7 @@ struct EditEntryView: View {
     @State private var isLoadingImage = false
     @State private var ogpFetchFailed = false
     @State private var showingCropView = false
+    @State private var didLoadEntry = false
 
     private let colorOptions: [(name: String, color: Color)] = [
         ("red", .red),
@@ -238,13 +239,14 @@ struct EditEntryView: View {
                 }
             }
             .onAppear {
-                if let entry {
+                if let entry, !didLoadEntry {
                     name = entry.name
                     url = entry.url
                     selectedColor = entry.iconColor
                     selectedDay = entry.dayOfWeek
                     publisher = entry.publisher
                     imageData = entry.imageData
+                    didLoadEntry = true
                 }
             }
             #if canImport(UIKit)


### PR DESCRIPTION
## Summary
- 編集画面でPublisherPickerViewから戻った際に`onAppear`が再発火し、掲載誌を含む全フィールドが元の値にリセットされるバグを修正
- `didLoadEntry`フラグで初回のみデータ読み込みを行うように制限

## Test plan
- [x] 既存エントリの編集画面で掲載誌を変更し、保存後に反映されていることを確認
- [x] 新規登録が引き続き正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)