### PR TITLE
Remove URL fallback for empty publisher in list

### DIFF
--- a/MangaLauncher/Views/ContentView.swift
+++ b/MangaLauncher/Views/ContentView.swift
@@ -344,11 +344,6 @@ struct ContentView: View {
                     Text(entry.publisher)
                         .font(.caption)
                         .foregroundStyle(.secondary)
-                } else {
-                    Text(entry.url)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
                 }
             }
 


### PR DESCRIPTION
## Summary
- 掲載誌が未設定の場合、URLを表示する代わりに名前のみ表示するように変更

## Test plan
- [x] 掲載誌未設定のエントリが名前のみで表示されることを確認
- [x] 掲載誌設定済みのエントリは従来通り掲載誌名が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)