### PR TITLE
Fix Xcode project warnings for Xcode 26.3

### DIFF
--- a/MangaLauncher.xcodeproj/project.pbxproj
+++ b/MangaLauncher.xcodeproj/project.pbxproj
@@ -361,7 +361,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1500;
-				LastUpgradeCheck = 1500;
+				LastUpgradeCheck = 2630;
 				TargetAttributes = {
 					A6000001 = {
 						CreatedOnToolsVersion = 15.0;
@@ -379,7 +379,7 @@
 			);
 			mainGroup = A5000001;
 			packageReferences = (
-				ECA66F792F6EAEE10096B6E5 /* XCRemoteSwiftPackageReference "Mantis.git" */,
+				ECA66F792F6EAEE10096B6E5 /* XCRemoteSwiftPackageReference "Mantis" */,
 			);
 			productRefGroup = A5000006 /* Products */;
 			projectDirPath = "";
@@ -493,7 +493,6 @@
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_ENTITLEMENTS = MangaWidget/MangaWidget.entitlements;
 				CURRENT_PROJECT_VERSION = 3;
-				DEVELOPMENT_TEAM = 5XJ8CR95CK;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MangaWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "マンガ曜日ウィジェット";
@@ -525,7 +524,6 @@
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_ENTITLEMENTS = MangaShareExtension/MangaShareExtension.entitlements;
 				CURRENT_PROJECT_VERSION = 3;
-				DEVELOPMENT_TEAM = 5XJ8CR95CK;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MangaShareExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "マンガ曜日に追加";
@@ -552,7 +550,6 @@
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_ENTITLEMENTS = MangaWidget/MangaWidget.entitlements;
 				CURRENT_PROJECT_VERSION = 3;
-				DEVELOPMENT_TEAM = 5XJ8CR95CK;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MangaWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "マンガ曜日ウィジェット";
@@ -582,6 +579,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -612,6 +610,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = 5XJ8CR95CK;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -634,6 +633,7 @@
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
@@ -644,6 +644,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -674,6 +675,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = 5XJ8CR95CK;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -689,6 +691,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				VALIDATE_PRODUCT = YES;
 			};
@@ -703,7 +706,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = 5XJ8CR95CK;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MangaLauncher/Info.plist;
@@ -739,7 +741,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = 5XJ8CR95CK;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MangaLauncher/Info.plist;
@@ -772,7 +773,6 @@
 				CLANG_ENABLE_OBJC_WEAK = NO;
 				CODE_SIGN_ENTITLEMENTS = MangaShareExtension/MangaShareExtension.entitlements;
 				CURRENT_PROJECT_VERSION = 3;
-				DEVELOPMENT_TEAM = 5XJ8CR95CK;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = MangaShareExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "マンガ曜日に追加";
@@ -834,7 +834,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		ECA66F792F6EAEE10096B6E5 /* XCRemoteSwiftPackageReference "Mantis.git" */ = {
+		ECA66F792F6EAEE10096B6E5 /* XCRemoteSwiftPackageReference "Mantis" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/guoyingtao/Mantis.git";
 			requirement = {
@@ -847,7 +847,7 @@
 /* Begin XCSwiftPackageProductDependency section */
 		ECA66F7A2F6EAEE10096B6E5 /* Mantis */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = ECA66F792F6EAEE10096B6E5 /* XCRemoteSwiftPackageReference "Mantis.git" */;
+			package = ECA66F792F6EAEE10096B6E5 /* XCRemoteSwiftPackageReference "Mantis" */;
 			productName = Mantis;
 		};
 /* End XCSwiftPackageProductDependency section */


### PR DESCRIPTION
## Summary
- Xcode 26.3のプロジェクト設定警告を解消
- `DEVELOPMENT_TEAM`をプロジェクトレベルに集約
- `CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED`、`STRING_CATALOG_GENERATE_SYMBOLS`を有効化
- `LastUpgradeCheck`を2630に更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)