### PR TITLE
Add bounce animation to catch-up completion screen

### DIFF
--- a/MangaLauncher/Views/CatchUpView.swift
+++ b/MangaLauncher/Views/CatchUpView.swift
@@ -11,6 +11,7 @@ struct CatchUpView: View {
     @State private var currentIndex: Int = 0
     @State private var offset: CGSize = .zero
     @State private var undoStack: [(entry: MangaEntry, action: SwipeAction)] = []
+    @State private var completionAnimated = false
 
     private enum SwipeAction {
         case read, skip
@@ -316,10 +317,14 @@ struct CatchUpView: View {
             Image(systemName: "checkmark.seal.fill")
                 .font(.system(size: 64))
                 .foregroundStyle(.green)
+                .scaleEffect(completionAnimated ? 1.0 : 0.3)
+                .opacity(completionAnimated ? 1.0 : 0.0)
             Text(message)
                 .font(.title2.bold())
+                .opacity(completionAnimated ? 1.0 : 0.0)
             if remainingUnread > 0 {
                 Button {
+                    completionAnimated = false
                     unreadItems = viewModel.unreadEntries(for: day)
                     currentIndex = 0
                     undoStack = []
@@ -327,10 +332,19 @@ struct CatchUpView: View {
                     Label("未読を再チェック（\(remainingUnread)件）", systemImage: "arrow.counterclockwise")
                 }
                 .buttonStyle(.bordered)
+                .opacity(completionAnimated ? 1.0 : 0.0)
             }
             Spacer()
         }
         .frame(maxWidth: .infinity)
+        .onAppear {
+            completionAnimated = false
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+                withAnimation(.spring(duration: 0.6, bounce: 0.5)) {
+                    completionAnimated = true
+                }
+            }
+        }
     }
 
     private func colorFromName(_ name: String) -> Color {


### PR DESCRIPTION
## Summary
- キャッチアップ完了画面でチェックマークが弾むようにスケールアップするアニメーションを追加
- テキストとボタンもフェードインで表示

## Test plan
- [x] 全カード処理後の完了画面でアニメーションが再生されること
- [x] 「未読を再チェック」後に再度完了した場合もアニメーションが再生されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)