### PR TITLE
Add read/unread management with catch-up UI

### DIFF
--- a/MangaLauncher.xcodeproj/project.pbxproj
+++ b/MangaLauncher.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		D500BDE07E6FE7D0E0396EA7 /* PlatformHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDD9A4D8748B9496E85A2A67 /* PlatformHelpers.swift */; };
 		E79C1EBA2299356887386C0C /* SharedModelContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C7FA9735199D021E15CEED8 /* SharedModelContainer.swift */; };
 		EB0EDF1F28050F1FBD0AC968 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 23E67B082915C8518CC0A973 /* WidgetKit.framework */; };
+		EC04B7CF2F70D9FE00AEE45F /* CatchUpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC04B7CE2F70D9FE00AEE45F /* CatchUpView.swift */; };
 		ECA66F7B2F6EAEE10096B6E5 /* Mantis in Frameworks */ = {isa = PBXBuildFile; productRef = ECA66F7A2F6EAEE10096B6E5 /* Mantis */; };
 		ECCD2FCE2F65596900BF3309 /* PublisherPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECCD2FCD2F65596900BF3309 /* PublisherPickerView.swift */; };
 		F8659628D6F745CA942803EB /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E7D977DE254FB1F216740BE6 /* Foundation.framework */; };
@@ -112,6 +113,7 @@
 		CDD9A4D8748B9496E85A2A67 /* PlatformHelpers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PlatformHelpers.swift; sourceTree = "<group>"; };
 		D899D5F8F3BA6AC39B41C8B4 /* MangaShareExtension.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = MangaShareExtension.entitlements; sourceTree = "<group>"; };
 		E7D977DE254FB1F216740BE6 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		EC04B7CE2F70D9FE00AEE45F /* CatchUpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatchUpView.swift; sourceTree = "<group>"; };
 		ECCD2FCD2F65596900BF3309 /* PublisherPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublisherPickerView.swift; sourceTree = "<group>"; };
 		EEC07D90615785B81C2E71C8 /* ImageCropView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImageCropView.swift; sourceTree = "<group>"; };
 		EEEF347AB79EE547A4014C35 /* MangaLauncher.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = MangaLauncher.entitlements; sourceTree = "<group>"; };
@@ -248,6 +250,7 @@
 		A5000004 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				EC04B7CE2F70D9FE00AEE45F /* CatchUpView.swift */,
 				ECCD2FCD2F65596900BF3309 /* PublisherPickerView.swift */,
 				A2000004 /* ContentView.swift */,
 				A2000005 /* EditEntryView.swift */,
@@ -454,6 +457,7 @@
 				A1000003 /* MangaViewModel.swift in Sources */,
 				A1000004 /* ContentView.swift in Sources */,
 				A1000005 /* EditEntryView.swift in Sources */,
+				EC04B7CF2F70D9FE00AEE45F /* CatchUpView.swift in Sources */,
 				0AD569E2465106D7BC72914B /* PlatformHelpers.swift in Sources */,
 				4975296B405867976ADBBA9F /* SharedModelContainer.swift in Sources */,
 				2AA2BDFC2D4CFE5BF3F85D4A /* DataMigration.swift in Sources */,

--- a/MangaLauncher/Models/BackupData.swift
+++ b/MangaLauncher/Models/BackupData.swift
@@ -16,11 +16,37 @@ struct BackupData: Codable {
         let iconColor: String
         let publisher: String
         let imageData: Data?
+        let lastReadDate: Date?
+
+        init(id: UUID, name: String, url: String, dayOfWeekRawValue: Int, sortOrder: Int, iconColor: String, publisher: String, imageData: Data?, lastReadDate: Date? = nil) {
+            self.id = id
+            self.name = name
+            self.url = url
+            self.dayOfWeekRawValue = dayOfWeekRawValue
+            self.sortOrder = sortOrder
+            self.iconColor = iconColor
+            self.publisher = publisher
+            self.imageData = imageData
+            self.lastReadDate = lastReadDate
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decode(UUID.self, forKey: .id)
+            name = try container.decode(String.self, forKey: .name)
+            url = try container.decode(String.self, forKey: .url)
+            dayOfWeekRawValue = try container.decode(Int.self, forKey: .dayOfWeekRawValue)
+            sortOrder = try container.decode(Int.self, forKey: .sortOrder)
+            iconColor = try container.decode(String.self, forKey: .iconColor)
+            publisher = try container.decode(String.self, forKey: .publisher)
+            imageData = try container.decodeIfPresent(Data.self, forKey: .imageData)
+            lastReadDate = try container.decodeIfPresent(Date.self, forKey: .lastReadDate)
+        }
     }
 
     static func from(_ entries: [MangaEntry]) -> BackupData {
         BackupData(
-            version: 1,
+            version: 2,
             exportDate: Date(),
             entries: entries.map {
                 BackupEntry(
@@ -31,7 +57,8 @@ struct BackupData: Codable {
                     sortOrder: $0.sortOrder,
                     iconColor: $0.iconColor,
                     publisher: $0.publisher,
-                    imageData: $0.imageData
+                    imageData: $0.imageData,
+                    lastReadDate: $0.lastReadDate
                 )
             }
         )

--- a/MangaLauncher/Models/MangaEntry.swift
+++ b/MangaLauncher/Models/MangaEntry.swift
@@ -55,11 +55,27 @@ final class MangaEntry {
     var iconColor: String = "blue"
     var publisher: String = ""
     @Attribute(.externalStorage) var imageData: Data?
+    var lastReadDate: Date?
 
     @Transient
     var dayOfWeek: DayOfWeek {
         get { DayOfWeek(rawValue: dayOfWeekRawValue) ?? .sunday }
         set { dayOfWeekRawValue = newValue.rawValue }
+    }
+
+    @Transient
+    var isRead: Bool {
+        guard let lastReadDate else { return false }
+        let mostRecentDay = Self.mostRecentOccurrence(of: dayOfWeek)
+        return lastReadDate >= mostRecentDay
+    }
+
+    static func mostRecentOccurrence(of day: DayOfWeek, from date: Date = .now) -> Date {
+        let calendar = Calendar.current
+        let todayWeekday = calendar.component(.weekday, from: date) - 1 // 0=Sun
+        let targetWeekday = day.rawValue
+        let daysBack = (todayWeekday - targetWeekday + 7) % 7
+        return calendar.startOfDay(for: calendar.date(byAdding: .day, value: -daysBack, to: date)!)
     }
 
     init(

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -17,6 +17,7 @@ final class MangaViewModel {
     }
 
     func fetchEntries(for day: DayOfWeek) -> [MangaEntry] {
+        let _ = refreshCounter
         let dayRawValue = day.rawValue
         let descriptor = FetchDescriptor<MangaEntry>(
             predicate: #Predicate { $0.dayOfWeekRawValue == dayRawValue },
@@ -123,6 +124,7 @@ final class MangaViewModel {
                 publisher: backupEntry.publisher,
                 imageData: backupEntry.imageData
             )
+            entry.lastReadDate = backupEntry.lastReadDate
             modelContext.insert(entry)
             importedCount += 1
         }
@@ -135,6 +137,28 @@ final class MangaViewModel {
             predicate: #Predicate { $0.id == id }
         )
         return try? modelContext.fetch(descriptor).first
+    }
+
+    func markAsRead(_ entry: MangaEntry) {
+        entry.lastReadDate = Date()
+        save()
+    }
+
+    func markAsUnread(_ entry: MangaEntry) {
+        entry.lastReadDate = nil
+        save()
+    }
+
+    func unreadEntries(for day: DayOfWeek) -> [MangaEntry] {
+        fetchEntries(for: day).filter { !$0.isRead }
+    }
+
+    func unreadCount(for day: DayOfWeek) -> Int {
+        unreadEntries(for: day).count
+    }
+
+    func notifyChange() {
+        refreshCounter += 1
     }
 
     func refresh() {

--- a/MangaLauncher/Views/CatchUpView.swift
+++ b/MangaLauncher/Views/CatchUpView.swift
@@ -1,0 +1,337 @@
+import SwiftUI
+
+struct CatchUpView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.openURL) private var openURL
+
+    var viewModel: MangaViewModel
+    let day: DayOfWeek
+
+    @State private var unreadItems: [MangaEntry] = []
+    @State private var currentIndex: Int = 0
+    @State private var offset: CGSize = .zero
+    @State private var undoStack: [(entry: MangaEntry, action: SwipeAction)] = []
+
+    private enum SwipeAction {
+        case read, skip
+    }
+
+    private var totalCount: Int { unreadItems.count }
+    private var remainingCount: Int { max(totalCount - currentIndex, 0) }
+    private var isCompleted: Bool { currentIndex >= totalCount }
+
+    var body: some View {
+        NavigationStack {
+            VStack {
+                if unreadItems.isEmpty {
+                    completedView(message: "未読のマンガはありません")
+                } else if isCompleted {
+                    completedView(message: "すべてチェックしました！")
+                } else {
+                    cardStackView
+                }
+            }
+            .navigationTitle("\(day.displayName)のキャッチアップ")
+            #if os(iOS) || os(visionOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("閉じる") { dismiss() }
+                }
+                if !undoStack.isEmpty {
+                    ToolbarItem(placement: .automatic) {
+                        Button {
+                            undoAction()
+                        } label: {
+                            Image(systemName: "arrow.uturn.backward")
+                        }
+                    }
+                }
+            }
+        }
+        .onAppear {
+            if unreadItems.isEmpty {
+                unreadItems = viewModel.unreadEntries(for: day)
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .mangaDataDidChange)) { _ in
+            reloadEntries()
+        }
+    }
+
+    // MARK: - Card Stack
+
+    private var cardStackView: some View {
+        VStack(spacing: 20) {
+            // Progress
+            HStack {
+                Text("\(currentIndex + 1) / \(totalCount)")
+                    .font(.subheadline.bold())
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Text("残り \(remainingCount) 件")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.horizontal)
+
+            ProgressView(value: Double(currentIndex), total: Double(totalCount))
+                .padding(.horizontal)
+
+            // Cards
+            ZStack {
+                // Next card (background)
+                if currentIndex + 1 < totalCount {
+                    cardView(for: unreadItems[currentIndex + 1])
+                        .scaleEffect(0.95)
+                        .opacity(0.5)
+                }
+
+                // Current card
+                cardView(for: unreadItems[currentIndex])
+                    .offset(offset)
+                    .rotationEffect(.degrees(Double(offset.width) / 20))
+                    .overlay {
+                        swipeOverlay
+                    }
+                    .gesture(dragGesture)
+            }
+            .padding(.horizontal)
+
+            // Action buttons
+            HStack(spacing: 60) {
+                // Skip (left)
+                Button {
+                    withAnimation(.spring(duration: 0.3)) {
+                        offset = CGSize(width: -500, height: 0)
+                    }
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                        performAction(.skip)
+                    }
+                } label: {
+                    VStack(spacing: 4) {
+                        Image(systemName: "clock.arrow.circlepath")
+                            .font(.system(size: 44))
+                        Text("あとで")
+                            .font(.caption.bold())
+                    }
+                    .foregroundStyle(.orange)
+                }
+
+                // Read (right)
+                Button {
+                    withAnimation(.spring(duration: 0.3)) {
+                        offset = CGSize(width: 500, height: 0)
+                    }
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                        performAction(.read)
+                    }
+                } label: {
+                    VStack(spacing: 4) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.system(size: 44))
+                        Text("既読")
+                            .font(.caption.bold())
+                    }
+                    .foregroundStyle(.green)
+                }
+            }
+            .padding(.bottom)
+        }
+    }
+
+    // MARK: - Card View
+
+    private func cardView(for entry: MangaEntry) -> some View {
+        VStack(spacing: 12) {
+            if let imageData = entry.imageData, let image = imageData.toSwiftUIImage() {
+                image
+                    .resizable()
+                    .scaledToFit()
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+            } else {
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(colorFromName(entry.iconColor))
+                    .aspectRatio(3/4, contentMode: .fit)
+                    .overlay {
+                        Text(entry.name)
+                            .font(.title.bold())
+                            .foregroundStyle(.white)
+                            .multilineTextAlignment(.center)
+                            .padding()
+                    }
+            }
+
+            Text(entry.name)
+                .font(.title3.bold())
+                .lineLimit(2)
+                .multilineTextAlignment(.center)
+
+            if !entry.publisher.isEmpty {
+                Text(entry.publisher)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(.background)
+                .shadow(color: .black.opacity(0.1), radius: 8, y: 4)
+        )
+        .contentShape(Rectangle())
+        .onTapGesture {
+            if let url = URL(string: entry.url) {
+                openURL(url)
+            }
+        }
+    }
+
+    // MARK: - Swipe Overlay
+
+    @ViewBuilder
+    private var swipeOverlay: some View {
+        if offset.width > 30 {
+            RoundedRectangle(cornerRadius: 16)
+                .fill(.green.opacity(0.2))
+                .overlay {
+                    VStack {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.system(size: 60))
+                            .foregroundStyle(.green)
+                        Text("既読")
+                            .font(.title2.bold())
+                            .foregroundStyle(.green)
+                    }
+                }
+                .opacity(min(Double(offset.width) / 100, 1))
+        } else if offset.width < -30 {
+            RoundedRectangle(cornerRadius: 16)
+                .fill(.orange.opacity(0.2))
+                .overlay {
+                    VStack {
+                        Image(systemName: "clock.arrow.circlepath")
+                            .font(.system(size: 60))
+                            .foregroundStyle(.orange)
+                        Text("あとで")
+                            .font(.title2.bold())
+                            .foregroundStyle(.orange)
+                    }
+                }
+                .opacity(min(Double(-offset.width) / 100, 1))
+        }
+    }
+
+    // MARK: - Drag Gesture
+
+    private var dragGesture: some Gesture {
+        DragGesture()
+            .onChanged { value in
+                offset = value.translation
+            }
+            .onEnded { value in
+                let threshold: CGFloat = 120
+                if value.translation.width > threshold {
+                    withAnimation(.spring(duration: 0.3)) {
+                        offset = CGSize(width: 500, height: value.translation.height)
+                    }
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                        performAction(.read)
+                    }
+                } else if value.translation.width < -threshold {
+                    withAnimation(.spring(duration: 0.3)) {
+                        offset = CGSize(width: -500, height: value.translation.height)
+                    }
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                        performAction(.skip)
+                    }
+                } else {
+                    withAnimation(.spring(duration: 0.3)) {
+                        offset = .zero
+                    }
+                }
+            }
+    }
+
+    // MARK: - Actions
+
+    private func performAction(_ action: SwipeAction) {
+        let entry = unreadItems[currentIndex]
+        undoStack.append((entry: entry, action: action))
+
+        if action == .read {
+            viewModel.markAsRead(entry)
+        }
+
+        offset = .zero
+        currentIndex += 1
+    }
+
+    private func reloadEntries() {
+        let processedIDs = Set(undoStack.filter { $0.action == .read }.map { $0.entry.id })
+        let allUnread = viewModel.unreadEntries(for: day)
+        var newItems: [MangaEntry] = []
+
+        // Keep already-processed entries in order
+        for i in 0..<currentIndex where i < unreadItems.count {
+            let oldEntry = unreadItems[i]
+            if let fresh = viewModel.findEntry(by: oldEntry.id) {
+                newItems.append(fresh)
+            }
+        }
+
+        // Remaining unread entries
+        for entry in allUnread where !processedIDs.contains(entry.id) && !newItems.contains(where: { $0.id == entry.id }) {
+            newItems.append(entry)
+        }
+
+        unreadItems = newItems
+        // Rebuild undo stack with fresh references
+        undoStack = undoStack.compactMap { item in
+            guard let fresh = viewModel.findEntry(by: item.entry.id) else { return nil }
+            return (entry: fresh, action: item.action)
+        }
+    }
+
+    private func undoAction() {
+        guard let last = undoStack.popLast() else { return }
+
+        if last.action == .read {
+            viewModel.markAsUnread(last.entry)
+        }
+
+        currentIndex -= 1
+        offset = .zero
+    }
+
+    // MARK: - Completed View
+
+    private func completedView(message: String) -> some View {
+        VStack(spacing: 16) {
+            Spacer()
+            Image(systemName: "checkmark.seal.fill")
+                .font(.system(size: 64))
+                .foregroundStyle(.green)
+            Text(message)
+                .font(.title2.bold())
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func colorFromName(_ name: String) -> Color {
+        switch name {
+        case "red": .red
+        case "orange": .orange
+        case "yellow": .yellow
+        case "green": .green
+        case "blue": .blue
+        case "purple": .purple
+        case "pink": .pink
+        case "teal": .teal
+        default: .blue
+        }
+    }
+}

--- a/MangaLauncher/Views/ContentView.swift
+++ b/MangaLauncher/Views/ContentView.swift
@@ -11,6 +11,7 @@ struct ContentView: View {
     @State private var viewModel: MangaViewModel?
     @State private var showingAddSheet = false
     @State private var showingSettings = false
+    @State private var showingCatchUp = false
     @State private var editingEntry: MangaEntry?
     @AppStorage("displayMode") private var displayMode: DisplayMode = .grid
     @State private var draggingEntryID: UUID?
@@ -42,11 +43,26 @@ struct ContentView: View {
                     }
                     dayPager(viewModel: viewModel)
                 }
-                .navigationTitle("マンガ曜日")
-                #if os(iOS) || os(visionOS)
-                .navigationBarTitleDisplayMode(.inline)
-                #endif
                 .toolbar {
+                    ToolbarItem(placement: .navigation) {
+                        let unreadCount = viewModel.unreadCount(for: viewModel.selectedDay)
+                        Button {
+                            showingCatchUp = true
+                        } label: {
+                            HStack(spacing: 4) {
+                                Image(systemName: "rectangle.stack")
+                                if unreadCount > 0 {
+                                    Text("\(unreadCount)")
+                                        .font(.caption2.bold())
+                                        .foregroundStyle(.white)
+                                        .padding(.horizontal, 5)
+                                        .padding(.vertical, 2)
+                                        .background(.red, in: Capsule())
+                                }
+                            }
+                        }
+                        .disabled(unreadCount == 0)
+                    }
                     ToolbarItem(placement: .automatic) {
                         Button {
                             withAnimation {
@@ -93,6 +109,11 @@ struct ContentView: View {
                 }
                 .sheet(isPresented: $showingSettings) {
                     SettingsView(viewModel: viewModel)
+                }
+                .fullScreenCover(isPresented: $showingCatchUp, onDismiss: {
+                    viewModel.notifyChange()
+                }) {
+                    CatchUpView(viewModel: viewModel, day: viewModel.selectedDay)
                 }
                 .onAppear {
                     pageIndex = pageIndexForDay(viewModel.selectedDay)
@@ -308,15 +329,23 @@ struct ContentView: View {
                     }
             }
 
-            VStack(alignment: .leading, spacing: 2) {
-                Text(entry.name)
-                    .font(.caption)
-                    .foregroundStyle(.primary)
-                    .lineLimit(2)
-                if !entry.publisher.isEmpty {
-                    Text(entry.publisher)
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
+            HStack(alignment: .top, spacing: 4) {
+                if !entry.isRead {
+                    Circle()
+                        .fill(Color.accentColor)
+                        .frame(width: 6, height: 6)
+                        .padding(.top, 4)
+                }
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(entry.name)
+                        .font(.caption)
+                        .foregroundStyle(.primary)
+                        .lineLimit(2)
+                    if !entry.publisher.isEmpty {
+                        Text(entry.publisher)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
                 }
             }
         }
@@ -325,6 +354,16 @@ struct ContentView: View {
             if let url = URL(string: entry.url) { openURL(url) }
         }
         .contextMenu {
+            Button {
+                if entry.isRead {
+                    viewModel.markAsUnread(entry)
+                } else {
+                    viewModel.markAsRead(entry)
+                }
+            } label: {
+                Label(entry.isRead ? "未読にする" : "既読にする",
+                      systemImage: entry.isRead ? "envelope.badge" : "envelope.open")
+            }
             Button {
                 editingEntry = entry
             } label: {
@@ -341,6 +380,15 @@ struct ContentView: View {
     @ViewBuilder
     private func entryRow(entry: MangaEntry) -> some View {
         HStack(spacing: 12) {
+            if !entry.isRead {
+                Circle()
+                    .fill(Color.accentColor)
+                    .frame(width: 8, height: 8)
+            } else {
+                Color.clear
+                    .frame(width: 8, height: 8)
+            }
+
             entryIcon(for: entry, size: 36)
 
             VStack(alignment: .leading, spacing: 2) {
@@ -364,6 +412,18 @@ struct ContentView: View {
             if let url = URL(string: entry.url) { openURL(url) }
         }
         .contextMenu {
+            Button {
+                if let viewModel {
+                    if entry.isRead {
+                        viewModel.markAsUnread(entry)
+                    } else {
+                        viewModel.markAsRead(entry)
+                    }
+                }
+            } label: {
+                Label(entry.isRead ? "未読にする" : "既読にする",
+                      systemImage: entry.isRead ? "envelope.badge" : "envelope.open")
+            }
             Button {
                 editingEntry = entry
             } label: {

--- a/MangaWidget/MangaWidget.swift
+++ b/MangaWidget/MangaWidget.swift
@@ -18,6 +18,7 @@ struct MangaWidgetItem: Identifiable {
     let iconColor: String
     let publisher: String
     let imageData: Data?
+    let isRead: Bool
 }
 
 // MARK: - Timeline Provider
@@ -53,7 +54,8 @@ struct MangaTimelineProvider: TimelineProvider {
             MangaWidgetItem(
                 id: $0.id, name: $0.name, url: $0.url,
                 iconColor: $0.iconColor, publisher: $0.publisher,
-                imageData: $0.imageData
+                imageData: $0.imageData,
+                isRead: $0.isRead
             )
         }
         return MangaTimelineEntry(
@@ -327,6 +329,14 @@ struct MangaWidgetEntryView: View {
             }
             .frame(width: size, height: size)
             .clipShape(RoundedRectangle(cornerRadius: 6))
+            .overlay(alignment: .topLeading) {
+                if !item.isRead {
+                    Circle()
+                        .fill(Color.accentColor)
+                        .frame(width: 6, height: 6)
+                        .padding(3)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- MangaEntryに`lastReadDate`を追加し、曜日ベースの未読・既読管理を実装
- 更新曜日が来ると自動的に未読にリセット
- Tinder風カードスワイプUIでキャッチアップ（右スワイプ=既読、左スワイプ=あとで）
- カードタップで漫画サイトに遷移
- 戻すボタンでundo対応
- リスト・グリッド・ウィジェットに未読ドット表示
- ツールバーに未読件数バッジ
- コンテキストメニューで既読/未読切り替え
- バックアップ/リストアで`lastReadDate`を保持

Closes #25

## Test plan
- [x] キャッチアップ画面で右スワイプ→既読、左スワイプ→スキップが動作すること
- [x] カードタップで漫画サイトに遷移し、戻った後も正常に動作すること
- [x] 戻すボタンで前のカードに戻れること
- [x] 一覧画面で未読ドットとバッジが正しく同期されること
- [x] コンテキストメニューから既読/未読切り替えが動作すること
- [x] ウィジェットに未読ドットが表示されること
- [x] 更新曜日が来ると既読が未読にリセットされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)