### PR TITLE
Add Package.resolved for Xcode Cloud builds

### DIFF
--- a/MangaLauncher.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/MangaLauncher.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "1498e6f863ed73ac0bf94393737c626ed04ab246f6a27ca5dbfbfe8a3494e2ef",
+  "pins" : [
+    {
+      "identity" : "mantis",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/guoyingtao/Mantis.git",
+      "state" : {
+        "revision" : "d6880eb97267248f89e6cef2dd52785d50627639",
+        "version" : "1.9.0"
+      }
+    }
+  ],
+  "version" : 3
+}


### PR DESCRIPTION
## Summary
- SPMの`Package.resolved`をリポジトリに追加
- Xcode Cloudでパッケージ依存関係の解決に必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)