### PR TITLE
Extract manga URL from X posts via share sheet

### DIFF
--- a/MangaLauncher.xcodeproj/project.pbxproj
+++ b/MangaLauncher.xcodeproj/project.pbxproj
@@ -43,6 +43,8 @@
 		E79C1EBA2299356887386C0C /* SharedModelContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C7FA9735199D021E15CEED8 /* SharedModelContainer.swift */; };
 		EB0EDF1F28050F1FBD0AC968 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 23E67B082915C8518CC0A973 /* WidgetKit.framework */; };
 		EC04B7CF2F70D9FE00AEE45F /* CatchUpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC04B7CE2F70D9FE00AEE45F /* CatchUpView.swift */; };
+		EC04B7D12F71384C00AEE45F /* BadgeManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC04B7D02F71384C00AEE45F /* BadgeManager.swift */; };
+		EC04B7D32F71441D00AEE45F /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC04B7D22F71441D00AEE45F /* NotificationManager.swift */; };
 		ECA66F7B2F6EAEE10096B6E5 /* Mantis in Frameworks */ = {isa = PBXBuildFile; productRef = ECA66F7A2F6EAEE10096B6E5 /* Mantis */; };
 		ECCD2FCE2F65596900BF3309 /* PublisherPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECCD2FCD2F65596900BF3309 /* PublisherPickerView.swift */; };
 		F8659628D6F745CA942803EB /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E7D977DE254FB1F216740BE6 /* Foundation.framework */; };
@@ -114,6 +116,8 @@
 		D899D5F8F3BA6AC39B41C8B4 /* MangaShareExtension.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = MangaShareExtension.entitlements; sourceTree = "<group>"; };
 		E7D977DE254FB1F216740BE6 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		EC04B7CE2F70D9FE00AEE45F /* CatchUpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CatchUpView.swift; sourceTree = "<group>"; };
+		EC04B7D02F71384C00AEE45F /* BadgeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BadgeManager.swift; sourceTree = "<group>"; };
+		EC04B7D22F71441D00AEE45F /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
 		ECCD2FCD2F65596900BF3309 /* PublisherPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublisherPickerView.swift; sourceTree = "<group>"; };
 		EEC07D90615785B81C2E71C8 /* ImageCropView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImageCropView.swift; sourceTree = "<group>"; };
 		EEEF347AB79EE547A4014C35 /* MangaLauncher.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = MangaLauncher.entitlements; sourceTree = "<group>"; };
@@ -176,6 +180,8 @@
 		6238B354545AE6BD66DCA01C /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				EC04B7D22F71441D00AEE45F /* NotificationManager.swift */,
+				EC04B7D02F71384C00AEE45F /* BadgeManager.swift */,
 				CDD9A4D8748B9496E85A2A67 /* PlatformHelpers.swift */,
 			);
 			path = Helpers;
@@ -466,8 +472,10 @@
 				A1A8B2ACB18D6E541985F304 /* MasonryLayout.swift in Sources */,
 				BA7DD3DF9519EF632F306D36 /* OGPImageFetcher.swift in Sources */,
 				07DC3626A7CCE68BC3104819 /* MangaExtractor.swift in Sources */,
+				EC04B7D32F71441D00AEE45F /* NotificationManager.swift in Sources */,
 				B31B9EA2FE243CD2D6209258 /* AddMangaIntent.swift in Sources */,
 				1299E093C31E1C940DD2CAC4 /* ImageCropView.swift in Sources */,
+				EC04B7D12F71384C00AEE45F /* BadgeManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MangaLauncher/Services/OGPImageFetcher.swift
+++ b/MangaLauncher/Services/OGPImageFetcher.swift
@@ -6,6 +6,29 @@ struct OGPResult {
     var title: String?
 }
 
+enum URLResolver {
+    static func resolveAll(_ urlString: String) async -> String {
+        guard let url = URL(string: urlString) else { return urlString }
+
+        let shortDomains = ["t.co", "bit.ly", "tinyurl.com", "ow.ly", "is.gd"]
+        guard let host = url.host, shortDomains.contains(where: { host.hasSuffix($0) }) else {
+            return urlString
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            if let finalURL = response.url {
+                return finalURL.absoluteString
+            }
+        } catch {}
+
+        return urlString
+    }
+}
+
 enum OGPFetcher {
     static func fetch(from urlString: String) async -> OGPResult {
         guard let url = URL(string: urlString) else { return OGPResult() }

--- a/MangaShareExtension/ShareExtensionView.swift
+++ b/MangaShareExtension/ShareExtensionView.swift
@@ -204,6 +204,24 @@ struct ShareExtensionView: View {
             }
         }
 
+        // If shared URL is an X/Twitter post, fetch the page and extract external URLs
+        let xDomains = ["x.com", "twitter.com"]
+        let isXPost = URL(string: sharedURL).flatMap { url in
+            xDomains.contains(where: { url.host?.hasSuffix($0) == true })
+        } ?? false
+
+        if isXPost {
+            let xResult = await extractFromXPost(sharedURL)
+            if let extractedURL = xResult.url {
+                sharedURL = extractedURL
+            }
+            if let tweetText = xResult.text, !tweetText.isEmpty {
+                sharedText = tweetText
+            }
+        } else if !sharedURL.isEmpty {
+            sharedURL = await URLResolver.resolveAll(sharedURL)
+        }
+
         url = sharedURL
 
         // Fetch OGP data (image, site_name)
@@ -229,6 +247,50 @@ struct ShareExtensionView: View {
         }
 
         isLoading = false
+    }
+
+    private func extractFromXPost(_ xURL: String) async -> (url: String?, text: String?) {
+        // Use Twitter oEmbed API to get tweet HTML with links
+        guard let encoded = xURL.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+              let oembedURL = URL(string: "https://publish.twitter.com/oembed?url=\(encoded)") else { return (nil, nil) }
+
+        guard let (data, _) = try? await URLSession.shared.data(from: oembedURL),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let html = json["html"] as? String else { return (nil, nil) }
+
+        // Extract plain text from oEmbed HTML (strip tags)
+        let tweetText = html
+            .replacingOccurrences(of: "<[^>]+>", with: " ", options: .regularExpression)
+            .replacingOccurrences(of: "&amp;", with: "&")
+            .replacingOccurrences(of: "&lt;", with: "<")
+            .replacingOccurrences(of: "&gt;", with: ">")
+            .replacingOccurrences(of: "&quot;", with: "\"")
+            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // Extract t.co links from the oEmbed HTML
+        let pattern = "https?://t\\.co/[A-Za-z0-9]+"
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return (nil, tweetText) }
+        let range = NSRange(html.startIndex..., in: html)
+        let matches = regex.matches(in: html, range: range)
+
+        var seen = Set<String>()
+        for match in matches {
+            guard let matchRange = Range(match.range, in: html) else { continue }
+            let tcoURL = String(html[matchRange])
+            guard !seen.contains(tcoURL) else { continue }
+            seen.insert(tcoURL)
+
+            let resolved = await URLResolver.resolveAll(tcoURL)
+            let resolvedHost = URL(string: resolved)?.host ?? ""
+
+            let xDomains = ["x.com", "twitter.com", "t.co"]
+            if !xDomains.contains(where: { resolvedHost.hasSuffix($0) }) {
+                return (resolved, tweetText)
+            }
+        }
+
+        return (nil, tweetText)
     }
 
     private func saveEntry() {


### PR DESCRIPTION
## Summary
- X（Twitter）の投稿から共有シートでマンガURLを抽出
- Twitter oEmbed APIでツイート内のt.coリンクを取得
- t.co短縮URLをリダイレクト解決して元のマンガサイトURLを使用
- ツイートテキストをFoundation Modelsに渡してタイトル抽出精度を向上
- URLResolverを追加（t.co, bit.ly等の短縮URL解決）

Closes #35

## Test plan
- [x] Xの投稿（マンガリンク付き）から共有してマンガURLが正しく取得されること
- [x] 漫画サイトから直接共有した場合が引き続き正常に動作すること
- [x] t.coリンクがない投稿の場合はX投稿URLがそのまま使われること

🤖 Generated with [Claude Code](https://claude.com/claude-code)