### PR TITLE
Fix tap-through to background card in catch-up view

### DIFF
--- a/MangaLauncher/Views/CatchUpView.swift
+++ b/MangaLauncher/Views/CatchUpView.swift
@@ -86,6 +86,7 @@ struct CatchUpView: View {
                     cardView(for: unreadItems[currentIndex + 1])
                         .scaleEffect(0.95)
                         .opacity(0.5)
+                        .allowsHitTesting(false)
                 }
 
                 // Current card


### PR DESCRIPTION
## Summary
- キャッチアップ画面で背面カードに`.allowsHitTesting(false)`を追加し、前面カードの画像が小さい時に背面カードがタップされる問題を修正

## Test plan
- [x] 画像サイズが異なるカードで背面カードがタップできないことを確認
- [x] 前面カードのタップ・スワイプが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)