### PR TITLE
Persist display mode with grid as default

### DIFF
--- a/MangaLauncher/Views/ContentView.swift
+++ b/MangaLauncher/Views/ContentView.swift
@@ -12,7 +12,7 @@ struct ContentView: View {
     @State private var showingAddSheet = false
     @State private var showingSettings = false
     @State private var editingEntry: MangaEntry?
-    @State private var displayMode: DisplayMode = .list
+    @AppStorage("displayMode") private var displayMode: DisplayMode = .grid
     @State private var draggingEntryID: UUID?
     #if os(iOS) || os(visionOS)
     @State private var listEditMode: EditMode = .inactive


### PR DESCRIPTION
## Summary
- `@State`を`@AppStorage`に変更し、リスト/グリッドの表示モードをアプリ再起動後も保持
- 初回起動時のデフォルトをグリッド表示に変更

## Test plan
- [x] 初回起動時にグリッド表示になることを確認
- [x] リスト表示に切り替えてアプリを再起動し、リスト表示が維持されることを確認
- [x] グリッド表示に切り替えてアプリを再起動し、グリッド表示が維持されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)