### PR TITLE
Add app icon badge for today's unread count

### DIFF
--- a/MangaLauncher/Helpers/BadgeManager.swift
+++ b/MangaLauncher/Helpers/BadgeManager.swift
@@ -1,0 +1,38 @@
+import Foundation
+import UserNotifications
+
+enum BadgeManager {
+    private static let enabledKey = "badgeEnabled"
+
+    static var isEnabled: Bool {
+        get { UserDefaults.standard.bool(forKey: enabledKey) }
+        set { UserDefaults.standard.set(newValue, forKey: enabledKey) }
+    }
+
+    static func requestPermissionAndEnable() async -> Bool {
+        let center = UNUserNotificationCenter.current()
+        do {
+            let granted = try await center.requestAuthorization(options: [.badge])
+            if granted {
+                isEnabled = true
+            }
+            return granted
+        } catch {
+            return false
+        }
+    }
+
+    static func updateBadge(unreadCount: Int) {
+        guard isEnabled else {
+            clearBadge()
+            return
+        }
+        let center = UNUserNotificationCenter.current()
+        center.setBadgeCount(unreadCount)
+    }
+
+    static func clearBadge() {
+        let center = UNUserNotificationCenter.current()
+        center.setBadgeCount(0)
+    }
+}

--- a/MangaLauncher/MangaLauncherApp.swift
+++ b/MangaLauncher/MangaLauncherApp.swift
@@ -55,6 +55,7 @@ struct MangaLauncherApp: App {
                     if newPhase == .active {
                         checkPendingIntent()
                         NotificationCenter.default.post(name: .mangaDataDidChange, object: nil)
+                        updateBadge()
                     }
                 }
         }
@@ -74,6 +75,12 @@ struct MangaLauncherApp: App {
             publisher: data["publisher"] ?? "",
             iconColor: data["iconColor"] ?? "blue"
         )
+    }
+
+    private func updateBadge() {
+        let viewModel = MangaViewModel(modelContext: container.mainContext)
+        let count = viewModel.unreadCount(for: .today)
+        BadgeManager.updateBadge(unreadCount: count)
     }
 
     private func handleDeepLink(_ url: URL) {

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -172,5 +172,6 @@ final class MangaViewModel {
         #if canImport(WidgetKit)
         WidgetCenter.shared.reloadAllTimelines()
         #endif
+        BadgeManager.updateBadge(unreadCount: unreadCount(for: .today))
     }
 }

--- a/MangaLauncher/Views/SettingsView.swift
+++ b/MangaLauncher/Views/SettingsView.swift
@@ -9,6 +9,7 @@ struct SettingsView: View {
     @State private var showingExporter = false
     @State private var showingImporter = false
     @State private var importResult: ImportResult?
+    @State private var badgeEnabled = BadgeManager.isEnabled
 
     private enum ImportResult: Identifiable {
         case success(Int)
@@ -67,6 +68,30 @@ struct SettingsView: View {
                     Text("データ管理")
                 } footer: {
                     Text("バックアップはJSON形式で保存されます。インポート時、同じIDのエントリはスキップされます。")
+                }
+
+                Section {
+                    Toggle("未読バッジ", isOn: $badgeEnabled)
+                        .onChange(of: badgeEnabled) { _, newValue in
+                            if newValue {
+                                Task {
+                                    let granted = await BadgeManager.requestPermissionAndEnable()
+                                    if !granted {
+                                        badgeEnabled = false
+                                    } else {
+                                        let count = viewModel.unreadCount(for: .today)
+                                        BadgeManager.updateBadge(unreadCount: count)
+                                    }
+                                }
+                            } else {
+                                BadgeManager.isEnabled = false
+                                BadgeManager.clearBadge()
+                            }
+                        }
+                } header: {
+                    Text("通知")
+                } footer: {
+                    Text("アプリアイコンに本日の未読マンガ数を表示します")
                 }
 
                 Section {


### PR DESCRIPTION
## Summary
- アプリアイコンに本日の未読マンガ数をバッジ表示
- 設定画面に「未読バッジ」トグルを追加（ONで通知許可をリクエスト）
- 既読にするとバッジ数が減り、全部既読でバッジが消える
- フォアグラウンド復帰時・データ変更時にバッジを自動更新

Closes #31

## Test plan
- [x] 設定画面でバッジをONにすると通知許可ダイアログが表示されること
- [x] 許可後、アプリアイコンに未読数が表示されること
- [x] 既読にするとバッジ数が減ること
- [x] バッジをOFFにするとアイコンのバッジが消えること

🤖 Generated with [Claude Code](https://claude.com/claude-code)