### PR TITLE
Fix duplicate manga entries in list display

### DIFF
--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -27,7 +27,12 @@ final class MangaViewModel {
         )
         let results = (try? modelContext.fetch(descriptor)) ?? []
         let pendingIDs = Set(pendingDeleteEntries.map(\.id))
-        return results.filter { !pendingIDs.contains($0.id) }
+        // Deduplicate by ID (CloudKit sync can cause temporary duplicates)
+        var seenIDs = Set<UUID>()
+        return results.filter { entry in
+            guard !pendingIDs.contains(entry.id) else { return false }
+            return seenIDs.insert(entry.id).inserted
+        }
     }
 
     func addEntry(name: String, url: String, days: Set<DayOfWeek>, iconColor: String, publisher: String = "", imageData: Data? = nil) {


### PR DESCRIPTION
## Summary
- フェッチ結果をIDで重複排除し、同じ漫画データが複数表示される問題を修正
- CloudKit同期時にSwiftDataのフェッチ結果に一時的な重複が含まれる場合に対応

Closes #41

## Test plan
- [x] 漫画データが重複表示されないことを確認
- [x] CloudKit同期後も正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)