### PR TITLE
Add scheduled notification reminders

### DIFF
--- a/MangaLauncher/Helpers/NotificationManager.swift
+++ b/MangaLauncher/Helpers/NotificationManager.swift
@@ -1,0 +1,90 @@
+import Foundation
+import UserNotifications
+
+enum NotificationManager {
+    private static let enabledKey = "notificationEnabled"
+    private static let hourKey = "notificationHour"
+    private static let minuteKey = "notificationMinute"
+    private static let identifierPrefix = "manga_reminder_"
+
+    static var isEnabled: Bool {
+        get { UserDefaults.standard.bool(forKey: enabledKey) }
+        set { UserDefaults.standard.set(newValue, forKey: enabledKey) }
+    }
+
+    static var notificationHour: Int {
+        get {
+            let val = UserDefaults.standard.object(forKey: hourKey) as? Int
+            return val ?? 9
+        }
+        set { UserDefaults.standard.set(newValue, forKey: hourKey) }
+    }
+
+    static var notificationMinute: Int {
+        get {
+            let val = UserDefaults.standard.object(forKey: minuteKey) as? Int
+            return val ?? 0
+        }
+        set { UserDefaults.standard.set(newValue, forKey: minuteKey) }
+    }
+
+    static var notificationTime: DateComponents {
+        var components = DateComponents()
+        components.hour = notificationHour
+        components.minute = notificationMinute
+        return components
+    }
+
+    static func requestPermissionAndEnable() async -> Bool {
+        let center = UNUserNotificationCenter.current()
+        do {
+            let granted = try await center.requestAuthorization(options: [.alert, .sound, .badge])
+            if granted {
+                isEnabled = true
+                // Also enable badge since we now have permission
+                BadgeManager.isEnabled = true
+            }
+            return granted
+        } catch {
+            return false
+        }
+    }
+
+    static func scheduleNotifications(entryCounts: [DayOfWeek: Int]) {
+        let center = UNUserNotificationCenter.current()
+
+        // Remove existing reminders
+        let identifiers = DayOfWeek.allCases.map { "\(identifierPrefix)\($0.rawValue)" }
+        center.removePendingNotificationRequests(withIdentifiers: identifiers)
+
+        guard isEnabled else { return }
+
+        for day in DayOfWeek.allCases {
+            let count = entryCounts[day] ?? 0
+            guard count > 0 else { continue }
+
+            let content = UNMutableNotificationContent()
+            content.title = "マンガ曜日"
+            content.body = "\(day.displayName)のマンガをチェックしましょう"
+            content.sound = .default
+
+            var dateComponents = notificationTime
+            // Calendar.weekday: 1=Sunday, 2=Monday, ...
+            dateComponents.weekday = day.rawValue + 1
+
+            let trigger = UNCalendarNotificationTrigger(dateMatching: dateComponents, repeats: true)
+            let request = UNNotificationRequest(
+                identifier: "\(identifierPrefix)\(day.rawValue)",
+                content: content,
+                trigger: trigger
+            )
+            center.add(request)
+        }
+    }
+
+    static func cancelAllNotifications() {
+        let center = UNUserNotificationCenter.current()
+        let identifiers = DayOfWeek.allCases.map { "\(identifierPrefix)\($0.rawValue)" }
+        center.removePendingNotificationRequests(withIdentifiers: identifiers)
+    }
+}

--- a/MangaLauncher/MangaLauncherApp.swift
+++ b/MangaLauncher/MangaLauncherApp.swift
@@ -1,8 +1,25 @@
 import SwiftUI
 import SwiftData
 
+import UserNotifications
+
 extension Notification.Name {
     static let mangaDataDidChange = Notification.Name("mangaDataDidChange")
+    static let switchToDay = Notification.Name("switchToDay")
+}
+
+class NotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
+    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+        let identifier = response.notification.request.identifier
+        // identifier format: "manga_reminder_X" where X is DayOfWeek.rawValue
+        if identifier.hasPrefix("manga_reminder_"),
+           let rawString = identifier.split(separator: "_").last,
+           let rawValue = Int(rawString),
+           let day = DayOfWeek(rawValue: rawValue) {
+            NotificationCenter.default.post(name: .switchToDay, object: day.rawValue)
+        }
+        completionHandler()
+    }
 }
 
 struct IntentPrefill: Identifiable {
@@ -19,9 +36,11 @@ struct MangaLauncherApp: App {
     let container: ModelContainer
     @Environment(\.scenePhase) private var scenePhase
     @State private var intentPrefill: IntentPrefill?
+    private let notificationDelegate = NotificationDelegate()
 
     init() {
         DataMigration.migrateToAppGroupIfNeeded()
+        UNUserNotificationCenter.current().delegate = notificationDelegate
         do {
             container = try SharedModelContainer.create()
         } catch {

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -157,6 +157,14 @@ final class MangaViewModel {
         unreadEntries(for: day).count
     }
 
+    func rescheduleNotifications() {
+        var counts: [DayOfWeek: Int] = [:]
+        for day in DayOfWeek.allCases {
+            counts[day] = fetchEntries(for: day).count
+        }
+        NotificationManager.scheduleNotifications(entryCounts: counts)
+    }
+
     func notifyChange() {
         refreshCounter += 1
     }
@@ -173,5 +181,6 @@ final class MangaViewModel {
         WidgetCenter.shared.reloadAllTimelines()
         #endif
         BadgeManager.updateBadge(unreadCount: unreadCount(for: .today))
+        rescheduleNotifications()
     }
 }

--- a/MangaLauncher/Views/ContentView.swift
+++ b/MangaLauncher/Views/ContentView.swift
@@ -128,6 +128,14 @@ struct ContentView: View {
         .onReceive(NotificationCenter.default.publisher(for: .mangaDataDidChange)) { _ in
             viewModel?.refresh()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .switchToDay)) { notification in
+            if let rawValue = notification.object as? Int,
+               let day = DayOfWeek(rawValue: rawValue),
+               let viewModel {
+                viewModel.selectedDay = day
+                pageIndex = pageIndexForDay(day)
+            }
+        }
     }
 
     @ViewBuilder

--- a/MangaLauncher/Views/SettingsView.swift
+++ b/MangaLauncher/Views/SettingsView.swift
@@ -10,6 +10,13 @@ struct SettingsView: View {
     @State private var showingImporter = false
     @State private var importResult: ImportResult?
     @State private var badgeEnabled = BadgeManager.isEnabled
+    @State private var notificationEnabled = NotificationManager.isEnabled
+    @State private var notificationTime: Date = {
+        var components = DateComponents()
+        components.hour = NotificationManager.notificationHour
+        components.minute = NotificationManager.notificationMinute
+        return Calendar.current.date(from: components) ?? Date()
+    }()
 
     private enum ImportResult: Identifiable {
         case success(Int)
@@ -88,10 +95,35 @@ struct SettingsView: View {
                                 BadgeManager.clearBadge()
                             }
                         }
+                    Toggle("更新通知", isOn: $notificationEnabled)
+                        .onChange(of: notificationEnabled) { _, newValue in
+                            if newValue {
+                                Task {
+                                    let granted = await NotificationManager.requestPermissionAndEnable()
+                                    if !granted {
+                                        notificationEnabled = false
+                                    } else {
+                                        viewModel.rescheduleNotifications()
+                                    }
+                                }
+                            } else {
+                                NotificationManager.isEnabled = false
+                                NotificationManager.cancelAllNotifications()
+                            }
+                        }
+                    if notificationEnabled {
+                        DatePicker("通知時間", selection: $notificationTime, displayedComponents: .hourAndMinute)
+                            .onChange(of: notificationTime) { _, newValue in
+                                let components = Calendar.current.dateComponents([.hour, .minute], from: newValue)
+                                NotificationManager.notificationHour = components.hour ?? 9
+                                NotificationManager.notificationMinute = components.minute ?? 0
+                                viewModel.rescheduleNotifications()
+                            }
+                    }
                 } header: {
                     Text("通知")
                 } footer: {
-                    Text("アプリアイコンに本日の未読マンガ数を表示します")
+                    Text("未読バッジはアプリアイコンに未読数を表示します。更新通知は登録がある曜日の指定時間にリマインドします。")
                 }
 
                 Section {


### PR DESCRIPTION
## Summary
- マンガ登録がある曜日に週次ローカル通知を送信
- 設定画面に「更新通知」トグルと通知時間のDatePickerを追加
- 通知タップで該当曜日のタブに自動切り替え
- マンガの追加/削除時に通知スケジュールを自動更新

Closes #5

## Test plan
- [x] 設定画面で更新通知をONにすると通知許可ダイアログが表示されること
- [x] 指定時間にマンガ登録がある曜日の通知が届くこと
- [x] 通知をタップするとアプリが開き該当曜日に切り替わること
- [x] 通知をOFFにすると通知が来なくなること
- [x] 通知時間を変更すると反映されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)