### PR TITLE
Add undo delete with toast notification

### DIFF
--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -9,6 +9,8 @@ import WidgetKit
 final class MangaViewModel {
     var selectedDay: DayOfWeek = .today
     private(set) var refreshCounter = 0
+    var pendingDeleteEntries: [MangaEntry] = []
+    private var deleteTimer: Timer?
 
     private(set) var modelContext: ModelContext
 
@@ -23,7 +25,9 @@ final class MangaViewModel {
             predicate: #Predicate { $0.dayOfWeekRawValue == dayRawValue },
             sortBy: [SortDescriptor(\.sortOrder)]
         )
-        return (try? modelContext.fetch(descriptor)) ?? []
+        let results = (try? modelContext.fetch(descriptor)) ?? []
+        let pendingIDs = Set(pendingDeleteEntries.map(\.id))
+        return results.filter { !pendingIDs.contains($0.id) }
     }
 
     func addEntry(name: String, url: String, days: Set<DayOfWeek>, iconColor: String, publisher: String = "", imageData: Data? = nil) {
@@ -70,6 +74,38 @@ final class MangaViewModel {
     func deleteEntry(_ entry: MangaEntry) {
         modelContext.delete(entry)
         save()
+    }
+
+    func queueDelete(_ entry: MangaEntry) {
+        pendingDeleteEntries.append(entry)
+        refreshCounter += 1
+        restartDeleteTimer()
+    }
+
+    func undoPendingDeletes() {
+        deleteTimer?.invalidate()
+        deleteTimer = nil
+        pendingDeleteEntries.removeAll()
+        refreshCounter += 1
+    }
+
+    func commitPendingDeletes() {
+        deleteTimer?.invalidate()
+        deleteTimer = nil
+        for entry in pendingDeleteEntries {
+            modelContext.delete(entry)
+        }
+        pendingDeleteEntries.removeAll()
+        save()
+    }
+
+    private func restartDeleteTimer() {
+        deleteTimer?.invalidate()
+        deleteTimer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: false) { [weak self] _ in
+            Task { @MainActor in
+                self?.commitPendingDeletes()
+            }
+        }
     }
 
     func moveEntries(for day: DayOfWeek, from source: IndexSet, to destination: Int) {

--- a/MangaLauncher/Views/ContentView.swift
+++ b/MangaLauncher/Views/ContentView.swift
@@ -35,14 +35,22 @@ struct ContentView: View {
     var body: some View {
         NavigationStack {
             if let viewModel {
-                VStack(spacing: 0) {
-                    dayTabBar(viewModel: viewModel)
-                    let publishers = viewModel.publishers(for: viewModel.selectedDay)
-                    if !publishers.isEmpty {
-                        publisherFilter(publishers: publishers)
+                ZStack(alignment: .bottom) {
+                    VStack(spacing: 0) {
+                        dayTabBar(viewModel: viewModel)
+                        let publishers = viewModel.publishers(for: viewModel.selectedDay)
+                        if !publishers.isEmpty {
+                            publisherFilter(publishers: publishers)
+                        }
+                        dayPager(viewModel: viewModel)
                     }
-                    dayPager(viewModel: viewModel)
+
+                    if !viewModel.pendingDeleteEntries.isEmpty {
+                        deleteToast(viewModel: viewModel)
+                            .transition(.move(edge: .bottom).combined(with: .opacity))
+                    }
                 }
+                .animation(.easeInOut(duration: 0.3), value: viewModel.pendingDeleteEntries.isEmpty)
                 .toolbar {
                     ToolbarItem(placement: .navigation) {
                         let unreadCount = viewModel.unreadCount(for: viewModel.selectedDay)
@@ -282,7 +290,7 @@ struct ContentView: View {
             .onDelete { indexSet in
                 let entriesToDelete = indexSet.map { entries[$0] }
                 for entry in entriesToDelete {
-                    viewModel.deleteEntry(entry)
+                    viewModel.queueDelete(entry)
                 }
             }
             .onMove { source, destination in
@@ -378,7 +386,7 @@ struct ContentView: View {
                 Label("編集", systemImage: "pencil")
             }
             Button(role: .destructive) {
-                viewModel.deleteEntry(entry)
+                viewModel.queueDelete(entry)
             } label: {
                 Label("削除", systemImage: "trash")
             }
@@ -438,7 +446,7 @@ struct ContentView: View {
                 Label("編集", systemImage: "pencil")
             }
             Button(role: .destructive) {
-                if let viewModel { viewModel.deleteEntry(entry) }
+                if let viewModel { viewModel.queueDelete(entry) }
             } label: {
                 Label("削除", systemImage: "trash")
             }
@@ -463,6 +471,32 @@ struct ContentView: View {
                         .foregroundStyle(.white)
                 }
         }
+    }
+
+    @ViewBuilder
+    private func deleteToast(viewModel: MangaViewModel) -> some View {
+        let count = viewModel.pendingDeleteEntries.count
+        HStack {
+            Text("\(count)件削除しました")
+                .font(.subheadline)
+                .foregroundStyle(.white)
+            Spacer()
+            Button {
+                viewModel.undoPendingDeletes()
+            } label: {
+                Text("元に戻す")
+                    .font(.subheadline.bold())
+                    .foregroundStyle(.yellow)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color(.darkGray))
+        )
+        .padding(.horizontal)
+        .padding(.bottom, 8)
     }
 
     private func colorFromName(_ name: String) -> Color {


### PR DESCRIPTION
## Summary
- 削除操作に5秒間のUndo期間を追加
- 画面下部にトースト「N件削除しました - 元に戻す」を表示
- 連続削除でタイマーがリセットされ、まとめてUndo可能
- 5秒経過で自動的にDB削除を実行
- リスト・グリッドのコンテキストメニュー、リストのスワイプ削除に対応

## Test plan
- [x] コンテキストメニューから削除するとトーストが表示されること
- [x] 「元に戻す」をタップすると削除が取り消されること
- [x] 5秒後にトーストが消えてデータが削除されること
- [x] 連続で削除するとトーストの件数が増え、タイマーがリセットされること
- [x] Undo後にデータが元通り表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)