### PR TITLE
Add retry button on catch-up completion screen

### DIFF
--- a/MangaLauncher/Views/CatchUpView.swift
+++ b/MangaLauncher/Views/CatchUpView.swift
@@ -309,13 +309,24 @@ struct CatchUpView: View {
     // MARK: - Completed View
 
     private func completedView(message: String) -> some View {
-        VStack(spacing: 16) {
+        let remainingUnread = viewModel.unreadCount(for: day)
+        return VStack(spacing: 16) {
             Spacer()
             Image(systemName: "checkmark.seal.fill")
                 .font(.system(size: 64))
                 .foregroundStyle(.green)
             Text(message)
                 .font(.title2.bold())
+            if remainingUnread > 0 {
+                Button {
+                    unreadItems = viewModel.unreadEntries(for: day)
+                    currentIndex = 0
+                    undoStack = []
+                } label: {
+                    Label("未読を再チェック（\(remainingUnread)件）", systemImage: "arrow.counterclockwise")
+                }
+                .buttonStyle(.bordered)
+            }
             Spacer()
         }
         .frame(maxWidth: .infinity)


### PR DESCRIPTION
## Summary
- キャッチアップ完了画面に「未読を再チェック」ボタンを追加
- スキップした未読マンガがある場合に表示され、閉じずに再チェックできる

## Test plan
- [x] いくつかスキップして完了画面に到達した時にボタンが表示されること
- [x] ボタンをタップすると残りの未読マンガのカードが表示されること
- [x] 全て既読にした場合はボタンが表示されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)