### PR TITLE
Fix scroll area issue on iPad grid view

### DIFF
--- a/MangaLauncher/Views/ContentView.swift
+++ b/MangaLauncher/Views/ContentView.swift
@@ -190,6 +190,7 @@ struct ContentView: View {
         TabView(selection: $pageIndex) {
             ForEach(0..<9, id: \.self) { index in
                 dayPage(day: dayForPageIndex(index), viewModel: viewModel)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .tag(index)
             }
         }


### PR DESCRIPTION
## Summary
- TabViewのページ内コンテンツに`frame(maxWidth: .infinity, maxHeight: .infinity)`を追加
- iPadでスクロール領域が縦半分になる問題の対策

Closes #42

## Test plan
- [x] iPadでグリッド表示のスクロールが正常に動作することを確認
- [x] iPhoneでの表示に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)