### PR TITLE
Add dynamic gradient background to CatchUp screen

### DIFF
--- a/MangaLauncher.xcodeproj/project.pbxproj
+++ b/MangaLauncher.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		C2C5E8A68C5957E075832254 /* ImageColorExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05365AD0D66B41D8C20EDF49 /* ImageColorExtractor.swift */; };
+		C2C5E8A68C5957E075832255 /* ImageColorExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05365AD0D66B41D8C20EDF49 /* ImageColorExtractor.swift */; };
 		ECCE6BE2DD70F34BA69061B3 /* DesignSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC38F4ED01AE0D411DA0C66B /* DesignSystem.swift */; };
 		0F66A6093327A5A5BD16B10F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E7D977DE254FB1F216740BE6 /* Foundation.framework */; };
 		125D8CEEBC201DD7B9C5BCE3 /* ShareExtensionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 358605C94F78CC23682FF911 /* ShareExtensionView.swift */; };
@@ -127,6 +129,7 @@
 
 /* Begin PBXFileReference section */
 		EC38F4ED01AE0D411DA0C66B /* DesignSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystem.swift; sourceTree = "<group>"; };
+		05365AD0D66B41D8C20EDF49 /* ImageColorExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageColorExtractor.swift; sourceTree = "<group>"; };
 		0557E9481117CB9F8B903947 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		0CDE508C489E5FAA3881A522 /* SettingsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		1CF568E5CBBFA07B55373C73 /* DataMigration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DataMigration.swift; sourceTree = "<group>"; };
@@ -456,6 +459,7 @@
 				ECFEA8202F7E8B9D00CE4DC0 /* UserDefaultsKeys.swift */,
 				ECD61F7CE55EE24A44A02F14 /* AnimationTiming.swift */,
 				EC38F4ED01AE0D411DA0C66B /* DesignSystem.swift */,
+				05365AD0D66B41D8C20EDF49 /* ImageColorExtractor.swift */,
 				EC44DD5EE5561C4C4F99C248 /* ModelContextExtensions.swift */,
 				ECFEA8472F7F6E5700CE4DC0 /* MangaURLOpener.swift */,
 			);
@@ -602,6 +606,7 @@
 				ECFEA8222F7E8B9D00CE4DC0 /* UserDefaultsKeys.swift in Sources */,
 				EC79B98AEA2FF142AA989EF0 /* AnimationTiming.swift in Sources */,
 				ECCE6BE2DD70F34BA69061B3 /* DesignSystem.swift in Sources */,
+				C2C5E8A68C5957E075832254 /* ImageColorExtractor.swift in Sources */,
 				EC440D83EFDF1B4B6F95E82D /* ModelContextExtensions.swift in Sources */,
 				AA000001 /* ReadingActivity.swift in Sources */,
 				ECFEA84A2F7F6E5700CE4DC0 /* MangaURLOpener.swift in Sources */,
@@ -648,6 +653,7 @@
 				ECFEA8232F7E8B9D00CE4DC0 /* UserDefaultsKeys.swift in Sources */,
 				ECFEA8932F7F93AF00CE4DC0 /* AnimationTiming.swift in Sources */,
 				ECCE6BE2DD70F34BA69061B3 /* DesignSystem.swift in Sources */,
+				C2C5E8A68C5957E075832255 /* ImageColorExtractor.swift in Sources */,
 				ECFEA8942F7F93AF00CE4DC0 /* ModelContextExtensions.swift in Sources */,
 				A1000005 /* EditEntryView.swift in Sources */,
 				EC04B7CF2F70D9FE00AEE45F /* CatchUpView.swift in Sources */,

--- a/MangaLauncher/MangaLauncherApp.swift
+++ b/MangaLauncher/MangaLauncherApp.swift
@@ -4,6 +4,14 @@ import UserNotifications
 import NotificationKit
 import CloudSyncKit
 
+/// sheet/fullScreenCover内で `.preferredColorScheme(nil)` が親を継承する問題の回避用。
+/// UIKitからOS設定のカラースキームを直接取得する。
+var systemColorScheme: ColorScheme {
+    let style = (UIApplication.shared.connectedScenes.first as? UIWindowScene)?
+        .traitCollection.userInterfaceStyle
+    return style == .dark ? .dark : .light
+}
+
 extension Notification.Name {
     static let mangaDataDidChange = CloudSyncMonitor.dataDidChangeNotification
     static let switchToDay = Notification.Name("switchToDay")

--- a/MangaLauncher/Shared/DesignSystem.swift
+++ b/MangaLauncher/Shared/DesignSystem.swift
@@ -76,6 +76,12 @@ struct ThemeStyle {
     /// `colorSchemeOverride == .dark` の簡易アクセス（各Viewのスタイリング分岐用）
     var forceDarkMode: Bool { colorSchemeOverride == .dark }
 
+    /// sheet/fullScreenCover内で安全に使えるカラースキーム。
+    /// `colorSchemeOverride` が `nil`（OS準拠）の場合、`systemColorScheme` で解決する。
+    func resolvedColorScheme(system: ColorScheme) -> ColorScheme {
+        colorSchemeOverride ?? system
+    }
+
     // Spacing
     let spacingSM: CGFloat
     let spacingMD: CGFloat
@@ -309,3 +315,5 @@ extension View {
         }
     }
 }
+
+

--- a/MangaLauncher/Shared/DesignSystem.swift
+++ b/MangaLauncher/Shared/DesignSystem.swift
@@ -107,7 +107,7 @@ extension ThemeStyle {
         surface: .clear,
         surfaceBright: .clear,
         surfaceContainerHigh: Color(.systemFill),
-        surfaceContainerHighest: Color(.darkGray),
+        surfaceContainerHighest: Color(.systemGray4),
         primary: .accentColor,
         secondary: .accentColor,
         tertiary: .yellow,

--- a/MangaLauncher/Shared/DesignSystem.swift
+++ b/MangaLauncher/Shared/DesignSystem.swift
@@ -296,3 +296,16 @@ struct SpeechBubbleButtonStyle: ButtonStyle {
             .animation(.easeInOut(duration: 0.1), value: configuration.isPressed)
     }
 }
+
+// MARK: - Conditional View Modifier
+
+extension View {
+    @ViewBuilder
+    func `if`<Content: View>(_ condition: Bool, transform: (Self) -> Content) -> some View {
+        if condition {
+            transform(self)
+        } else {
+            self
+        }
+    }
+}

--- a/MangaLauncher/Shared/ImageColorExtractor.swift
+++ b/MangaLauncher/Shared/ImageColorExtractor.swift
@@ -45,6 +45,21 @@ enum ImageColorExtractor {
         #endif
     }
 
+    /// アイコンカラーからフォールバック用グラデーションを生成する
+    static func gradientFromColor(_ color: Color) -> GradientColors {
+        #if canImport(UIKit)
+        let uiColor = UIColor(color)
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        uiColor.getRed(&r, green: &g, blue: &b, alpha: &a)
+        return GradientColors(
+            top: Color(red: r * 0.5, green: g * 0.5, blue: b * 0.5),
+            bottom: Color(red: r * 0.25, green: g * 0.25, blue: b * 0.25)
+        )
+        #else
+        return GradientColors(top: color.opacity(0.5), bottom: color.opacity(0.25))
+        #endif
+    }
+
     private static func averageColor(
         pixels: UnsafeMutablePointer<UInt8>,
         size: Int,

--- a/MangaLauncher/Shared/ImageColorExtractor.swift
+++ b/MangaLauncher/Shared/ImageColorExtractor.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#endif
+
+/// 画像から支配的な色を抽出し、Apple Music風の背景グラデーションを生成する
+enum ImageColorExtractor {
+
+    struct GradientColors: Equatable {
+        let top: Color
+        let bottom: Color
+    }
+
+    /// 画像データから背景グラデーション用の2色を抽出する
+    static func extractGradient(from data: Data) -> GradientColors? {
+        #if canImport(UIKit)
+        guard let uiImage = UIImage(data: data),
+              let cgImage = uiImage.cgImage else { return nil }
+
+        let size = 40
+        guard let context = CGContext(
+            data: nil,
+            width: size,
+            height: size,
+            bitsPerComponent: 8,
+            bytesPerRow: size * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { return nil }
+
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: size, height: size))
+
+        guard let pixelData = context.data else { return nil }
+        let pixels = pixelData.bindMemory(to: UInt8.self, capacity: size * size * 4)
+
+        let top = averageColor(pixels: pixels, size: size, rowRange: 0..<(size / 3))
+        let bottom = averageColor(pixels: pixels, size: size, rowRange: (size * 2 / 3)..<size)
+
+        return GradientColors(
+            top: Color(red: top.r * 0.6, green: top.g * 0.6, blue: top.b * 0.6),
+            bottom: Color(red: bottom.r * 0.4, green: bottom.g * 0.4, blue: bottom.b * 0.4)
+        )
+        #else
+        return nil
+        #endif
+    }
+
+    private static func averageColor(
+        pixels: UnsafeMutablePointer<UInt8>,
+        size: Int,
+        rowRange: Range<Int>
+    ) -> (r: CGFloat, g: CGFloat, b: CGFloat) {
+        var totalR: CGFloat = 0
+        var totalG: CGFloat = 0
+        var totalB: CGFloat = 0
+        var count: CGFloat = 0
+
+        for y in rowRange {
+            for x in 0..<size {
+                let offset = (y * size + x) * 4
+                totalR += CGFloat(pixels[offset]) / 255
+                totalG += CGFloat(pixels[offset + 1]) / 255
+                totalB += CGFloat(pixels[offset + 2]) / 255
+                count += 1
+            }
+        }
+
+        guard count > 0 else { return (0, 0, 0) }
+        return (totalR / count, totalG / count, totalB / count)
+    }
+}

--- a/MangaLauncher/Views/CatchUp/CatchUpCardView.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpCardView.swift
@@ -10,12 +10,17 @@ struct CatchUpCardView: View {
     private var theme: ThemeStyle { ThemeManager.shared.style }
 
     var body: some View {
-        switch ThemeManager.shared.mode {
-        case .ink:
-            inkCard
-        case .classic:
-            classicCard
-        }
+        cardContent
+            .contentShape(Rectangle())
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("\(entry.name)\(entry.publisher.isEmpty ? "" : "、\(entry.publisher)")")
+            .accessibilityHint("タップでサイトを開く、長押しで編集")
+            .onTapGesture {
+                onOpenURL(entry.url)
+            }
+            .onLongPressGesture {
+                editingEntry = entry
+            }
     }
 
     // MARK: - Card Cover
@@ -39,78 +44,59 @@ struct CatchUpCardView: View {
         }
     }
 
-    // MARK: - Ink Card
+    // MARK: - Card Content
 
-    private var inkCard: some View {
-        VStack(spacing: 0) {
-            cardCover
+    @ViewBuilder
+    private var cardContent: some View {
+        switch ThemeManager.shared.mode {
+        case .ink:
+            VStack(spacing: 0) {
+                cardCover
 
-            VStack(spacing: 4) {
+                VStack(spacing: 4) {
+                    Text(entry.name)
+                        .font(theme.title3Font)
+                        .foregroundStyle(theme.onSurface)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.center)
+
+                    if !entry.publisher.isEmpty {
+                        Text(entry.publisher)
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundStyle(theme.onSurfaceVariant)
+                    }
+                }
+                .padding(.horizontal, theme.spacingMD)
+                .padding(.vertical, theme.spacingSM + 4)
+                .frame(maxWidth: .infinity)
+                .background(.thinMaterial)
+            }
+            .clipShape(RoundedRectangle(cornerRadius: theme.cardCornerRadius))
+
+        case .classic:
+            VStack(spacing: 12) {
+                cardCover
+                    .clipShape(RoundedRectangle(cornerRadius: theme.cardCornerRadius))
+
                 Text(entry.name)
                     .font(theme.title3Font)
-                    .foregroundStyle(theme.onSurface)
+                    .foregroundStyle(hasGradientBackground ? .white : theme.onSurface)
                     .lineLimit(2)
                     .multilineTextAlignment(.center)
 
                 if !entry.publisher.isEmpty {
                     Text(entry.publisher)
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundStyle(theme.onSurfaceVariant)
+                        .font(theme.subheadlineFont)
+                        .foregroundStyle(hasGradientBackground ? .white.opacity(0.7) : theme.onSurfaceVariant)
                 }
             }
-            .padding(.horizontal, theme.spacingMD)
-            .padding(.vertical, theme.spacingSM + 4)
+            .padding()
             .frame(maxWidth: .infinity)
-            .background(.thinMaterial)
-        }
-        .clipShape(RoundedRectangle(cornerRadius: theme.cardCornerRadius))
-        .contentShape(Rectangle())
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(entry.name)\(entry.publisher.isEmpty ? "" : "、\(entry.publisher)")")
-        .accessibilityHint("タップでサイトを開く、長押しで編集")
-        .onTapGesture {
-            onOpenURL(entry.url)
-        }
-        .onLongPressGesture {
-            editingEntry = entry
-        }
-    }
-
-    // MARK: - Classic Card
-
-    private var classicCard: some View {
-        VStack(spacing: 12) {
-            cardCover
-                .clipShape(RoundedRectangle(cornerRadius: theme.cardCornerRadius))
-
-            Text(entry.name)
-                .font(theme.title3Font)
-                .foregroundStyle(hasGradientBackground ? .white : theme.onSurface)
-                .lineLimit(2)
-                .multilineTextAlignment(.center)
-
-            if !entry.publisher.isEmpty {
-                Text(entry.publisher)
-                    .font(theme.subheadlineFont)
-                    .foregroundStyle(hasGradientBackground ? .white.opacity(0.7) : theme.onSurfaceVariant)
-            }
-        }
-        .padding()
-        .frame(maxWidth: .infinity)
-        .background(
-            RoundedRectangle(cornerRadius: 16)
-                .fill(.ultraThinMaterial)
-                .shadow(color: .black.opacity(theme.hasShadows ? 0.1 : 0), radius: 8, y: 4)
-        )
-        .contentShape(Rectangle())
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(entry.name)\(entry.publisher.isEmpty ? "" : "、\(entry.publisher)")")
-        .accessibilityHint("タップでサイトを開く、長押しで編集")
-        .onTapGesture {
-            onOpenURL(entry.url)
-        }
-        .onLongPressGesture {
-            editingEntry = entry
+            .background(
+                RoundedRectangle(cornerRadius: 16)
+                    .fill(.ultraThinMaterial)
+                    .shadow(color: .black.opacity(theme.hasShadows ? 0.1 : 0), radius: 8, y: 4)
+            )
         }
     }
 }

--- a/MangaLauncher/Views/CatchUp/CatchUpCardView.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpCardView.swift
@@ -5,6 +5,7 @@ struct CatchUpCardView: View {
     let entry: MangaEntry
     @Binding var editingEntry: MangaEntry?
     let onOpenURL: (String) -> Void
+    var hasGradientBackground: Bool = false
 
     private var theme: ThemeStyle { ThemeManager.shared.style }
 
@@ -21,29 +22,26 @@ struct CatchUpCardView: View {
 
     private var inkCard: some View {
         VStack(spacing: 0) {
-            ZStack(alignment: .topLeading) {
-                if let imageData = entry.imageData, let image = imageData.toSwiftUIImage() {
-                    image
-                        .resizable()
-                        .scaledToFit()
-                        .clipShape(RoundedRectangle(cornerRadius: theme.cardCornerRadius))
-                } else {
-                    RoundedRectangle(cornerRadius: theme.cardCornerRadius)
-                        .fill(Color.fromName(entry.iconColor))
-                        .aspectRatio(3/4, contentMode: .fit)
-                        .overlay {
-                            ZStack {
-                                if theme.usesScreenTone {
-                                    ScreenTonePattern(opacity: 0.08, spacing: 4)
-                                }
-                                Text(entry.name)
-                                    .font(.system(size: 28, weight: .black))
-                                    .foregroundStyle(.white)
-                                    .multilineTextAlignment(.center)
-                                    .padding()
+            if let imageData = entry.imageData, let image = imageData.toSwiftUIImage() {
+                image
+                    .resizable()
+                    .scaledToFit()
+            } else {
+                Rectangle()
+                    .fill(Color.fromName(entry.iconColor))
+                    .aspectRatio(3/4, contentMode: .fit)
+                    .overlay {
+                        ZStack {
+                            if theme.usesScreenTone {
+                                ScreenTonePattern(opacity: 0.08, spacing: 4)
                             }
+                            Text(entry.name)
+                                .font(.system(size: 28, weight: .black))
+                                .foregroundStyle(.white)
+                                .multilineTextAlignment(.center)
+                                .padding()
                         }
-                }
+                    }
             }
 
             VStack(spacing: 4) {
@@ -62,13 +60,9 @@ struct CatchUpCardView: View {
             .padding(.horizontal, theme.spacingMD)
             .padding(.vertical, theme.spacingSM + 4)
             .frame(maxWidth: .infinity)
-            .background(theme.surfaceContainerHighest)
+            .background(.thinMaterial)
         }
         .clipShape(RoundedRectangle(cornerRadius: theme.cardCornerRadius))
-        .background(
-            RoundedRectangle(cornerRadius: theme.cardCornerRadius)
-                .fill(theme.surfaceContainerHigh)
-        )
         .contentShape(Rectangle())
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(entry.name)\(entry.publisher.isEmpty ? "" : "、\(entry.publisher)")")
@@ -105,20 +99,21 @@ struct CatchUpCardView: View {
 
             Text(entry.name)
                 .font(theme.title3Font)
+                .foregroundStyle(hasGradientBackground ? .white : theme.onSurface)
                 .lineLimit(2)
                 .multilineTextAlignment(.center)
 
             if !entry.publisher.isEmpty {
                 Text(entry.publisher)
                     .font(theme.subheadlineFont)
-                    .foregroundStyle(theme.onSurfaceVariant)
+                    .foregroundStyle(hasGradientBackground ? .white.opacity(0.7) : theme.onSurfaceVariant)
             }
         }
         .padding()
         .frame(maxWidth: .infinity)
         .background(
             RoundedRectangle(cornerRadius: 16)
-                .fill(.background)
+                .fill(.ultraThinMaterial)
                 .shadow(color: .black.opacity(theme.hasShadows ? 0.1 : 0), radius: 8, y: 4)
         )
         .contentShape(Rectangle())

--- a/MangaLauncher/Views/CatchUp/CatchUpCardView.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpCardView.swift
@@ -18,31 +18,32 @@ struct CatchUpCardView: View {
         }
     }
 
+    // MARK: - Card Cover
+
+    @ViewBuilder
+    private var cardCover: some View {
+        if let imageData = entry.imageData, let image = imageData.toSwiftUIImage() {
+            image
+                .resizable()
+                .scaledToFit()
+        } else {
+            Color.fromName(entry.iconColor)
+                .overlay {
+                    Text(entry.name)
+                        .font(theme.forceDarkMode ? .system(size: 28, weight: .black) : .title.bold())
+                        .foregroundStyle(.white)
+                        .multilineTextAlignment(.center)
+                        .padding()
+                }
+                .aspectRatio(4/3, contentMode: .fit)
+        }
+    }
+
     // MARK: - Ink Card
 
     private var inkCard: some View {
         VStack(spacing: 0) {
-            if let imageData = entry.imageData, let image = imageData.toSwiftUIImage() {
-                image
-                    .resizable()
-                    .scaledToFit()
-            } else {
-                Rectangle()
-                    .fill(Color.fromName(entry.iconColor))
-                    .aspectRatio(3/4, contentMode: .fit)
-                    .overlay {
-                        ZStack {
-                            if theme.usesScreenTone {
-                                ScreenTonePattern(opacity: 0.08, spacing: 4)
-                            }
-                            Text(entry.name)
-                                .font(.system(size: 28, weight: .black))
-                                .foregroundStyle(.white)
-                                .multilineTextAlignment(.center)
-                                .padding()
-                        }
-                    }
-            }
+            cardCover
 
             VStack(spacing: 4) {
                 Text(entry.name)
@@ -79,23 +80,8 @@ struct CatchUpCardView: View {
 
     private var classicCard: some View {
         VStack(spacing: 12) {
-            if let imageData = entry.imageData, let image = imageData.toSwiftUIImage() {
-                image
-                    .resizable()
-                    .scaledToFit()
-                    .clipShape(RoundedRectangle(cornerRadius: theme.cardCornerRadius))
-            } else {
-                RoundedRectangle(cornerRadius: theme.cardCornerRadius)
-                    .fill(Color.fromName(entry.iconColor))
-                    .aspectRatio(3/4, contentMode: .fit)
-                    .overlay {
-                        Text(entry.name)
-                            .font(.title.bold())
-                            .foregroundStyle(.white)
-                            .multilineTextAlignment(.center)
-                            .padding()
-                    }
-            }
+            cardCover
+                .clipShape(RoundedRectangle(cornerRadius: theme.cardCornerRadius))
 
             Text(entry.name)
                 .font(theme.title3Font)

--- a/MangaLauncher/Views/CatchUp/CatchUpCompletedView.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpCompletedView.swift
@@ -67,9 +67,6 @@ struct CatchUpCompletedView: View {
             Spacer()
         }
         .frame(maxWidth: .infinity)
-        .if(theme.forceDarkMode) { view in
-            view.background(theme.surface)
-        }
         .onAppear {
             completionAnimated = false
             achievementAnimated = false
@@ -115,16 +112,5 @@ struct CatchUpCompletedView: View {
                 }
             }
         )
-    }
-}
-
-private extension View {
-    @ViewBuilder
-    func `if`<Content: View>(_ condition: Bool, transform: (Self) -> Content) -> some View {
-        if condition {
-            transform(self)
-        } else {
-            self
-        }
     }
 }

--- a/MangaLauncher/Views/CatchUp/CatchUpTutorialOverlay.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpTutorialOverlay.swift
@@ -101,14 +101,3 @@ struct CatchUpTutorialOverlay: View {
         }
     }
 }
-
-private extension View {
-    @ViewBuilder
-    func `if`<Content: View>(_ condition: Bool, transform: (Self) -> Content) -> some View {
-        if condition {
-            transform(self)
-        } else {
-            self
-        }
-    }
-}

--- a/MangaLauncher/Views/CatchUp/CatchUpView.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpView.swift
@@ -28,13 +28,6 @@ struct CatchUpView: View {
     private var theme: ThemeStyle { ThemeManager.shared.style }
     private var hasGradient: Bool { backgroundGradient != nil }
 
-    /// fullScreenCover内ではnil（OS準拠）が親を継承するため、UIKitからOS設定を直接取得
-    private var systemColorScheme: ColorScheme {
-        let style = (UIApplication.shared.connectedScenes.first as? UIWindowScene)?
-            .traitCollection.userInterfaceStyle
-        return style == .dark ? .dark : .light
-    }
-
     private enum SwipeAction {
         case read, skip
     }
@@ -136,7 +129,7 @@ struct CatchUpView: View {
                 .ignoresSafeArea()
         }
         #endif
-        .preferredColorScheme(hasGradient ? .dark : (theme.colorSchemeOverride ?? systemColorScheme))
+        .preferredColorScheme(hasGradient ? .dark : theme.resolvedColorScheme(system: systemColorScheme))
     }
 
     // MARK: - Card Stack

--- a/MangaLauncher/Views/CatchUp/CatchUpView.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpView.swift
@@ -23,8 +23,17 @@ struct CatchUpView: View {
     @State private var achievementAnimated = false
     @State private var streakAchievement: Int?
     @State private var milestoneAchievement: Int?
+    @State private var backgroundGradient: ImageColorExtractor.GradientColors?
 
     private var theme: ThemeStyle { ThemeManager.shared.style }
+    private var hasGradient: Bool { backgroundGradient != nil }
+
+    /// fullScreenCover内ではnil（OS準拠）が親を継承するため、UIKitからOS設定を直接取得
+    private var systemColorScheme: ColorScheme {
+        let style = (UIApplication.shared.connectedScenes.first as? UIWindowScene)?
+            .traitCollection.userInterfaceStyle
+        return style == .dark ? .dark : .light
+    }
 
     private enum SwipeAction {
         case read, skip
@@ -45,19 +54,29 @@ struct CatchUpView: View {
                     cardStackView
                 }
             }
-            .if(theme.forceDarkMode) { view in
-                view.background(theme.surface)
+            .background {
+                if let gradient = backgroundGradient {
+                    LinearGradient(
+                        colors: [gradient.top, gradient.bottom],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                    .ignoresSafeArea()
+                    .animation(.easeInOut(duration: 0.5), value: backgroundGradient)
+                } else if theme.forceDarkMode {
+                    theme.surface.ignoresSafeArea()
+                }
             }
             .toolbar {
                 ToolbarItem(placement: .principal) {
                     VStack(spacing: 2) {
                         Text("\(day.displayName)のキャッチアップ")
                             .font(theme.headlineFont)
-                            .foregroundStyle(theme.onSurface)
+                            .foregroundStyle(hasGradient ? .white : theme.onSurface)
                         if let publisher {
                             Text(publisher)
                                 .font(theme.captionFont)
-                                .foregroundStyle(theme.onSurfaceVariant)
+                                .foregroundStyle(hasGradient ? .white.opacity(0.7) : theme.onSurfaceVariant)
                         }
                     }
                 }
@@ -65,13 +84,11 @@ struct CatchUpView: View {
             #if os(iOS) || os(visionOS)
             .navigationBarTitleDisplayMode(.inline)
             #endif
-            .themedNavigationStyle()
+            .toolbarBackground(.hidden, for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("閉じる") { dismiss() }
-                        .if(theme.forceDarkMode) { view in
-                            view.foregroundStyle(theme.primary)
-                        }
+                        .foregroundStyle(hasGradient ? .white : (theme.forceDarkMode ? theme.primary : Color.accentColor))
                 }
                 if !undoStack.isEmpty {
                     ToolbarItem(placement: .automatic) {
@@ -90,6 +107,12 @@ struct CatchUpView: View {
             }
             if !hasSeenTutorial && !unreadItems.isEmpty {
                 showTutorial = true
+            }
+            updateBackgroundGradient()
+        }
+        .onChange(of: currentIndex) { _, newIndex in
+            if newIndex < unreadItems.count {
+                updateBackgroundGradient()
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: .mangaDataDidChange)) { _ in
@@ -113,6 +136,7 @@ struct CatchUpView: View {
                 .ignoresSafeArea()
         }
         #endif
+        .preferredColorScheme(hasGradient ? .dark : (theme.colorSchemeOverride ?? systemColorScheme))
     }
 
     // MARK: - Card Stack
@@ -123,12 +147,13 @@ struct CatchUpView: View {
             HStack {
                 Text("\(currentIndex + 1) / \(totalCount)")
                     .font(theme.subheadlineFont)
-                    .foregroundStyle(theme.onSurfaceVariant)
+                    .foregroundStyle(hasGradient ? .white : theme.onSurfaceVariant)
                 Spacer()
                 Text("残り \(remainingCount) 件")
                     .font(theme.subheadlineFont)
-                    .foregroundStyle(theme.onSurfaceVariant)
+                    .foregroundStyle(hasGradient ? .white : theme.onSurfaceVariant)
             }
+            .shadow(color: hasGradient ? .black.opacity(0.5) : .clear, radius: 2, y: 1)
             .padding(.horizontal)
 
             ProgressView(value: Double(currentIndex), total: Double(totalCount))
@@ -139,14 +164,14 @@ struct CatchUpView: View {
 
             ZStack {
                 if currentIndex + 1 < totalCount {
-                    CatchUpCardView(entry: unreadItems[currentIndex + 1], editingEntry: $editingEntry, onOpenURL: openMangaURL)
+                    CatchUpCardView(entry: unreadItems[currentIndex + 1], editingEntry: $editingEntry, onOpenURL: openMangaURL, hasGradientBackground: hasGradient)
                         .id("\(unreadItems[currentIndex + 1].id)-\(reloadCount)")
                         .scaleEffect(0.95)
                         .opacity(0.5)
                         .allowsHitTesting(false)
                 }
 
-                CatchUpCardView(entry: unreadItems[currentIndex], editingEntry: $editingEntry, onOpenURL: openMangaURL)
+                CatchUpCardView(entry: unreadItems[currentIndex], editingEntry: $editingEntry, onOpenURL: openMangaURL, hasGradientBackground: hasGradient)
                     .id("\(unreadItems[currentIndex].id)-\(reloadCount)")
                     .offset(offset)
                     .rotationEffect(.degrees(Double(offset.width) / 20))
@@ -348,18 +373,25 @@ struct CatchUpView: View {
         }
     }
 
+    private func updateBackgroundGradient() {
+        guard currentIndex < unreadItems.count else { return }
+        guard let imageData = unreadItems[currentIndex].imageData else {
+            withAnimation(.easeInOut(duration: 0.5)) {
+                backgroundGradient = nil
+            }
+            return
+        }
+        Task.detached(priority: .userInitiated) {
+            let gradient = ImageColorExtractor.extractGradient(from: imageData)
+            await MainActor.run {
+                withAnimation(.easeInOut(duration: 0.5)) {
+                    backgroundGradient = gradient
+                }
+            }
+        }
+    }
+
     private func openMangaURL(_ urlString: String) {
         MangaURLOpener(browserMode: browserMode, openURL: openURL) { safariURL = $0 }.open(urlString)
-    }
-}
-
-private extension View {
-    @ViewBuilder
-    func `if`<Content: View>(_ condition: Bool, transform: (Self) -> Content) -> some View {
-        if condition {
-            transform(self)
-        } else {
-            self
-        }
     }
 }

--- a/MangaLauncher/Views/CatchUp/CatchUpView.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpView.swift
@@ -375,9 +375,10 @@ struct CatchUpView: View {
 
     private func updateBackgroundGradient() {
         guard currentIndex < unreadItems.count else { return }
-        guard let imageData = unreadItems[currentIndex].imageData else {
+        let entry = unreadItems[currentIndex]
+        guard let imageData = entry.imageData else {
             withAnimation(.easeInOut(duration: 0.5)) {
-                backgroundGradient = nil
+                backgroundGradient = ImageColorExtractor.gradientFromColor(Color.fromName(entry.iconColor))
             }
             return
         }

--- a/MangaLauncher/Views/Common/OnboardingView.swift
+++ b/MangaLauncher/Views/Common/OnboardingView.swift
@@ -93,14 +93,3 @@ struct OnboardingView: View {
         }
     }
 }
-
-private extension View {
-    @ViewBuilder
-    func `if`<Content: View>(_ condition: Bool, transform: (Self) -> Content) -> some View {
-        if condition {
-            transform(self)
-        } else {
-            self
-        }
-    }
-}

--- a/MangaLauncher/Views/Entry/EditEntryView.swift
+++ b/MangaLauncher/Views/Entry/EditEntryView.swift
@@ -417,17 +417,6 @@ struct EditEntryView: View {
     }
 }
 
-private extension View {
-    @ViewBuilder
-    func `if`<Content: View>(_ condition: Bool, transform: (Self) -> Content) -> some View {
-        if condition {
-            transform(self)
-        } else {
-            self
-        }
-    }
-}
-
 #Preview("New Entry") {
     let container = try! ModelContainer(for: MangaEntry.self, configurations: ModelConfiguration(isStoredInMemoryOnly: true))
     let viewModel = MangaViewModel(modelContext: container.mainContext)

--- a/MangaLauncher/Views/Entry/PublisherPickerView.swift
+++ b/MangaLauncher/Views/Entry/PublisherPickerView.swift
@@ -87,14 +87,3 @@ struct PublisherPickerView: View {
         }
     }
 }
-
-private extension View {
-    @ViewBuilder
-    func `if`<Content: View>(_ condition: Bool, transform: (Self) -> Content) -> some View {
-        if condition {
-            transform(self)
-        } else {
-            self
-        }
-    }
-}

--- a/MangaLauncher/Views/Heatmap/ReadingHeatmapView.swift
+++ b/MangaLauncher/Views/Heatmap/ReadingHeatmapView.swift
@@ -344,17 +344,6 @@ private struct DayActivitySheet: View {
     }
 }
 
-private extension View {
-    @ViewBuilder
-    func `if`<Content: View>(_ condition: Bool, transform: (Self) -> Content) -> some View {
-        if condition {
-            transform(self)
-        } else {
-            self
-        }
-    }
-}
-
 // MARK: - Date + Identifiable
 
 extension Date: @retroactive Identifiable {

--- a/MangaLauncher/Views/MangaCell/MangaListView.swift
+++ b/MangaLauncher/Views/MangaCell/MangaListView.swift
@@ -54,14 +54,3 @@ struct MangaListView: View {
         #endif
     }
 }
-
-private extension View {
-    @ViewBuilder
-    func `if`<Content: View>(_ condition: Bool, transform: (Self) -> Content) -> some View {
-        if condition {
-            transform(self)
-        } else {
-            self
-        }
-    }
-}

--- a/MangaLauncher/Views/Settings/SettingsView.swift
+++ b/MangaLauncher/Views/Settings/SettingsView.swift
@@ -20,13 +20,6 @@ struct SettingsView: View {
     @State private var showingSyncError = false
     @State private var currentThemeMode: ThemeMode = ThemeManager.shared.mode
 
-    /// sheet内ではnil（OS準拠）が親の.darkを継承するため、UIKitからOS設定を直接取得
-    private var systemColorScheme: ColorScheme {
-        let style = (UIApplication.shared.connectedScenes.first as? UIWindowScene)?
-            .traitCollection.userInterfaceStyle
-        return style == .dark ? .dark : .light
-    }
-
     private enum UpdateStatus {
         case idle, checking, available(String), upToDate, error
     }
@@ -277,7 +270,7 @@ struct SettingsView: View {
             .scrollContentBackground(.hidden)
             .background(currentThemeMode.style.groupedBackground)
             .toolbarBackground(currentThemeMode.style.toolbarBackgroundVisibility, for: .navigationBar)
-            .toolbarColorScheme(currentThemeMode.style.colorSchemeOverride ?? systemColorScheme, for: .navigationBar)
+            .toolbarColorScheme(currentThemeMode.style.resolvedColorScheme(system: systemColorScheme), for: .navigationBar)
             .navigationTitle("設定")
             #if os(iOS) || os(visionOS)
             .navigationBarTitleDisplayMode(.inline)
@@ -336,7 +329,7 @@ struct SettingsView: View {
                 }
             }
         }
-        .preferredColorScheme(currentThemeMode.style.colorSchemeOverride ?? systemColorScheme)
+        .preferredColorScheme(currentThemeMode.style.resolvedColorScheme(system: systemColorScheme))
         .onChange(of: currentThemeMode) { _, newValue in
             ThemeManager.shared.mode = newValue
         }


### PR DESCRIPTION
## Summary
- キャッチアップ画面にApple Music風の動的グラデーション背景を追加
- マンガのカバー画像から支配的な色を抽出し、カード切替時にスムーズにアニメーション
- カードのテキスト部分はマテリアル背景でグラデーションが透けて見える
- 完了画面でも最後のカードのグラデーションを維持
- 8ファイルに重複していた `if` View extensionを `DesignSystem.swift` に統合

### 変更ファイル
- **新規**: `ImageColorExtractor.swift` - 画像から色抽出
- **CatchUpView**: グラデーション背景、ナビバー・ステータスバーの色適応
- **CatchUpCardView**: マテリアル背景（ink: `.thinMaterial`, classic: `.ultraThinMaterial`）
- **CatchUpCompletedView**: 不透明背景の削除
- **7ファイル**: 重複 `if` extension の削除

## Test plan
- [x] Classic/Inkテーマでキャッチアップ画面のグラデーション背景を確認
- [x] カードスワイプ時にグラデーションが滑らかに切り替わることを確認
- [x] 完了画面で最後のカードのグラデーションが維持されることを確認
- [x] ナビバー・ステータスバーの白テキストがグラデーション上で読みやすいことを確認
- [x] 画像のないエントリでフォールバック表示を確認
- [x] OSダークモード/ライトモード両方で正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)