### PR TITLE
Add today marker dot to day tab bar

### DIFF
--- a/MangaLauncher/Views/ContentView.swift
+++ b/MangaLauncher/Views/ContentView.swift
@@ -127,6 +127,12 @@ struct ContentView: View {
                                     ? Color.accentColor
                                     : .secondary
                             )
+                        Circle()
+                            .fill(day == .today
+                                ? (viewModel.selectedDay == day ? Color.accentColor : .secondary)
+                                : .clear
+                            )
+                            .frame(width: 5, height: 5)
                         Rectangle()
                             .fill(viewModel.selectedDay == day ? Color.accentColor : .clear)
                             .frame(height: 2)


### PR DESCRIPTION
## Summary
- 曜日タブバーに今日の曜日を示すドットインジケータを追加
- 選択中はアクセントカラー、非選択時はセカンダリカラーで表示

Closes #24

## Test plan
- [x] 今日の曜日タブにドットが表示されることを確認
- [x] 他の曜日にはドットが表示されないことを確認
- [x] 曜日を切り替えてもドットの位置が変わらないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)