### PR TITLE
Add theme switching (Classic / Kinetic Ink)

### DIFF
--- a/MangaLauncher.xcodeproj/project.pbxproj
+++ b/MangaLauncher.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		ECCE6BE2DD70F34BA69061B3 /* DesignSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC38F4ED01AE0D411DA0C66B /* DesignSystem.swift */; };
 		0F66A6093327A5A5BD16B10F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E7D977DE254FB1F216740BE6 /* Foundation.framework */; };
 		125D8CEEBC201DD7B9C5BCE3 /* ShareExtensionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 358605C94F78CC23682FF911 /* ShareExtensionView.swift */; };
 		1299E093C31E1C940DD2CAC4 /* ImageCropView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC07D90615785B81C2E71C8 /* ImageCropView.swift */; };
@@ -125,6 +126,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		EC38F4ED01AE0D411DA0C66B /* DesignSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystem.swift; sourceTree = "<group>"; };
 		0557E9481117CB9F8B903947 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		0CDE508C489E5FAA3881A522 /* SettingsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		1CF568E5CBBFA07B55373C73 /* DataMigration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DataMigration.swift; sourceTree = "<group>"; };
@@ -453,6 +455,7 @@
 				1CF568E5CBBFA07B55373C73 /* DataMigration.swift */,
 				ECFEA8202F7E8B9D00CE4DC0 /* UserDefaultsKeys.swift */,
 				ECD61F7CE55EE24A44A02F14 /* AnimationTiming.swift */,
+				EC38F4ED01AE0D411DA0C66B /* DesignSystem.swift */,
 				EC44DD5EE5561C4C4F99C248 /* ModelContextExtensions.swift */,
 				ECFEA8472F7F6E5700CE4DC0 /* MangaURLOpener.swift */,
 			);
@@ -598,6 +601,7 @@
 				3650352634B47DCA879C45C1 /* ChangeDayIntent.swift in Sources */,
 				ECFEA8222F7E8B9D00CE4DC0 /* UserDefaultsKeys.swift in Sources */,
 				EC79B98AEA2FF142AA989EF0 /* AnimationTiming.swift in Sources */,
+				ECCE6BE2DD70F34BA69061B3 /* DesignSystem.swift in Sources */,
 				EC440D83EFDF1B4B6F95E82D /* ModelContextExtensions.swift in Sources */,
 				AA000001 /* ReadingActivity.swift in Sources */,
 				ECFEA84A2F7F6E5700CE4DC0 /* MangaURLOpener.swift in Sources */,
@@ -614,6 +618,7 @@
 				B26E164ECFAC0FC6A4B39CC6 /* SharedModelContainer.swift in Sources */,
 				ECFEA8212F7E8B9D00CE4DC0 /* UserDefaultsKeys.swift in Sources */,
 				ECFEA8952F7F93AF00CE4DC0 /* AnimationTiming.swift in Sources */,
+				ECCE6BE2DD70F34BA69061B3 /* DesignSystem.swift in Sources */,
 				ECFEA8962F7F93AF00CE4DC0 /* ModelContextExtensions.swift in Sources */,
 				AA000002 /* ReadingActivity.swift in Sources */,
 				ECFEA8492F7F6E5700CE4DC0 /* MangaURLOpener.swift in Sources */,
@@ -642,6 +647,7 @@
 				ECFEA8742F7F8C3F00CE4DC0 /* CatchUpSwipeOverlay.swift in Sources */,
 				ECFEA8232F7E8B9D00CE4DC0 /* UserDefaultsKeys.swift in Sources */,
 				ECFEA8932F7F93AF00CE4DC0 /* AnimationTiming.swift in Sources */,
+				ECCE6BE2DD70F34BA69061B3 /* DesignSystem.swift in Sources */,
 				ECFEA8942F7F93AF00CE4DC0 /* ModelContextExtensions.swift in Sources */,
 				A1000005 /* EditEntryView.swift in Sources */,
 				EC04B7CF2F70D9FE00AEE45F /* CatchUpView.swift in Sources */,

--- a/MangaLauncher/MangaLauncherApp.swift
+++ b/MangaLauncher/MangaLauncherApp.swift
@@ -41,8 +41,6 @@ struct MangaLauncherApp: App {
     @State private var syncMonitor = CloudSyncMonitor()
     private let notificationDelegate = NotificationDelegate()
 
-    private var theme: ThemeStyle { ThemeManager.shared.style }
-
     init() {
         DataMigration.migrateToAppGroupIfNeeded()
         UNUserNotificationCenter.current().delegate = notificationDelegate

--- a/MangaLauncher/MangaLauncherApp.swift
+++ b/MangaLauncher/MangaLauncherApp.swift
@@ -41,6 +41,8 @@ struct MangaLauncherApp: App {
     @State private var syncMonitor = CloudSyncMonitor()
     private let notificationDelegate = NotificationDelegate()
 
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
     init() {
         DataMigration.migrateToAppGroupIfNeeded()
         UNUserNotificationCenter.current().delegate = notificationDelegate
@@ -54,6 +56,11 @@ struct MangaLauncherApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .background {
+                    // Ink background applied OUTSIDE ContentView to avoid breaking drag
+                    ThemeManager.shared.style.groupedBackground.ignoresSafeArea()
+                }
+                .preferredColorScheme(ThemeManager.shared.style.colorSchemeOverride)
                 .environment(syncMonitor)
                 .onOpenURL { url in
                     handleDeepLink(url)

--- a/MangaLauncher/Shared/DesignSystem.swift
+++ b/MangaLauncher/Shared/DesignSystem.swift
@@ -1,0 +1,305 @@
+import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#endif
+
+// MARK: - Theme Mode
+
+enum ThemeMode: String, CaseIterable {
+    case classic
+    case ink
+
+    var displayName: String {
+        switch self {
+        case .classic: return "クラシック"
+        case .ink: return "Kinetic Ink"
+        }
+    }
+
+    var iconName: String {
+        switch self {
+        case .classic: return "circle.lefthalf.filled"
+        case .ink: return "paintbrush.pointed.fill"
+        }
+    }
+
+    var style: ThemeStyle {
+        switch self {
+        case .classic: return .classic
+        case .ink: return .ink
+        }
+    }
+}
+
+// MARK: - Theme Style
+
+struct ThemeStyle {
+    // Colors
+    let surface: Color
+    let surfaceBright: Color
+    let surfaceContainerHigh: Color
+    let surfaceContainerHighest: Color
+    let primary: Color
+    let secondary: Color
+    let tertiary: Color
+    let primaryDim: Color
+    let onSurface: Color
+    let onSurfaceVariant: Color
+    let onPrimary: Color
+    let error: Color
+
+    // Fonts
+    let headlineFont: Font
+    let bodyFont: Font
+    let captionFont: Font
+    let caption2Font: Font
+    let subheadlineFont: Font
+    let title2Font: Font
+    let title3Font: Font
+
+    // Shape
+    let cornerRadius: CGFloat
+    let cardCornerRadius: CGFloat
+    let chipShape: AnyShape
+    let iconFallbackIsCircle: Bool
+
+    // Appearance
+    /// テーマが強制するカラースキーム。`nil` はOS設定に従う。
+    let colorSchemeOverride: ColorScheme?
+    let groupedBackground: Color
+    let toolbarBackgroundVisibility: Visibility
+
+    // Feature flags
+    let usesScreenTone: Bool
+    let hasShadows: Bool
+
+    /// `colorSchemeOverride == .dark` の簡易アクセス（各Viewのスタイリング分岐用）
+    var forceDarkMode: Bool { colorSchemeOverride == .dark }
+
+    // Context-specific colors (where ink mapping ≠ classic system color)
+    let badgeColor: Color
+    let catchUpReadColor: Color
+    let catchUpSkipColor: Color
+    let heatmapColor: Color
+    let onboardingColors: [Color]
+    let tutorialColors: (tap: Color, read: Color, skip: Color, undo: Color)
+}
+
+extension ThemeStyle {
+    static let classic = ThemeStyle(
+        surface: .clear,
+        surfaceBright: .clear,
+        surfaceContainerHigh: Color(.systemFill),
+        surfaceContainerHighest: Color(.darkGray),
+        primary: .accentColor,
+        secondary: .accentColor,
+        tertiary: .yellow,
+        primaryDim: .accentColor.opacity(0.7),
+        onSurface: .primary,
+        onSurfaceVariant: .secondary,
+        onPrimary: .white,
+        error: .red,
+        headlineFont: .headline,
+        bodyFont: .body,
+        captionFont: .caption,
+        caption2Font: .caption2,
+        subheadlineFont: .subheadline,
+        title2Font: .title2.bold(),
+        title3Font: .title3.bold(),
+        cornerRadius: 8,
+        cardCornerRadius: 12,
+        chipShape: AnyShape(Capsule()),
+        iconFallbackIsCircle: true,
+        colorSchemeOverride: nil,
+        groupedBackground: Color(UIColor.systemGroupedBackground),
+        toolbarBackgroundVisibility: .automatic,
+        usesScreenTone: false,
+        hasShadows: true,
+        badgeColor: .red,
+        catchUpReadColor: .green,
+        catchUpSkipColor: .orange,
+        heatmapColor: .green,
+        onboardingColors: [.blue, .green, .orange, .purple],
+        tutorialColors: (tap: .blue, read: .green, skip: .orange, undo: .secondary)
+    )
+
+    static let ink = ThemeStyle(
+        surface: Color(hex: "0e0e0e"),
+        surfaceBright: Color(hex: "1a1a1a"),
+        surfaceContainerHigh: Color(hex: "212121"),
+        surfaceContainerHighest: Color(hex: "262626"),
+        primary: Color(hex: "ff8d8d"),
+        secondary: Color(hex: "00eefc"),
+        tertiary: Color(hex: "ffeb92"),
+        primaryDim: Color(hex: "cc6b6b"),
+        onSurface: .white,
+        onSurfaceVariant: Color(hex: "a0a0a0"),
+        onPrimary: Color(hex: "0e0e0e"),
+        error: Color(hex: "ff7351"),
+        headlineFont: .system(size: 15, weight: .black),
+        bodyFont: .system(size: 15, weight: .bold),
+        captionFont: .system(size: 12, weight: .bold),
+        caption2Font: .system(size: 10),
+        subheadlineFont: .system(size: 14, weight: .bold),
+        title2Font: .system(size: 22, weight: .black),
+        title3Font: .system(size: 18, weight: .black),
+        cornerRadius: 4,
+        cardCornerRadius: 6,
+        chipShape: AnyShape(RoundedRectangle(cornerRadius: 4)),
+        iconFallbackIsCircle: false,
+        colorSchemeOverride: .dark,
+        groupedBackground: Color(hex: "0e0e0e"),
+        toolbarBackgroundVisibility: .visible,
+        usesScreenTone: true,
+        hasShadows: false,
+        badgeColor: Color(hex: "ff8d8d"),
+        catchUpReadColor: Color(hex: "00eefc"),
+        catchUpSkipColor: Color(hex: "ffeb92"),
+        heatmapColor: Color(hex: "ff8d8d"),
+        onboardingColors: [Color(hex: "ff8d8d"), Color(hex: "00eefc"), Color(hex: "ffeb92"), Color(hex: "ff8d8d")],
+        tutorialColors: (tap: Color(hex: "00eefc"), read: Color(hex: "00eefc"), skip: Color(hex: "ffeb92"), undo: Color(hex: "a0a0a0"))
+    )
+}
+
+// MARK: - Theme Manager
+
+@Observable
+final class ThemeManager {
+    static let shared = ThemeManager()
+
+    var mode: ThemeMode {
+        didSet { UserDefaults.standard.set(mode.rawValue, forKey: "appTheme") }
+    }
+
+    private init() {
+        self.mode = ThemeMode(rawValue: UserDefaults.standard.string(forKey: "appTheme") ?? "classic") ?? .classic
+    }
+
+    var style: ThemeStyle { mode.style }
+}
+
+// MARK: - InkTheme Constants (for ink-only structural code)
+
+enum InkTheme {
+    static let surface = Color(hex: "0e0e0e")
+    static let surfaceBright = Color(hex: "1a1a1a")
+    static let surfaceContainerHigh = Color(hex: "212121")
+    static let surfaceContainerHighest = Color(hex: "262626")
+    static let primary = Color(hex: "ff8d8d")
+    static let secondary = Color(hex: "00eefc")
+    static let tertiary = Color(hex: "ffeb92")
+    static let primaryDim = Color(hex: "cc6b6b")
+    static let onSurface = Color.white
+    static let onSurfaceVariant = Color(hex: "a0a0a0")
+    static let onPrimary = Color(hex: "0e0e0e")
+    static let cornerRadius: CGFloat = 4
+    static let cardCornerRadius: CGFloat = 6
+    static let spacingMD: CGFloat = 16
+    static let spacingSM: CGFloat = 8
+    static let spacingLG: CGFloat = 24
+}
+
+// MARK: - Color Hex Extension
+
+extension Color {
+    init(hex: String) {
+        let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        var int: UInt64 = 0
+        Scanner(string: hex).scanHexInt64(&int)
+        let a, r, g, b: UInt64
+        switch hex.count {
+        case 6:
+            (a, r, g, b) = (255, (int >> 16) & 0xFF, (int >> 8) & 0xFF, int & 0xFF)
+        case 8:
+            (a, r, g, b) = ((int >> 24) & 0xFF, (int >> 16) & 0xFF, (int >> 8) & 0xFF, int & 0xFF)
+        default:
+            (a, r, g, b) = (255, 0, 0, 0)
+        }
+        self.init(.sRGB, red: Double(r) / 255, green: Double(g) / 255, blue: Double(b) / 255, opacity: Double(a) / 255)
+    }
+}
+
+// MARK: - Screen-Tone Pattern
+
+struct ScreenTonePattern: View {
+    var opacity: Double = 0.05
+    var dotSize: CGFloat = 2
+    var spacing: CGFloat = 6
+
+    var body: some View {
+        Canvas { context, size in
+            for x in stride(from: 0, to: size.width, by: spacing) {
+                for y in stride(from: 0, to: size.height, by: spacing) {
+                    let rect = CGRect(x: x, y: y, width: dotSize, height: dotSize)
+                    context.fill(Path(ellipseIn: rect), with: .color(.white.opacity(opacity)))
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Themed Navigation Style
+
+extension View {
+    func themedNavigationStyle() -> some View {
+        let style = ThemeManager.shared.style
+        return self
+            .scrollContentBackground(.hidden)
+            .background(style.groupedBackground)
+            .toolbarBackground(style.toolbarBackgroundVisibility, for: .navigationBar)
+            .toolbarColorScheme(style.colorSchemeOverride, for: .navigationBar)
+    }
+}
+
+// MARK: - Drag Preview Cell
+
+struct DragPreviewCell: View {
+    let entry: MangaEntry
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            if let imageData = entry.imageData, let image = imageData.toSwiftUIImage() {
+                image
+                    .resizable()
+                    .scaledToFit()
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+            } else {
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color.fromName(entry.iconColor))
+                    .aspectRatio(3/4, contentMode: .fit)
+                    .overlay {
+                        Text(entry.name)
+                            .font(.caption.bold())
+                            .foregroundStyle(.white)
+                            .multilineTextAlignment(.center)
+                            .padding(4)
+                    }
+            }
+            Text(entry.name)
+                .font(.caption2)
+                .lineLimit(1)
+        }
+    }
+}
+
+// MARK: - Speech Bubble Button Style
+
+struct SpeechBubbleButtonStyle: ButtonStyle {
+    var isPrimary: Bool = true
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.headline)
+            .foregroundStyle(isPrimary ? InkTheme.onPrimary : InkTheme.onSurface)
+            .padding(.horizontal, InkTheme.spacingLG)
+            .padding(.vertical, InkTheme.spacingMD)
+            .background(
+                isPrimary
+                    ? AnyShapeStyle(LinearGradient(colors: [InkTheme.primary, InkTheme.primaryDim], startPoint: .top, endPoint: .bottom))
+                    : AnyShapeStyle(InkTheme.surfaceBright)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 16))
+            .scaleEffect(configuration.isPressed ? 0.95 : 1.0)
+            .animation(.easeInOut(duration: 0.1), value: configuration.isPressed)
+    }
+}

--- a/MangaLauncher/Shared/DesignSystem.swift
+++ b/MangaLauncher/Shared/DesignSystem.swift
@@ -76,6 +76,23 @@ struct ThemeStyle {
     /// `colorSchemeOverride == .dark` の簡易アクセス（各Viewのスタイリング分岐用）
     var forceDarkMode: Bool { colorSchemeOverride == .dark }
 
+    // Spacing
+    let spacingSM: CGFloat
+    let spacingMD: CGFloat
+    let spacingLG: CGFloat
+
+    // Tab bar
+    let tabSpacing: CGFloat
+    let tabItemSpacing: CGFloat
+    let tabFont: (_ isSelected: Bool) -> Font
+    let tabItemHeight: CGFloat?
+    let tabUnreadDotSize: CGFloat
+    let tabUnderlineHeight: CGFloat
+    let tabUnderlineCornerRadius: CGFloat
+    let tabSelectedRotation: Double
+    let tabSelectedScale: CGFloat
+    let tabShowsTodayCircle: Bool
+
     // Context-specific colors (where ink mapping ≠ classic system color)
     let badgeColor: Color
     let catchUpReadColor: Color
@@ -115,6 +132,19 @@ extension ThemeStyle {
         toolbarBackgroundVisibility: .automatic,
         usesScreenTone: false,
         hasShadows: true,
+        spacingSM: 8,
+        spacingMD: 16,
+        spacingLG: 24,
+        tabSpacing: 0,
+        tabItemSpacing: 4,
+        tabFont: { _ in .headline },
+        tabItemHeight: nil,
+        tabUnreadDotSize: 5,
+        tabUnderlineHeight: 2,
+        tabUnderlineCornerRadius: 0,
+        tabSelectedRotation: 0,
+        tabSelectedScale: 1.0,
+        tabShowsTodayCircle: true,
         badgeColor: .red,
         catchUpReadColor: .green,
         catchUpSkipColor: .orange,
@@ -152,6 +182,19 @@ extension ThemeStyle {
         toolbarBackgroundVisibility: .visible,
         usesScreenTone: true,
         hasShadows: false,
+        spacingSM: 8,
+        spacingMD: 16,
+        spacingLG: 24,
+        tabSpacing: 2,
+        tabItemSpacing: 2,
+        tabFont: { isSelected in .system(size: isSelected ? 26 : 18, weight: .black) },
+        tabItemHeight: 52,
+        tabUnreadDotSize: 6,
+        tabUnderlineHeight: 3,
+        tabUnderlineCornerRadius: 2,
+        tabSelectedRotation: -3,
+        tabSelectedScale: 1.1,
+        tabShowsTodayCircle: false,
         badgeColor: Color(hex: "ff8d8d"),
         catchUpReadColor: Color(hex: "00eefc"),
         catchUpSkipColor: Color(hex: "ffeb92"),
@@ -178,26 +221,6 @@ final class ThemeManager {
     var style: ThemeStyle { mode.style }
 }
 
-// MARK: - InkTheme Constants (for ink-only structural code)
-
-enum InkTheme {
-    static let surface = Color(hex: "0e0e0e")
-    static let surfaceBright = Color(hex: "1a1a1a")
-    static let surfaceContainerHigh = Color(hex: "212121")
-    static let surfaceContainerHighest = Color(hex: "262626")
-    static let primary = Color(hex: "ff8d8d")
-    static let secondary = Color(hex: "00eefc")
-    static let tertiary = Color(hex: "ffeb92")
-    static let primaryDim = Color(hex: "cc6b6b")
-    static let onSurface = Color.white
-    static let onSurfaceVariant = Color(hex: "a0a0a0")
-    static let onPrimary = Color(hex: "0e0e0e")
-    static let cornerRadius: CGFloat = 4
-    static let cardCornerRadius: CGFloat = 6
-    static let spacingMD: CGFloat = 16
-    static let spacingSM: CGFloat = 8
-    static let spacingLG: CGFloat = 24
-}
 
 // MARK: - Color Hex Extension
 
@@ -251,52 +274,22 @@ extension View {
     }
 }
 
-// MARK: - Drag Preview Cell
-
-struct DragPreviewCell: View {
-    let entry: MangaEntry
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            if let imageData = entry.imageData, let image = imageData.toSwiftUIImage() {
-                image
-                    .resizable()
-                    .scaledToFit()
-                    .clipShape(RoundedRectangle(cornerRadius: 8))
-            } else {
-                RoundedRectangle(cornerRadius: 8)
-                    .fill(Color.fromName(entry.iconColor))
-                    .aspectRatio(3/4, contentMode: .fit)
-                    .overlay {
-                        Text(entry.name)
-                            .font(.caption.bold())
-                            .foregroundStyle(.white)
-                            .multilineTextAlignment(.center)
-                            .padding(4)
-                    }
-            }
-            Text(entry.name)
-                .font(.caption2)
-                .lineLimit(1)
-        }
-    }
-}
-
 // MARK: - Speech Bubble Button Style
 
 struct SpeechBubbleButtonStyle: ButtonStyle {
     var isPrimary: Bool = true
+    private var ink: ThemeStyle { .ink }
 
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .font(.headline)
-            .foregroundStyle(isPrimary ? InkTheme.onPrimary : InkTheme.onSurface)
-            .padding(.horizontal, InkTheme.spacingLG)
-            .padding(.vertical, InkTheme.spacingMD)
+            .foregroundStyle(isPrimary ? ink.onPrimary : ink.onSurface)
+            .padding(.horizontal, ink.spacingLG)
+            .padding(.vertical, ink.spacingMD)
             .background(
                 isPrimary
-                    ? AnyShapeStyle(LinearGradient(colors: [InkTheme.primary, InkTheme.primaryDim], startPoint: .top, endPoint: .bottom))
-                    : AnyShapeStyle(InkTheme.surfaceBright)
+                    ? AnyShapeStyle(LinearGradient(colors: [ink.primary, ink.primaryDim], startPoint: .top, endPoint: .bottom))
+                    : AnyShapeStyle(ink.surfaceBright)
             )
             .clipShape(RoundedRectangle(cornerRadius: 16))
             .scaleEffect(configuration.isPressed ? 0.95 : 1.0)

--- a/MangaLauncher/Views/CatchUp/CatchUpCardView.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpCardView.swift
@@ -59,8 +59,8 @@ struct CatchUpCardView: View {
                         .foregroundStyle(theme.onSurfaceVariant)
                 }
             }
-            .padding(.horizontal, InkTheme.spacingMD)
-            .padding(.vertical, InkTheme.spacingSM + 4)
+            .padding(.horizontal, theme.spacingMD)
+            .padding(.vertical, theme.spacingSM + 4)
             .frame(maxWidth: .infinity)
             .background(theme.surfaceContainerHighest)
         }

--- a/MangaLauncher/Views/CatchUp/CatchUpCardView.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpCardView.swift
@@ -6,15 +6,92 @@ struct CatchUpCardView: View {
     @Binding var editingEntry: MangaEntry?
     let onOpenURL: (String) -> Void
 
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
     var body: some View {
+        switch ThemeManager.shared.mode {
+        case .ink:
+            inkCard
+        case .classic:
+            classicCard
+        }
+    }
+
+    // MARK: - Ink Card
+
+    private var inkCard: some View {
+        VStack(spacing: 0) {
+            ZStack(alignment: .topLeading) {
+                if let imageData = entry.imageData, let image = imageData.toSwiftUIImage() {
+                    image
+                        .resizable()
+                        .scaledToFit()
+                        .clipShape(RoundedRectangle(cornerRadius: theme.cardCornerRadius))
+                } else {
+                    RoundedRectangle(cornerRadius: theme.cardCornerRadius)
+                        .fill(Color.fromName(entry.iconColor))
+                        .aspectRatio(3/4, contentMode: .fit)
+                        .overlay {
+                            ZStack {
+                                if theme.usesScreenTone {
+                                    ScreenTonePattern(opacity: 0.08, spacing: 4)
+                                }
+                                Text(entry.name)
+                                    .font(.system(size: 28, weight: .black))
+                                    .foregroundStyle(.white)
+                                    .multilineTextAlignment(.center)
+                                    .padding()
+                            }
+                        }
+                }
+            }
+
+            VStack(spacing: 4) {
+                Text(entry.name)
+                    .font(theme.title3Font)
+                    .foregroundStyle(theme.onSurface)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.center)
+
+                if !entry.publisher.isEmpty {
+                    Text(entry.publisher)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(theme.onSurfaceVariant)
+                }
+            }
+            .padding(.horizontal, InkTheme.spacingMD)
+            .padding(.vertical, InkTheme.spacingSM + 4)
+            .frame(maxWidth: .infinity)
+            .background(theme.surfaceContainerHighest)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: theme.cardCornerRadius))
+        .background(
+            RoundedRectangle(cornerRadius: theme.cardCornerRadius)
+                .fill(theme.surfaceContainerHigh)
+        )
+        .contentShape(Rectangle())
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(entry.name)\(entry.publisher.isEmpty ? "" : "、\(entry.publisher)")")
+        .accessibilityHint("タップでサイトを開く、長押しで編集")
+        .onTapGesture {
+            onOpenURL(entry.url)
+        }
+        .onLongPressGesture {
+            editingEntry = entry
+        }
+    }
+
+    // MARK: - Classic Card
+
+    private var classicCard: some View {
         VStack(spacing: 12) {
             if let imageData = entry.imageData, let image = imageData.toSwiftUIImage() {
                 image
                     .resizable()
                     .scaledToFit()
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .clipShape(RoundedRectangle(cornerRadius: theme.cardCornerRadius))
             } else {
-                RoundedRectangle(cornerRadius: 12)
+                RoundedRectangle(cornerRadius: theme.cardCornerRadius)
                     .fill(Color.fromName(entry.iconColor))
                     .aspectRatio(3/4, contentMode: .fit)
                     .overlay {
@@ -27,14 +104,14 @@ struct CatchUpCardView: View {
             }
 
             Text(entry.name)
-                .font(.title3.bold())
+                .font(theme.title3Font)
                 .lineLimit(2)
                 .multilineTextAlignment(.center)
 
             if !entry.publisher.isEmpty {
                 Text(entry.publisher)
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
+                    .font(theme.subheadlineFont)
+                    .foregroundStyle(theme.onSurfaceVariant)
             }
         }
         .padding()
@@ -42,7 +119,7 @@ struct CatchUpCardView: View {
         .background(
             RoundedRectangle(cornerRadius: 16)
                 .fill(.background)
-                .shadow(color: .black.opacity(0.1), radius: 8, y: 4)
+                .shadow(color: .black.opacity(theme.hasShadows ? 0.1 : 0), radius: 8, y: 4)
         )
         .contentShape(Rectangle())
         .accessibilityElement(children: .combine)

--- a/MangaLauncher/Views/CatchUp/CatchUpCompletedView.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpCompletedView.swift
@@ -11,6 +11,8 @@ struct CatchUpCompletedView: View {
     let checkMilestone: () -> Int?
     var onRecheck: (() -> Void)?
 
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
     private var hasAchievement: Bool {
         streakAchievement != nil || milestoneAchievement != nil
     }
@@ -20,20 +22,21 @@ struct CatchUpCompletedView: View {
             Spacer()
             Image(systemName: "checkmark.seal.fill")
                 .font(.system(size: 64))
-                .foregroundStyle(.green)
+                .foregroundStyle(theme.catchUpReadColor)
                 .scaleEffect(completionAnimated ? 1.0 : 0.3)
                 .opacity(completionAnimated ? 1.0 : 0.0)
             Text(message)
-                .font(.title2.bold())
+                .font(theme.title2Font)
+                .foregroundStyle(theme.onSurface)
                 .opacity(completionAnimated ? 1.0 : 0.0)
 
             if hasAchievement {
                 VStack(spacing: 12) {
                     if let streak = streakAchievement {
-                        achievementCard(icon: "flame.fill", iconColor: .orange, text: "\(streak)日連続！")
+                        achievementCard(icon: "flame.fill", iconColor: theme.primary, text: "\(streak)日連続！")
                     }
                     if let milestone = milestoneAchievement {
-                        achievementCard(icon: "trophy.fill", iconColor: .yellow, text: "\(milestone)話達成！")
+                        achievementCard(icon: "trophy.fill", iconColor: theme.tertiary, text: "\(milestone)話達成！")
                     }
                 }
                 .scaleEffect(achievementAnimated ? 1.0 : 0.3)
@@ -41,17 +44,32 @@ struct CatchUpCompletedView: View {
             }
 
             if remainingUnread > 0, let onRecheck {
-                Button {
-                    onRecheck()
-                } label: {
-                    Label("未読を再チェック（\(remainingUnread)件）", systemImage: "arrow.counterclockwise")
+                switch ThemeManager.shared.mode {
+                case .ink:
+                    Button {
+                        onRecheck()
+                    } label: {
+                        Label("未読を再チェック（\(remainingUnread)件）", systemImage: "arrow.counterclockwise")
+                            .font(.system(size: 15, weight: .bold))
+                    }
+                    .buttonStyle(SpeechBubbleButtonStyle(isPrimary: false))
+                    .opacity(completionAnimated ? 1.0 : 0.0)
+                case .classic:
+                    Button {
+                        onRecheck()
+                    } label: {
+                        Label("未読を再チェック（\(remainingUnread)件）", systemImage: "arrow.counterclockwise")
+                    }
+                    .buttonStyle(.bordered)
+                    .opacity(completionAnimated ? 1.0 : 0.0)
                 }
-                .buttonStyle(.bordered)
-                .opacity(completionAnimated ? 1.0 : 0.0)
             }
             Spacer()
         }
         .frame(maxWidth: .infinity)
+        .if(theme.forceDarkMode) { view in
+            view.background(theme.surface)
+        }
         .onAppear {
             completionAnimated = false
             achievementAnimated = false
@@ -76,17 +94,37 @@ struct CatchUpCompletedView: View {
     private func achievementCard(icon: String, iconColor: Color, text: String) -> some View {
         HStack(spacing: 12) {
             Image(systemName: icon)
-                .font(.title2)
+                .font(theme.title2Font)
                 .foregroundStyle(iconColor)
             Text(text)
-                .font(.headline)
+                .font(theme.headlineFont)
+                .foregroundStyle(theme.onSurface)
         }
         .padding(.horizontal, 24)
         .padding(.vertical, 14)
         .background(
-            RoundedRectangle(cornerRadius: 16)
-                .fill(.ultraThinMaterial)
-                .shadow(color: .black.opacity(0.08), radius: 4, y: 2)
+            Group {
+                switch ThemeManager.shared.mode {
+                case .ink:
+                    RoundedRectangle(cornerRadius: theme.cardCornerRadius)
+                        .fill(theme.surfaceContainerHighest)
+                case .classic:
+                    RoundedRectangle(cornerRadius: 16)
+                        .fill(.ultraThinMaterial)
+                        .shadow(color: .black.opacity(0.08), radius: 4, y: 2)
+                }
+            }
         )
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func `if`<Content: View>(_ condition: Bool, transform: (Self) -> Content) -> some View {
+        if condition {
+            transform(self)
+        } else {
+            self
+        }
     }
 }

--- a/MangaLauncher/Views/CatchUp/CatchUpSwipeOverlay.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpSwipeOverlay.swift
@@ -3,32 +3,34 @@ import SwiftUI
 struct CatchUpSwipeOverlay: View {
     let offsetWidth: CGFloat
 
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
     var body: some View {
         if offsetWidth > 30 {
-            RoundedRectangle(cornerRadius: 16)
-                .fill(.green.opacity(0.2))
+            RoundedRectangle(cornerRadius: theme.cardCornerRadius)
+                .fill(theme.catchUpReadColor.opacity(0.15))
                 .overlay {
                     VStack {
                         Image(systemName: "checkmark.circle.fill")
-                            .font(.system(size: 60))
-                            .foregroundStyle(.green)
+                            .font(theme.forceDarkMode ? .system(size: 60, weight: .black) : .system(size: 60))
+                            .foregroundStyle(theme.catchUpReadColor)
                         Text("既読")
-                            .font(.title2.bold())
-                            .foregroundStyle(.green)
+                            .font(theme.title2Font)
+                            .foregroundStyle(theme.catchUpReadColor)
                     }
                 }
                 .opacity(min(Double(offsetWidth) / 100, 1))
         } else if offsetWidth < -30 {
-            RoundedRectangle(cornerRadius: 16)
-                .fill(.orange.opacity(0.2))
+            RoundedRectangle(cornerRadius: theme.cardCornerRadius)
+                .fill(theme.catchUpSkipColor.opacity(0.15))
                 .overlay {
                     VStack {
                         Image(systemName: "clock.arrow.circlepath")
-                            .font(.system(size: 60))
-                            .foregroundStyle(.orange)
+                            .font(theme.forceDarkMode ? .system(size: 60, weight: .black) : .system(size: 60))
+                            .foregroundStyle(theme.catchUpSkipColor)
                         Text("あとで")
-                            .font(.title2.bold())
-                            .foregroundStyle(.orange)
+                            .font(theme.title2Font)
+                            .foregroundStyle(theme.catchUpSkipColor)
                     }
                 }
                 .opacity(min(Double(-offsetWidth) / 100, 1))

--- a/MangaLauncher/Views/CatchUp/CatchUpTutorialOverlay.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpTutorialOverlay.swift
@@ -4,38 +4,40 @@ struct CatchUpTutorialOverlay: View {
     @Binding var hasSeenTutorial: Bool
     @Binding var showTutorial: Bool
 
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
     var body: some View {
         ZStack {
-            Color.black.opacity(0.6)
+            Color.black.opacity(theme.forceDarkMode ? 0.7 : 0.6)
                 .ignoresSafeArea()
 
             VStack(spacing: 24) {
                 Text("使い方")
-                    .font(.title2.bold())
-                    .foregroundStyle(.white)
+                    .font(theme.title2Font)
+                    .foregroundStyle(theme.forceDarkMode ? theme.onSurface : .white)
 
                 VStack(alignment: .leading, spacing: 16) {
                     tutorialRow(
                         icon: "hand.tap.fill",
-                        color: .blue,
+                        color: theme.tutorialColors.tap,
                         title: "タップで開く",
                         description: "カード画像をタップするとサイトを開けます"
                     )
                     tutorialRow(
                         icon: "arrow.right",
-                        color: .green,
+                        color: theme.tutorialColors.read,
                         title: "右スワイプ → 既読",
                         description: "読み終わったマンガを既読にします"
                     )
                     tutorialRow(
                         icon: "arrow.left",
-                        color: .orange,
+                        color: theme.tutorialColors.skip,
                         title: "左スワイプ → あとで",
                         description: "あとで読むマンガをスキップします"
                     )
                     tutorialRow(
                         icon: "arrow.uturn.backward",
-                        color: .secondary,
+                        color: theme.tutorialColors.undo,
                         title: "元に戻す",
                         description: "ツールバーのボタンで直前の操作を取り消せます"
                     )
@@ -48,19 +50,34 @@ struct CatchUpTutorialOverlay: View {
                     }
                 } label: {
                     Text("OK")
-                        .font(.headline)
+                        .font(theme.headlineFont)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 12)
-                        .background(Color.accentColor)
-                        .foregroundStyle(.white)
-                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                        .background(theme.primary)
+                        .foregroundStyle(theme.onPrimary)
+                        .clipShape(RoundedRectangle(cornerRadius: theme.cardCornerRadius))
                 }
             }
             .padding(24)
             .background(
-                RoundedRectangle(cornerRadius: 20)
-                    .fill(.ultraThinMaterial)
+                Group {
+                    switch ThemeManager.shared.mode {
+                    case .ink:
+                        RoundedRectangle(cornerRadius: theme.cardCornerRadius)
+                            .fill(theme.surfaceContainerHigh)
+                    case .classic:
+                        RoundedRectangle(cornerRadius: 20)
+                            .fill(.ultraThinMaterial)
+                    }
+                }
             )
+            .if(theme.forceDarkMode) { view in
+                view.overlay {
+                    RoundedRectangle(cornerRadius: theme.cardCornerRadius)
+                        .inset(by: 0.5)
+                        .stroke(theme.surfaceContainerHighest, lineWidth: 1)
+                }
+            }
             .frame(maxWidth: 400)
             .padding(.horizontal, 32)
         }
@@ -70,17 +87,28 @@ struct CatchUpTutorialOverlay: View {
     private func tutorialRow(icon: String, color: Color, title: String, description: String) -> some View {
         HStack(alignment: .top, spacing: 12) {
             Image(systemName: icon)
-                .font(.title3)
+                .font(theme.title3Font)
                 .foregroundStyle(color)
                 .frame(width: 28)
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
-                    .font(.subheadline.bold())
-                    .foregroundStyle(.white)
+                    .font(theme.subheadlineFont)
+                    .foregroundStyle(theme.forceDarkMode ? theme.onSurface : .white)
                 Text(description)
-                    .font(.caption)
-                    .foregroundStyle(.white.opacity(0.8))
+                    .font(theme.captionFont)
+                    .foregroundStyle(theme.forceDarkMode ? theme.onSurfaceVariant : .white.opacity(0.8))
             }
+        }
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func `if`<Content: View>(_ condition: Bool, transform: (Self) -> Content) -> some View {
+        if condition {
+            transform(self)
+        } else {
+            self
         }
     }
 }

--- a/MangaLauncher/Views/CatchUp/CatchUpView.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpView.swift
@@ -24,6 +24,8 @@ struct CatchUpView: View {
     @State private var streakAchievement: Int?
     @State private var milestoneAchievement: Int?
 
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
     private enum SwipeAction {
         case read, skip
     }
@@ -43,15 +45,19 @@ struct CatchUpView: View {
                     cardStackView
                 }
             }
+            .if(theme.forceDarkMode) { view in
+                view.background(theme.surface)
+            }
             .toolbar {
                 ToolbarItem(placement: .principal) {
                     VStack(spacing: 2) {
                         Text("\(day.displayName)のキャッチアップ")
-                            .font(.headline)
+                            .font(theme.headlineFont)
+                            .foregroundStyle(theme.onSurface)
                         if let publisher {
                             Text(publisher)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
+                                .font(theme.captionFont)
+                                .foregroundStyle(theme.onSurfaceVariant)
                         }
                     }
                 }
@@ -59,9 +65,13 @@ struct CatchUpView: View {
             #if os(iOS) || os(visionOS)
             .navigationBarTitleDisplayMode(.inline)
             #endif
+            .themedNavigationStyle()
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("閉じる") { dismiss() }
+                        .if(theme.forceDarkMode) { view in
+                            view.foregroundStyle(theme.primary)
+                        }
                 }
                 if !undoStack.isEmpty {
                     ToolbarItem(placement: .automatic) {
@@ -112,16 +122,19 @@ struct CatchUpView: View {
             Spacer(minLength: 0)
             HStack {
                 Text("\(currentIndex + 1) / \(totalCount)")
-                    .font(.subheadline.bold())
-                    .foregroundStyle(.secondary)
+                    .font(theme.subheadlineFont)
+                    .foregroundStyle(theme.onSurfaceVariant)
                 Spacer()
                 Text("残り \(remainingCount) 件")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
+                    .font(theme.subheadlineFont)
+                    .foregroundStyle(theme.onSurfaceVariant)
             }
             .padding(.horizontal)
 
             ProgressView(value: Double(currentIndex), total: Double(totalCount))
+                .if(theme.forceDarkMode) { view in
+                    view.tint(theme.primary)
+                }
                 .padding(.horizontal)
 
             ZStack {
@@ -155,11 +168,11 @@ struct CatchUpView: View {
                 } label: {
                     VStack(spacing: 4) {
                         Image(systemName: "clock.arrow.circlepath")
-                            .font(.system(size: 44))
+                            .font(theme.forceDarkMode ? .system(size: 44, weight: .bold) : .system(size: 44))
                         Text("あとで")
-                            .font(.caption.bold())
+                            .font(theme.forceDarkMode ? .system(size: 12, weight: .black) : .caption.bold())
                     }
-                    .foregroundStyle(.orange)
+                    .foregroundStyle(theme.catchUpSkipColor)
                 }
 
                 Button {
@@ -172,11 +185,11 @@ struct CatchUpView: View {
                 } label: {
                     VStack(spacing: 4) {
                         Image(systemName: "checkmark.circle.fill")
-                            .font(.system(size: 44))
+                            .font(theme.forceDarkMode ? .system(size: 44, weight: .bold) : .system(size: 44))
                         Text("既読")
-                            .font(.caption.bold())
+                            .font(theme.forceDarkMode ? .system(size: 12, weight: .black) : .caption.bold())
                     }
-                    .foregroundStyle(.green)
+                    .foregroundStyle(theme.catchUpReadColor)
                 }
             }
             .padding(.bottom)
@@ -337,5 +350,16 @@ struct CatchUpView: View {
 
     private func openMangaURL(_ urlString: String) {
         MangaURLOpener(browserMode: browserMode, openURL: openURL) { safariURL = $0 }.open(urlString)
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func `if`<Content: View>(_ condition: Bool, transform: (Self) -> Content) -> some View {
+        if condition {
+            transform(self)
+        } else {
+            self
+        }
     }
 }

--- a/MangaLauncher/Views/Common/DeleteToastView.swift
+++ b/MangaLauncher/Views/Common/DeleteToastView.swift
@@ -3,26 +3,28 @@ import SwiftUI
 struct DeleteToastView: View {
     var viewModel: MangaViewModel
 
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
     var body: some View {
         let count = viewModel.pendingDeleteEntries.count
         HStack {
             Text("\(count)件削除しました")
-                .font(.subheadline)
-                .foregroundStyle(.white)
+                .font(theme.subheadlineFont)
+                .foregroundStyle(theme.onSurface)
             Spacer()
             Button {
                 viewModel.undoPendingDeletes()
             } label: {
                 Text("元に戻す")
-                    .font(.subheadline.bold())
-                    .foregroundStyle(.yellow)
+                    .font(theme.subheadlineFont.bold())
+                    .foregroundStyle(theme.tertiary)
             }
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 12)
         .background(
-            RoundedRectangle(cornerRadius: 12)
-                .fill(Color(.darkGray))
+            RoundedRectangle(cornerRadius: theme.cardCornerRadius)
+                .fill(theme.surfaceContainerHighest)
         )
         .padding(.horizontal)
         .padding(.bottom, 8)

--- a/MangaLauncher/Views/Common/OnboardingView.swift
+++ b/MangaLauncher/Views/Common/OnboardingView.swift
@@ -5,32 +5,17 @@ struct OnboardingView: View {
     var onComplete: (() -> Void)?
     @State private var currentPage = 0
 
-    private let pages: [(icon: String, title: String, description: String, color: Color)] = [
-        (
-            "calendar",
-            "曜日ごとに管理",
-            "週間連載のマンガを曜日ごとに登録。\n今日読むマンガがひと目で分かります。",
-            .blue
-        ),
-        (
-            "rectangle.stack",
-            "キャッチアップ",
-            "カードスワイプで未読マンガをチェック。\n右スワイプで既読、左スワイプであとで。",
-            .green
-        ),
-        (
-            "square.grid.2x2",
-            "ウィジェット & 通知",
-            "ホーム画面のウィジェットから\n今日のマンガをすぐに確認。\n指定時間にリマインド通知も。",
-            .orange
-        ),
-        (
-            "square.and.arrow.up",
-            "かんたん登録",
-            "マンガアプリやブラウザの共有ボタンから\nワンタップで登録できます。",
-            .purple
-        ),
-    ]
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
+    private var pages: [(icon: String, title: String, description: String, color: Color)] {
+        let colors = theme.onboardingColors
+        return [
+            ("calendar", "曜日ごとに管理", "週間連載のマンガを曜日ごとに登録。\n今日読むマンガがひと目で分かります。", colors[0]),
+            ("rectangle.stack", "キャッチアップ", "カードスワイプで未読マンガをチェック。\n右スワイプで既読、左スワイプであとで。", colors[1]),
+            ("square.grid.2x2", "ウィジェット & 通知", "ホーム画面のウィジェットから\n今日のマンガをすぐに確認。\n指定時間にリマインド通知も。", colors[2]),
+            ("square.and.arrow.up", "かんたん登録", "マンガアプリやブラウザの共有ボタンから\nワンタップで登録できます。", colors[3]),
+        ]
+    }
 
     var body: some View {
         VStack {
@@ -58,12 +43,12 @@ struct OnboardingView: View {
                 }
             } label: {
                 Text(currentPage < pages.count - 1 ? "次へ" : "はじめる")
-                    .font(.headline)
+                    .font(theme.headlineFont)
                     .frame(maxWidth: 320)
                     .padding()
-                    .background(Color.accentColor)
-                    .foregroundStyle(.white)
-                    .clipShape(RoundedRectangle(cornerRadius: 14))
+                    .background(theme.primary)
+                    .foregroundStyle(theme.onPrimary)
+                    .clipShape(RoundedRectangle(cornerRadius: theme.cardCornerRadius))
             }
             .frame(maxWidth: .infinity)
             .padding(.bottom, 16)
@@ -75,10 +60,13 @@ struct OnboardingView: View {
                     dismiss()
                 }
             }
-            .font(.subheadline)
-            .foregroundStyle(.secondary)
+            .font(theme.subheadlineFont)
+            .foregroundStyle(theme.onSurfaceVariant)
             .padding(.bottom, 8)
             .opacity(currentPage < pages.count - 1 ? 1 : 0)
+        }
+        .if(theme.forceDarkMode) { view in
+            view.background(theme.surface)
         }
     }
 
@@ -88,18 +76,31 @@ struct OnboardingView: View {
 
             Image(systemName: page.icon)
                 .font(.system(size: 72))
+                .fontWeight(theme.forceDarkMode ? .bold : .regular)
                 .foregroundStyle(page.color)
 
             Text(page.title)
-                .font(.title.bold())
+                .font(.title.weight(theme.forceDarkMode ? .black : .bold))
+                .foregroundStyle(theme.onSurface)
 
             Text(page.description)
-                .font(.body)
-                .foregroundStyle(.secondary)
+                .font(theme.bodyFont)
+                .foregroundStyle(theme.onSurfaceVariant)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 32)
 
             Spacer()
+        }
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func `if`<Content: View>(_ condition: Bool, transform: (Self) -> Content) -> some View {
+        if condition {
+            transform(self)
+        } else {
+            self
         }
     }
 }

--- a/MangaLauncher/Views/Entry/EditEntryView.swift
+++ b/MangaLauncher/Views/Entry/EditEntryView.swift
@@ -31,6 +31,8 @@ struct EditEntryView: View {
     @State private var isOnHiatus = false
     @State private var isCompleted = false
 
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
     private let colorOptions: [(name: String, color: Color)] = [
         ("red", .red),
         ("orange", .orange),
@@ -136,18 +138,18 @@ struct EditEntryView: View {
                         .autocorrectionDisabled()
                     if !url.isEmpty && !isValidURL {
                         Text("有効なURLを入力してください（例: https://...）")
-                            .font(.caption)
-                            .foregroundStyle(.red)
+                            .font(theme.captionFont)
+                            .foregroundStyle(theme.error)
                     }
                     NavigationLink {
                         PublisherPickerView(publisher: $publisher, viewModel: viewModel)
                     } label: {
                         HStack {
                             Text("掲載誌")
-                                .foregroundStyle(.primary)
+                                .foregroundStyle(theme.onSurface)
                             Spacer()
                             Text(publisher.isEmpty ? "未設定" : publisher)
-                                .foregroundStyle(publisher.isEmpty ? .tertiary : .secondary)
+                                .foregroundStyle(publisher.isEmpty ? theme.onSurfaceVariant.opacity(0.5) : theme.onSurfaceVariant)
                         }
                     }
                 }
@@ -218,19 +220,19 @@ struct EditEntryView: View {
                     LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 7), spacing: 8) {
                         ForEach(DayOfWeek.orderedDays) { day in
                             Text(day.shortName)
-                                .font(.subheadline.bold())
+                                .font(theme.subheadlineFont)
                                 .frame(width: 36, height: 36)
                                 .background(
                                     selectedDay == day
-                                        ? Color.accentColor
-                                        : Color.platformGray5
+                                        ? theme.primary
+                                        : theme.surfaceContainerHighest
                                 )
                                 .foregroundStyle(
                                     selectedDay == day
-                                        ? .white
-                                        : .primary
+                                        ? theme.onPrimary
+                                        : theme.onSurface
                                 )
-                                .clipShape(Circle())
+                                .clipShape(theme.chipShape)
                                 .onTapGesture {
                                     selectedDay = day
                                     // nextUpdateCandidatesはselectedDayに依存するので
@@ -319,6 +321,7 @@ struct EditEntryView: View {
                     }
                 }
             }
+            .themedNavigationStyle()
             .navigationTitle(isEditing ? "編集" : "新規登録")
             #if os(iOS) || os(visionOS)
             .navigationBarTitleDisplayMode(.inline)
@@ -328,6 +331,9 @@ struct EditEntryView: View {
                     Button("キャンセル") {
                         dismiss()
                     }
+                    .if(theme.forceDarkMode) { view in
+                        view.foregroundStyle(theme.onSurfaceVariant)
+                    }
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("保存") {
@@ -335,6 +341,9 @@ struct EditEntryView: View {
                         dismiss()
                     }
                     .disabled(name.isEmpty || url.isEmpty || !isValidURL)
+                    .if(theme.forceDarkMode) { view in
+                        view.foregroundStyle(theme.primary)
+                    }
                 }
             }
             .onAppear {
@@ -404,6 +413,17 @@ struct EditEntryView: View {
             entry.isCompleted = isCompleted
         } else {
             viewModel.addEntry(name: name, url: url, days: [selectedDay], iconColor: selectedColor, publisher: publisher, imageData: imageData, updateIntervalWeeks: interval, nextExpectedUpdate: nextUpdateDate, isOnHiatus: isOnHiatus)
+        }
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func `if`<Content: View>(_ condition: Bool, transform: (Self) -> Content) -> some View {
+        if condition {
+            transform(self)
+        } else {
+            self
         }
     }
 }

--- a/MangaLauncher/Views/Entry/PublisherPickerView.swift
+++ b/MangaLauncher/Views/Entry/PublisherPickerView.swift
@@ -7,6 +7,8 @@ struct PublisherPickerView: View {
 
     @State private var newPublisher: String = ""
 
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
     private var existingPublishers: [String] {
         var pubs = Set(viewModel.allPublishers())
         if !publisher.isEmpty {
@@ -28,6 +30,9 @@ struct PublisherPickerView: View {
                             selectPublisher(newPublisher)
                         }
                         .bold()
+                        .if(theme.forceDarkMode) { view in
+                            view.foregroundStyle(theme.primary)
+                        }
                     }
                 }
             }
@@ -40,11 +45,14 @@ struct PublisherPickerView: View {
                         } label: {
                             HStack {
                                 Text(pub)
-                                    .foregroundStyle(.primary)
+                                    .foregroundStyle(theme.onSurface)
                                 Spacer()
                                 if publisher == pub {
                                     Image(systemName: "checkmark")
-                                        .foregroundStyle(Color.accentColor)
+                                        .foregroundStyle(theme.primary)
+                                        .if(theme.forceDarkMode) { view in
+                                            view.fontWeight(.bold)
+                                        }
                                 }
                             }
                         }
@@ -58,10 +66,14 @@ struct PublisherPickerView: View {
                         selectPublisher("")
                     } label: {
                         Text("掲載誌を解除")
+                            .if(theme.forceDarkMode) { view in
+                                view.foregroundStyle(theme.error)
+                            }
                     }
                 }
             }
         }
+        .themedNavigationStyle()
         .navigationTitle("掲載誌")
         #if os(iOS) || os(visionOS)
         .navigationBarTitleDisplayMode(.inline)
@@ -72,6 +84,17 @@ struct PublisherPickerView: View {
         publisher = value
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             dismiss()
+        }
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func `if`<Content: View>(_ condition: Bool, transform: (Self) -> Content) -> some View {
+        if condition {
+            transform(self)
+        } else {
+            self
         }
     }
 }

--- a/MangaLauncher/Views/Heatmap/ReadingHeatmapView.swift
+++ b/MangaLauncher/Views/Heatmap/ReadingHeatmapView.swift
@@ -10,6 +10,8 @@ struct ReadingHeatmapView: View {
     private let cellSpacing: CGFloat = 3
     private let dayLabels = DayOfWeek.orderedDays.map(\.shortName)
 
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
     @State private var activityCounts: [Date: Int] = [:]
     @State private var selectedDate: Date?
 
@@ -22,6 +24,7 @@ struct ReadingHeatmapView: View {
             }
             .padding()
         }
+        .themedNavigationStyle()
         .navigationTitle("読書アクティビティ")
         #if os(iOS) || os(visionOS)
         .navigationBarTitleDisplayMode(.inline)
@@ -53,20 +56,28 @@ struct ReadingHeatmapView: View {
     private func statCard(title: String, value: String, unit: String) -> some View {
         VStack(spacing: 4) {
             Text(title)
-                .font(.caption)
-                .foregroundStyle(.secondary)
+                .font(theme.captionFont)
+                .foregroundStyle(theme.onSurfaceVariant)
             HStack(alignment: .lastTextBaseline, spacing: 2) {
                 Text(value)
                     .font(.title2)
-                    .fontWeight(.bold)
+                    .fontWeight(theme.forceDarkMode ? .black : .bold)
+                    .foregroundStyle(theme.onSurface)
                 Text(unit)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .font(theme.captionFont)
+                    .foregroundStyle(theme.onSurfaceVariant)
             }
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 12)
-        .background(.fill.tertiary, in: RoundedRectangle(cornerRadius: 10))
+        .background {
+            switch ThemeManager.shared.mode {
+            case .ink:
+                RoundedRectangle(cornerRadius: theme.cardCornerRadius).fill(theme.surfaceContainerHigh)
+            case .classic:
+                RoundedRectangle(cornerRadius: 10).fill(.fill.tertiary)
+            }
+        }
     }
 
     // MARK: - Heatmap
@@ -84,8 +95,8 @@ struct ReadingHeatmapView: View {
                     .frame(height: 14)
                 ForEach(0..<7, id: \.self) { dayIndex in
                     Text(dayLabels[dayIndex])
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
+                        .font(theme.caption2Font)
+                        .foregroundStyle(theme.onSurfaceVariant)
                         .frame(width: 20, height: cellSize)
                 }
             }
@@ -100,8 +111,8 @@ struct ReadingHeatmapView: View {
                                 let date = grid[weekIndex][0]
                                 if let date, isFirstWeekOfMonth(date: date, weekIndex: weekIndex, grid: grid) {
                                     Text(monthLabel(for: date))
-                                        .font(.caption2)
-                                        .foregroundStyle(.secondary)
+                                        .font(theme.caption2Font)
+                                        .foregroundStyle(theme.onSurfaceVariant)
                                         .fixedSize()
                                         .frame(width: cellSize, alignment: .leading)
                                 } else {
@@ -152,16 +163,16 @@ struct ReadingHeatmapView: View {
         HStack(spacing: 4) {
             Spacer()
             Text("少ない")
-                .font(.caption2)
-                .foregroundStyle(.secondary)
+                .font(theme.caption2Font)
+                .foregroundStyle(theme.onSurfaceVariant)
             ForEach(0..<5, id: \.self) { level in
                 RoundedRectangle(cornerRadius: 2)
                     .fill(levelColor(level))
                     .frame(width: 12, height: 12)
             }
             Text("多い")
-                .font(.caption2)
-                .foregroundStyle(.secondary)
+                .font(theme.caption2Font)
+                .foregroundStyle(theme.onSurfaceVariant)
         }
     }
 
@@ -195,7 +206,7 @@ struct ReadingHeatmapView: View {
 
     private func cellColor(count: Int, maxCount: Int) -> Color {
         if count == 0 {
-            return Color(.systemGray5)
+            return theme.forceDarkMode ? theme.surfaceContainerHigh : Color(.systemGray5)
         }
         let level: Int
         if maxCount <= 4 {
@@ -209,12 +220,12 @@ struct ReadingHeatmapView: View {
 
     private func levelColor(_ level: Int) -> Color {
         switch level {
-        case 0: Color(.systemGray5)
-        case 1: Color.green.opacity(0.3)
-        case 2: Color.green.opacity(0.5)
-        case 3: Color.green.opacity(0.7)
-        case 4: Color.green.opacity(0.9)
-        default: Color.green
+        case 0: theme.forceDarkMode ? theme.surfaceContainerHigh : Color(.systemGray5)
+        case 1: theme.heatmapColor.opacity(0.3)
+        case 2: theme.heatmapColor.opacity(0.5)
+        case 3: theme.heatmapColor.opacity(0.7)
+        case 4: theme.heatmapColor.opacity(0.9)
+        default: theme.heatmapColor
         }
     }
 
@@ -244,6 +255,8 @@ private struct DayActivitySheet: View {
     @AppStorage("browserMode") private var browserMode: String = "external"
     @State private var safariURL: URL?
 
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
     var body: some View {
         NavigationStack {
             List {
@@ -262,24 +275,20 @@ private struct DayActivitySheet: View {
                                     .resizable()
                                     .aspectRatio(contentMode: .fill)
                                     .frame(width: 40, height: 40)
-                                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                                    .clipShape(RoundedRectangle(cornerRadius: theme.cardCornerRadius))
                             } else {
-                                RoundedRectangle(cornerRadius: 8)
-                                    .fill(.fill.tertiary)
-                                    .frame(width: 40, height: 40)
-                                    .overlay {
-                                        Image(systemName: "book.closed")
-                                            .foregroundStyle(.secondary)
-                                    }
+                                activityPlaceholderIcon
                             }
                             Text(activity.mangaName)
-                                .foregroundStyle(.primary)
+                                .foregroundStyle(theme.onSurface)
+                                .fontWeight(theme.forceDarkMode ? .bold : .regular)
                         }
                     }
-                    .tint(.primary)
+                    .tint(theme.onSurface)
                     .disabled(entry == nil)
                 }
             }
+            .themedNavigationStyle()
             .navigationTitle(dateTitle)
             #if os(iOS) || os(visionOS)
             .navigationBarTitleDisplayMode(.inline)
@@ -287,6 +296,9 @@ private struct DayActivitySheet: View {
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("閉じる") { dismiss() }
+                        .if(theme.forceDarkMode) { view in
+                            view.foregroundStyle(theme.onSurfaceVariant)
+                        }
                 }
             }
             #if canImport(UIKit)
@@ -302,11 +314,44 @@ private struct DayActivitySheet: View {
         MangaURLOpener(browserMode: browserMode, openURL: openURL) { safariURL = $0 }.open(urlString)
     }
 
+    @ViewBuilder
+    private var activityPlaceholderIcon: some View {
+        switch ThemeManager.shared.mode {
+        case .ink:
+            RoundedRectangle(cornerRadius: theme.cardCornerRadius)
+                .fill(theme.surfaceContainerHighest)
+                .frame(width: 40, height: 40)
+                .overlay {
+                    Image(systemName: "book.closed")
+                        .foregroundStyle(theme.onSurfaceVariant)
+                }
+        case .classic:
+            RoundedRectangle(cornerRadius: 8)
+                .fill(.fill.tertiary)
+                .frame(width: 40, height: 40)
+                .overlay {
+                    Image(systemName: "book.closed")
+                        .foregroundStyle(.secondary)
+                }
+        }
+    }
+
     private var dateTitle: String {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "ja_JP")
         formatter.dateFormat = "M月d日(E)"
         return formatter.string(from: date)
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func `if`<Content: View>(_ condition: Bool, transform: (Self) -> Content) -> some View {
+        if condition {
+            transform(self)
+        } else {
+            self
+        }
     }
 }
 

--- a/MangaLauncher/Views/Home/ContentToolbar.swift
+++ b/MangaLauncher/Views/Home/ContentToolbar.swift
@@ -12,6 +12,8 @@ struct ContentToolbar: ToolbarContent {
     var onAdd: () -> Void
     var onSettings: () -> Void
 
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
     var body: some ToolbarContent {
         ToolbarItem(placement: .navigation) {
             let allUnread = viewModel.unreadEntries(for: viewModel.selectedDay)
@@ -27,11 +29,12 @@ struct ContentToolbar: ToolbarContent {
                     Image(systemName: "rectangle.stack")
                     if unreadCount > 0 {
                         Text("\(unreadCount)")
-                            .font(.caption2.bold())
-                            .foregroundStyle(.white)
+                            .font(theme.caption2Font.bold())
+                            .foregroundStyle(theme.onPrimary)
                             .padding(.horizontal, 5)
                             .padding(.vertical, 2)
-                            .background(.red.opacity(edit.isEditing ? 0.3 : 1), in: Capsule())
+                            .background(theme.badgeColor.opacity(edit.isEditing ? 0.3 : 1),
+                                in: Capsule())
                     }
                 }
             }

--- a/MangaLauncher/Views/Home/DayPageView.swift
+++ b/MangaLauncher/Views/Home/DayPageView.swift
@@ -12,6 +12,8 @@ struct DayPageView: View {
     @Binding var showingAddSheet: Bool
     let onOpenURL: (String) -> Void
 
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
     var body: some View {
         let _ = viewModel.refreshCounter
         let allEntries = viewModel.fetchEntries(for: day)
@@ -31,24 +33,31 @@ struct DayPageView: View {
                             if day.isCompleted {
                                 ContentUnavailableView {
                                     Label("完結したマンガはありません", systemImage: "checkmark.seal")
+                                        .modifier(ThemedLabelModifier())
                                 } description: {
                                     Text("コンテキストメニューや編集画面から\n「完結にする」でここに移動できます")
+                                        .modifier(ThemedDescriptionModifier())
                                 }
                             } else if day.isHiatus {
                                 ContentUnavailableView {
                                     Label("休載中のマンガはありません", systemImage: "moon.zzz")
+                                        .modifier(ThemedLabelModifier())
                                 } description: {
                                     Text("コンテキストメニューや編集画面から\n「休載中にする」でここに移動できます")
+                                        .modifier(ThemedDescriptionModifier())
                                 }
                             } else {
                                 ContentUnavailableView {
                                     Label("エントリなし", systemImage: "book.closed")
+                                        .modifier(ThemedLabelModifier())
                                 } description: {
                                     Text("\(day.displayName)に登録されたマンガはありません")
+                                        .modifier(ThemedDescriptionModifier())
                                 } actions: {
                                     Button("追加する") {
                                         showingAddSheet = true
                                     }
+                                    .modifier(ThemedActionModifier())
                                 }
                             }
                         }
@@ -58,12 +67,15 @@ struct DayPageView: View {
                         EmptyStateView(hasWallpaper: hasWallpaper, reduceTransparency: reduceTransparency, headerHeight: headerHeight) {
                             ContentUnavailableView {
                                 Label("該当なし", systemImage: "line.3.horizontal.decrease.circle")
+                                    .modifier(ThemedLabelModifier())
                             } description: {
                                 Text("この掲載誌のマンガはありません")
+                                    .modifier(ThemedDescriptionModifier())
                             } actions: {
                                 Button("フィルター解除") {
                                     selectedPublisher = nil
                                 }
+                                .modifier(ThemedActionModifier())
                             }
                         }
                         .frame(maxWidth: 600)
@@ -123,5 +135,30 @@ struct DayPageView: View {
                 ))
             }
         }
+    }
+}
+
+// MARK: - Themed Modifiers for DayPageView
+
+private struct ThemedLabelModifier: ViewModifier {
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+    func body(content: Content) -> some View {
+        content.foregroundStyle(theme.onSurfaceVariant)
+    }
+}
+
+private struct ThemedDescriptionModifier: ViewModifier {
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+    func body(content: Content) -> some View {
+        content.foregroundStyle(theme.onSurfaceVariant.opacity(0.7))
+    }
+}
+
+private struct ThemedActionModifier: ViewModifier {
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+    func body(content: Content) -> some View {
+        content
+            .fontWeight(.bold)
+            .foregroundStyle(theme.primary)
     }
 }

--- a/MangaLauncher/Views/Home/DayTabBarView.swift
+++ b/MangaLauncher/Views/Home/DayTabBarView.swift
@@ -12,9 +12,12 @@ struct DayTabBarView: View {
 
     @State private var dropTargetDay: DayOfWeek?
 
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+    private var isInk: Bool { ThemeManager.shared.mode == .ink }
+
     var body: some View {
         let currentDay = paging.currentDay
-        HStack(spacing: 0) {
+        HStack(spacing: isInk ? 2 : 0) {
             ForEach(orderedDays) { day in
                 Button {
                     paging.isAnimatingPageChange = true
@@ -29,47 +32,41 @@ struct DayTabBarView: View {
                 } label: {
                     let isSelected = currentDay == day
                     let hasUnread = !day.isHiatus && !day.isCompleted && viewModel.unreadCount(for: day) > 0
-                    VStack(spacing: 4) {
+                    VStack(spacing: isInk ? 2 : 4) {
                         Text(day.shortName)
-                            .font(.headline)
-                            .foregroundStyle(
-                                !day.isHiatus && !day.isCompleted && day == .today
-                                    ? .white
-                                    : (hasWallpaper && isSelected)
-                                        ? .white
-                                        : isSelected
-                                            ? Color.accentColor
-                                            : (day.isHiatus || day.isCompleted) ? .secondary : .primary
-                            )
-                            .frame(width: 32, height: 32)
+                            .font(isInk ? .system(size: isSelected ? 26 : 18, weight: .black) : .headline)
+                            .foregroundStyle(tabTextColor(day: day, isSelected: isSelected))
+                            .frame(width: isInk ? nil : 32, height: isInk ? nil : 32)
                             .background {
-                                if !day.isHiatus && !day.isCompleted && day == .today {
-                                    Circle()
-                                        .fill(Color.accentColor)
-                                } else if hasWallpaper && isSelected {
-                                    Circle()
-                                        .fill(Color.black.opacity(0.3))
+                                if !isInk {
+                                    if !day.isHiatus && !day.isCompleted && day == .today {
+                                        Circle().fill(Color.accentColor)
+                                    } else if hasWallpaper && isSelected {
+                                        Circle().fill(Color.black.opacity(0.3))
+                                    }
                                 }
                             }
+                            .rotationEffect(.degrees(isInk && isSelected ? -3 : 0))
+                            .scaleEffect(isInk && isSelected ? 1.1 : 1.0)
                         Circle()
-                            .fill(hasUnread ? Color.accentColor : .clear)
-                            .frame(width: 5, height: 5)
+                            .fill(hasUnread ? (isInk ? theme.primary : Color.accentColor) : .clear)
+                            .frame(width: isInk ? 6 : 5, height: isInk ? 6 : 5)
                         if isSelected {
-                            Rectangle()
-                                .fill(Color.accentColor)
-                                .frame(height: 2)
+                            RoundedRectangle(cornerRadius: isInk ? 2 : 0)
+                                .fill(isInk ? theme.secondary : Color.accentColor)
+                                .frame(height: isInk ? 3 : 2)
                                 .matchedGeometryEffect(id: "tabUnderline", in: tabUnderline)
                         } else {
-                            Color.clear
-                                .frame(height: 2)
+                            Color.clear.frame(height: isInk ? 3 : 2)
                         }
                     }
+                    .frame(height: isInk ? 52 : nil)
                 }
                 .frame(maxWidth: .infinity)
                 .background(
-                    RoundedRectangle(cornerRadius: 8)
-                        .fill(dropTargetDay == day ? Color.accentColor.opacity(0.3) : .clear)
-                        .padding(.horizontal, 2)
+                    RoundedRectangle(cornerRadius: isInk ? theme.cornerRadius : 8)
+                        .fill(dropTargetDay == day ? (isInk ? theme.secondary : Color.accentColor).opacity(0.3) : .clear)
+                        .padding(.horizontal, isInk ? 0 : 2)
                 )
                 .onDrop(of: [.text], isTargeted: Binding(
                     get: { dropTargetDay == day },
@@ -104,7 +101,23 @@ struct DayTabBarView: View {
             }
         }
         .padding(.horizontal, 8)
-        .padding(.top, 4)
+        .padding(.top, isInk ? 0 : 4)
+        .padding(.vertical, isInk ? 6 : 0)
         .animation(.easeInOut(duration: 0.25), value: paging.pageIndex)
+    }
+
+    private func tabTextColor(day: DayOfWeek, isSelected: Bool) -> Color {
+        if isInk {
+            if isSelected { return theme.secondary }
+            if !day.isHiatus && !day.isCompleted && day == .today { return theme.primary }
+            if day.isHiatus || day.isCompleted { return theme.onSurfaceVariant.opacity(0.5) }
+            return theme.onSurfaceVariant
+        } else {
+            if !day.isHiatus && !day.isCompleted && day == .today { return .white }
+            if hasWallpaper && isSelected { return .white }
+            if isSelected { return Color.accentColor }
+            if day.isHiatus || day.isCompleted { return .secondary }
+            return .primary
+        }
     }
 }

--- a/MangaLauncher/Views/Home/DayTabBarView.swift
+++ b/MangaLauncher/Views/Home/DayTabBarView.swift
@@ -13,11 +13,10 @@ struct DayTabBarView: View {
     @State private var dropTargetDay: DayOfWeek?
 
     private var theme: ThemeStyle { ThemeManager.shared.style }
-    private var isInk: Bool { ThemeManager.shared.mode == .ink }
 
     var body: some View {
         let currentDay = paging.currentDay
-        HStack(spacing: isInk ? 2 : 0) {
+        HStack(spacing: theme.tabSpacing) {
             ForEach(orderedDays) { day in
                 Button {
                     paging.isAnimatingPageChange = true
@@ -32,13 +31,14 @@ struct DayTabBarView: View {
                 } label: {
                     let isSelected = currentDay == day
                     let hasUnread = !day.isHiatus && !day.isCompleted && viewModel.unreadCount(for: day) > 0
-                    VStack(spacing: isInk ? 2 : 4) {
+                    VStack(spacing: theme.tabItemSpacing) {
                         Text(day.shortName)
-                            .font(isInk ? .system(size: isSelected ? 26 : 18, weight: .black) : .headline)
+                            .font(theme.tabFont(isSelected))
                             .foregroundStyle(tabTextColor(day: day, isSelected: isSelected))
-                            .frame(width: isInk ? nil : 32, height: isInk ? nil : 32)
+                            .frame(width: theme.tabShowsTodayCircle ? 32 : nil,
+                                   height: theme.tabShowsTodayCircle ? 32 : nil)
                             .background {
-                                if !isInk {
+                                if theme.tabShowsTodayCircle {
                                     if !day.isHiatus && !day.isCompleted && day == .today {
                                         Circle().fill(Color.accentColor)
                                     } else if hasWallpaper && isSelected {
@@ -46,27 +46,27 @@ struct DayTabBarView: View {
                                     }
                                 }
                             }
-                            .rotationEffect(.degrees(isInk && isSelected ? -3 : 0))
-                            .scaleEffect(isInk && isSelected ? 1.1 : 1.0)
+                            .rotationEffect(.degrees(isSelected ? theme.tabSelectedRotation : 0))
+                            .scaleEffect(isSelected ? theme.tabSelectedScale : 1.0)
                         Circle()
-                            .fill(hasUnread ? (isInk ? theme.primary : Color.accentColor) : .clear)
-                            .frame(width: isInk ? 6 : 5, height: isInk ? 6 : 5)
+                            .fill(hasUnread ? theme.primary : .clear)
+                            .frame(width: theme.tabUnreadDotSize, height: theme.tabUnreadDotSize)
                         if isSelected {
-                            RoundedRectangle(cornerRadius: isInk ? 2 : 0)
-                                .fill(isInk ? theme.secondary : Color.accentColor)
-                                .frame(height: isInk ? 3 : 2)
+                            RoundedRectangle(cornerRadius: theme.tabUnderlineCornerRadius)
+                                .fill(theme.secondary)
+                                .frame(height: theme.tabUnderlineHeight)
                                 .matchedGeometryEffect(id: "tabUnderline", in: tabUnderline)
                         } else {
-                            Color.clear.frame(height: isInk ? 3 : 2)
+                            Color.clear.frame(height: theme.tabUnderlineHeight)
                         }
                     }
-                    .frame(height: isInk ? 52 : nil)
+                    .frame(height: theme.tabItemHeight)
                 }
                 .frame(maxWidth: .infinity)
                 .background(
-                    RoundedRectangle(cornerRadius: isInk ? theme.cornerRadius : 8)
-                        .fill(dropTargetDay == day ? (isInk ? theme.secondary : Color.accentColor).opacity(0.3) : .clear)
-                        .padding(.horizontal, isInk ? 0 : 2)
+                    RoundedRectangle(cornerRadius: theme.cornerRadius)
+                        .fill(dropTargetDay == day ? theme.secondary.opacity(0.3) : .clear)
+                        .padding(.horizontal, theme.tabShowsTodayCircle ? 2 : 0)
                 )
                 .onDrop(of: [.text], isTargeted: Binding(
                     get: { dropTargetDay == day },
@@ -101,13 +101,13 @@ struct DayTabBarView: View {
             }
         }
         .padding(.horizontal, 8)
-        .padding(.top, isInk ? 0 : 4)
-        .padding(.vertical, isInk ? 6 : 0)
+        .padding(.top, theme.tabShowsTodayCircle ? 4 : 0)
+        .padding(.vertical, theme.tabShowsTodayCircle ? 0 : 6)
         .animation(.easeInOut(duration: 0.25), value: paging.pageIndex)
     }
 
     private func tabTextColor(day: DayOfWeek, isSelected: Bool) -> Color {
-        if isInk {
+        if theme.forceDarkMode {
             if isSelected { return theme.secondary }
             if !day.isHiatus && !day.isCompleted && day == .today { return theme.primary }
             if day.isHiatus || day.isCompleted { return theme.onSurfaceVariant.opacity(0.5) }

--- a/MangaLauncher/Views/Home/EditModeButtons.swift
+++ b/MangaLauncher/Views/Home/EditModeButtons.swift
@@ -7,18 +7,31 @@ struct EditModeButtons: View {
     #endif
     @Binding var showingWallpaperPicker: Bool
 
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
     var body: some View {
         HStack(spacing: 12) {
             Button {
                 showingWallpaperPicker = true
             } label: {
-                Label("壁紙", systemImage: "photo.artframe")
-                    .font(.headline)
-                    .fixedSize()
-                    .padding(.horizontal, 20)
-                    .padding(.vertical, 10)
-                    .foregroundStyle(.primary)
-                    .background(.regularMaterial, in: Capsule())
+                switch ThemeManager.shared.mode {
+                case .classic:
+                    Label("壁紙", systemImage: "photo.artframe")
+                        .font(theme.headlineFont)
+                        .fixedSize()
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, 10)
+                        .foregroundStyle(theme.onSurface)
+                        .background(.regularMaterial, in: Capsule())
+                case .ink:
+                    Label("壁紙", systemImage: "photo.artframe")
+                        .font(theme.headlineFont)
+                        .fixedSize()
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, 10)
+                        .foregroundStyle(theme.onSurface)
+                        .background(theme.surfaceContainerHighest, in: Capsule())
+                }
             }
             Button {
                 withAnimation(.easeInOut(duration: 0.2)) {
@@ -28,15 +41,25 @@ struct EditModeButtons: View {
                     #endif
                 }
             } label: {
-                Text("完了")
-                    .font(.headline)
-                    .padding(.horizontal, 24)
-                    .padding(.vertical, 10)
-                    .foregroundStyle(.primary)
-                    .background(.regularMaterial, in: Capsule())
+                switch ThemeManager.shared.mode {
+                case .classic:
+                    Text("完了")
+                        .font(theme.headlineFont)
+                        .padding(.horizontal, 24)
+                        .padding(.vertical, 10)
+                        .foregroundStyle(theme.onSurface)
+                        .background(.regularMaterial, in: Capsule())
+                case .ink:
+                    Text("完了")
+                        .font(theme.headlineFont)
+                        .padding(.horizontal, 24)
+                        .padding(.vertical, 10)
+                        .foregroundStyle(theme.onPrimary)
+                        .background(theme.primary, in: Capsule())
+                }
             }
         }
-        .shadow(color: .black.opacity(0.15), radius: 8, y: 4)
+        .shadow(color: theme.hasShadows ? .black.opacity(0.15) : .clear, radius: theme.hasShadows ? 8 : 0, y: theme.hasShadows ? 4 : 0)
         .padding(.bottom, 16)
     }
 }

--- a/MangaLauncher/Views/Home/EmptyStateView.swift
+++ b/MangaLauncher/Views/Home/EmptyStateView.swift
@@ -31,7 +31,7 @@ struct EmptyStateView<Content: View>: View {
             case .ink:
                 content()
                     .padding(.top, headerHeight)
-                    .background(InkTheme.surface)
+                    .background(theme.surface)
             }
         }
     }

--- a/MangaLauncher/Views/Home/EmptyStateView.swift
+++ b/MangaLauncher/Views/Home/EmptyStateView.swift
@@ -6,6 +6,8 @@ struct EmptyStateView<Content: View>: View {
     let headerHeight: CGFloat
     @ViewBuilder let content: () -> Content
 
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
     var body: some View {
         if hasWallpaper {
             content()
@@ -13,17 +15,24 @@ struct EmptyStateView<Content: View>: View {
                 .padding(.top, headerHeight)
                 .background {
                     ZStack {
-                        RoundedRectangle(cornerRadius: 16)
-                            .fill(Color(.systemFill))
-                        RoundedRectangle(cornerRadius: 16)
+                        RoundedRectangle(cornerRadius: theme.cardCornerRadius)
+                            .fill(theme.surfaceContainerHigh)
+                        RoundedRectangle(cornerRadius: theme.cardCornerRadius)
                             .fill(reduceTransparency ? .thickMaterial : .ultraThinMaterial)
                     }
                     .padding()
                     .padding(.top, headerHeight)
                 }
         } else {
-            content()
-                .padding(.top, headerHeight)
+            switch ThemeManager.shared.mode {
+            case .classic:
+                content()
+                    .padding(.top, headerHeight)
+            case .ink:
+                content()
+                    .padding(.top, headerHeight)
+                    .background(InkTheme.surface)
+            }
         }
     }
 }

--- a/MangaLauncher/Views/Home/FilterChip.swift
+++ b/MangaLauncher/Views/Home/FilterChip.swift
@@ -6,15 +6,17 @@ struct FilterChip: View {
     let isSelected: Bool
     let action: () -> Void
 
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
     var body: some View {
         Button(action: action) {
             Text(label)
-                .font(.caption)
+                .font(theme.captionFont)
                 .padding(.horizontal, 12)
                 .padding(.vertical, 6)
-                .background(isSelected ? Color.accentColor : Color.platformGray5)
-                .foregroundStyle(isSelected ? .white : .primary)
-                .clipShape(Capsule())
+                .background(isSelected ? theme.primary : theme.surfaceContainerHigh)
+                .foregroundStyle(isSelected ? theme.onPrimary : theme.onSurfaceVariant)
+                .clipShape(theme.chipShape)
         }
         .buttonStyle(.plain)
     }

--- a/MangaLauncher/Views/MangaCell/EntryIcon.swift
+++ b/MangaLauncher/Views/MangaCell/EntryIcon.swift
@@ -5,23 +5,36 @@ struct EntryIcon: View {
     let entry: MangaEntry
     let size: CGFloat
 
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
     var body: some View {
         if let imageData = entry.imageData, let image = imageData.toSwiftUIImage() {
             image
                 .resizable()
                 .scaledToFill()
                 .frame(width: size, height: size)
-                .clipShape(RoundedRectangle(cornerRadius: size > 40 ? 8 : 6))
+                .clipShape(RoundedRectangle(cornerRadius: size > 40 ? theme.cardCornerRadius : theme.cornerRadius))
                 .accessibilityLabel("\(entry.name)のアイコン")
         } else {
-            Circle()
-                .fill(Color.fromName(entry.iconColor))
-                .frame(width: size, height: size)
-                .overlay {
-                    Text(String(entry.name.prefix(1)))
-                        .font(size > 40 ? .title : .headline)
-                        .foregroundStyle(.white)
-                }
+            if theme.iconFallbackIsCircle {
+                Circle()
+                    .fill(Color.fromName(entry.iconColor))
+                    .frame(width: size, height: size)
+                    .overlay {
+                        Text(String(entry.name.prefix(1)))
+                            .font(size > 40 ? .title : .headline)
+                            .foregroundStyle(theme.onPrimary)
+                    }
+            } else {
+                RoundedRectangle(cornerRadius: size > 40 ? theme.cardCornerRadius : theme.cornerRadius)
+                    .fill(Color.fromName(entry.iconColor))
+                    .frame(width: size, height: size)
+                    .overlay {
+                        Text(String(entry.name.prefix(1)))
+                            .font(size > 40 ? .title.bold() : .headline.bold())
+                            .foregroundStyle(theme.onSurface)
+                    }
+            }
         }
     }
 }

--- a/MangaLauncher/Views/MangaCell/MangaGridCell.swift
+++ b/MangaLauncher/Views/MangaCell/MangaGridCell.swift
@@ -10,8 +10,6 @@ struct MangaGridCell: View {
     @Binding var editingEntry: MangaEntry?
     let onOpenURL: (String) -> Void
 
-    private var theme: ThemeStyle { ThemeManager.shared.style }
-
     var body: some View {
         if entry.isDeleted || entry.modelContext == nil {
             EmptyView()

--- a/MangaLauncher/Views/MangaCell/MangaGridCell.swift
+++ b/MangaLauncher/Views/MangaCell/MangaGridCell.swift
@@ -10,6 +10,8 @@ struct MangaGridCell: View {
     @Binding var editingEntry: MangaEntry?
     let onOpenURL: (String) -> Void
 
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
     var body: some View {
         if entry.isDeleted || entry.modelContext == nil {
             EmptyView()

--- a/MangaLauncher/Views/MangaCell/MangaListView.swift
+++ b/MangaLauncher/Views/MangaCell/MangaListView.swift
@@ -14,6 +14,8 @@ struct MangaListView: View {
     #endif
     let onOpenURL: (String) -> Void
 
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
     var body: some View {
         List {
             ForEach(entries, id: \.id) { entry in
@@ -28,11 +30,17 @@ struct MangaListView: View {
             .onMove { source, destination in
                 viewModel.moveEntries(for: day, from: source, to: destination)
             }
-            .listRowSeparator(hasWallpaper ? .hidden : .automatic)
+            .listRowSeparator(theme.forceDarkMode ? .hidden : (hasWallpaper ? .hidden : .automatic))
+            .if(theme.forceDarkMode) { view in
+                view.listRowInsets(EdgeInsets(top: 2, leading: 12, bottom: 2, trailing: 12))
+            }
         }
         .listStyle(.plain)
         .contentMargins(.top, headerHeight, for: .scrollContent)
-        .scrollContentBackground(hasWallpaper ? .hidden : .automatic)
+        .scrollContentBackground(theme.forceDarkMode ? .hidden : (hasWallpaper ? .hidden : .automatic))
+        .if(theme.forceDarkMode) { view in
+            view.background(theme.surface)
+        }
         .simultaneousGesture(
             LongPressGesture(minimumDuration: 0.5)
                 .onEnded { _ in
@@ -44,5 +52,16 @@ struct MangaListView: View {
         #if os(iOS) || os(visionOS)
         .environment(\.editMode, $listEditMode)
         #endif
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func `if`<Content: View>(_ condition: Bool, transform: (Self) -> Content) -> some View {
+        if condition {
+            transform(self)
+        } else {
+            self
+        }
     }
 }

--- a/MangaLauncher/Views/MangaCell/MangaRowCell.swift
+++ b/MangaLauncher/Views/MangaCell/MangaRowCell.swift
@@ -12,39 +12,66 @@ struct MangaRowCell: View {
     #endif
     let onOpenURL: (String) -> Void
 
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
     var body: some View {
         if entry.isDeleted || entry.modelContext == nil {
             EmptyView()
         } else {
             HStack(spacing: 12) {
-                if !entry.isRead {
-                    Circle()
-                        .fill(Color.accentColor)
-                        .frame(width: 8, height: 8)
-                } else {
-                    Color.clear
-                        .frame(width: 8, height: 8)
+                switch ThemeManager.shared.mode {
+                case .ink:
+                    if !entry.isRead {
+                        Text("NEW")
+                            .font(.system(size: 9, weight: .black))
+                            .foregroundStyle(theme.onPrimary)
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 2)
+                            .background(theme.primary)
+                            .clipShape(RoundedRectangle(cornerRadius: 2))
+                    } else {
+                        Color.clear
+                            .frame(width: 28, height: 8)
+                    }
+                case .classic:
+                    if !entry.isRead {
+                        Circle()
+                            .fill(theme.badgeColor)
+                            .frame(width: 8, height: 8)
+                    } else {
+                        Color.clear
+                            .frame(width: 8, height: 8)
+                    }
                 }
 
                 EntryIcon(entry: entry, size: 36)
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text(entry.name)
-                        .font(.body)
+                        .font(theme.bodyFont)
+                        .foregroundStyle(theme.onSurface)
                     if !entry.publisher.isEmpty {
                         Text(entry.publisher)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+                            .font(theme.captionFont)
+                            .foregroundStyle(theme.onSurfaceVariant)
                     }
                 }
 
                 Spacer()
 
-                Image(systemName: "chevron.right")
-                    .font(.caption)
-                    .foregroundStyle(.tertiary)
+                switch ThemeManager.shared.mode {
+                case .ink:
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 11, weight: .bold))
+                        .foregroundStyle(theme.onSurfaceVariant.opacity(0.5))
+                case .classic:
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
             }
-            .padding(.vertical, hasWallpaper ? 4 : 0)
+            .padding(.vertical, theme.forceDarkMode ? 8 : (hasWallpaper ? 4 : 0))
+            .padding(.horizontal, theme.forceDarkMode ? 4 : 0)
             .contentShape(Rectangle())
             .accessibilityElement(children: .combine)
             .accessibilityLabel("\(entry.name)\(entry.publisher.isEmpty ? "" : "、\(entry.publisher)")\(entry.isRead ? "" : "、未読")")
@@ -54,17 +81,33 @@ struct MangaRowCell: View {
             }
             .listRowBackground(
                 Group {
-                    if hasWallpaper {
-                        ZStack {
-                            RoundedRectangle(cornerRadius: 12)
-                                .fill(Color(.systemFill))
-                            RoundedRectangle(cornerRadius: 12)
-                                .fill(reduceTransparency ? .thickMaterial : .ultraThinMaterial)
+                    switch ThemeManager.shared.mode {
+                    case .ink:
+                        if hasWallpaper {
+                            ZStack {
+                                RoundedRectangle(cornerRadius: theme.cardCornerRadius)
+                                    .fill(theme.surfaceContainerHigh)
+                                RoundedRectangle(cornerRadius: theme.cardCornerRadius)
+                                    .fill(reduceTransparency ? .thickMaterial : .ultraThinMaterial)
+                            }
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 2)
+                        } else {
+                            theme.surface
                         }
-                        .padding(.horizontal, 4)
-                        .padding(.vertical, 2)
-                    } else {
-                        Color.platformBackground
+                    case .classic:
+                        if hasWallpaper {
+                            ZStack {
+                                RoundedRectangle(cornerRadius: theme.cardCornerRadius)
+                                    .fill(theme.surfaceContainerHigh)
+                                RoundedRectangle(cornerRadius: theme.cardCornerRadius)
+                                    .fill(reduceTransparency ? .thickMaterial : .ultraThinMaterial)
+                            }
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 2)
+                        } else {
+                            Color.platformBackground
+                        }
                     }
                 }
             )

--- a/MangaLauncher/Views/Settings/SettingsView.swift
+++ b/MangaLauncher/Views/Settings/SettingsView.swift
@@ -18,6 +18,14 @@ struct SettingsView: View {
     @State private var updateStatus: UpdateStatus = .idle
     @State private var showingOnboarding = false
     @State private var showingSyncError = false
+    @State private var currentThemeMode: ThemeMode = ThemeManager.shared.mode
+
+    /// sheet内ではnil（OS準拠）が親の.darkを継承するため、UIKitからOS設定を直接取得
+    private var systemColorScheme: ColorScheme {
+        let style = (UIApplication.shared.connectedScenes.first as? UIWindowScene)?
+            .traitCollection.userInterfaceStyle
+        return style == .dark ? .dark : .light
+    }
 
     private enum UpdateStatus {
         case idle, checking, available(String), upToDate, error
@@ -154,6 +162,18 @@ struct SettingsView: View {
                 }
 
                 Section {
+                    Picker("テーマ", selection: $currentThemeMode) {
+                        ForEach(ThemeMode.allCases, id: \.self) { mode in
+                            Label(mode.displayName, systemImage: mode.iconName).tag(mode)
+                        }
+                    }
+                } header: {
+                    Text("テーマ")
+                } footer: {
+                    Text("「Kinetic Ink」はマンガ風のダークテーマです。")
+                }
+
+                Section {
                     Picker("ブラウザ", selection: $browserMode) {
                         Text("アプリ内（Safari）").tag("inApp")
                         Text("デフォルトブラウザ").tag("external")
@@ -254,6 +274,10 @@ struct SettingsView: View {
                     Text("登録されたすべてのマンガデータを削除します。この操作は取り消せません。")
                 }
             }
+            .scrollContentBackground(.hidden)
+            .background(currentThemeMode.style.groupedBackground)
+            .toolbarBackground(currentThemeMode.style.toolbarBackgroundVisibility, for: .navigationBar)
+            .toolbarColorScheme(currentThemeMode.style.colorSchemeOverride ?? systemColorScheme, for: .navigationBar)
             .navigationTitle("設定")
             #if os(iOS) || os(visionOS)
             .navigationBarTitleDisplayMode(.inline)
@@ -311,6 +335,10 @@ struct SettingsView: View {
                     Text(message)
                 }
             }
+        }
+        .preferredColorScheme(currentThemeMode.style.colorSchemeOverride ?? systemColorScheme)
+        .onChange(of: currentThemeMode) { _, newValue in
+            ThemeManager.shared.mode = newValue
         }
     }
 
@@ -427,6 +455,7 @@ struct SettingsView: View {
                     #endif
                 }
             }
+            .themedNavigationStyle()
             .navigationTitle("ライセンス")
             #if os(iOS) || os(visionOS)
             .navigationBarTitleDisplayMode(.inline)

--- a/MangaShareExtension/ShareViewController.swift
+++ b/MangaShareExtension/ShareViewController.swift
@@ -2,11 +2,16 @@ import UIKit
 import SwiftUI
 
 class ShareViewController: UIViewController {
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        overrideUserInterfaceStyle = theme.forceDarkMode ? .dark : .unspecified
+
         let hostingView = UIHostingController(
             rootView: ShareExtensionView(extensionContext: extensionContext)
+                .preferredColorScheme(theme.colorSchemeOverride)
         )
         addChild(hostingView)
         view.addSubview(hostingView.view)


### PR DESCRIPTION
## Summary
- テーマ切替機能を追加（Classic / Kinetic Ink）
- `DesignSystem.swift` にThemeManager・ThemeStyle・ThemeModeを集約したデザインシステムを導入
- 全Viewをテーマ対応に更新（色・フォント・形状・スペーシング）
- 設定画面からリアルタイムにテーマ切替可能
- Classic: OS設定（ダーク/ライト）に従う、Kinetic Ink: マンガ風の強制ダークテーマ

### 技術的なポイント
- `ThemeStyle.colorSchemeOverride`: `nil`（Classic=OS準拠）/ `.dark`（Ink=強制）で管理
- sheet内の `.preferredColorScheme(nil)` が親の `.dark` を継承する問題を、UIKitからOS設定を直接取得して解決
- テーマ固有値（`groupedBackground`, `toolbarBackgroundVisibility` 等）をThemeStyleに集約し、View側のハードコードを排除

## Test plan
- [x] Classic テーマで従来通りの外観を確認
- [x] Kinetic Ink テーマでマンガ風ダーク外観を確認
- [x] 設定画面でテーマ切替がリアルタイムに反映されることを確認
- [x] Classic + OSダークモードでダーク外観になることを確認
- [x] Classic + OSライトモードでライト外観になることを確認
- [x] CatchUp画面、ヒートマップ、編集画面等の各画面でテーマが正しく適用されることを確認
- [x] Share Extensionでテーマが反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)