### PR TITLE
Add retro (劇画エディトリアル) theme

### DIFF
--- a/MangaLauncher/Shared/DesignSystem.swift
+++ b/MangaLauncher/Shared/DesignSystem.swift
@@ -8,11 +8,13 @@ import UIKit
 enum ThemeMode: String, CaseIterable {
     case classic
     case ink
+    case retro
 
     var displayName: String {
         switch self {
         case .classic: return "クラシック"
         case .ink: return "Kinetic Ink"
+        case .retro: return "劇画エディトリアル"
         }
     }
 
@@ -20,6 +22,7 @@ enum ThemeMode: String, CaseIterable {
         switch self {
         case .classic: return "circle.lefthalf.filled"
         case .ink: return "paintbrush.pointed.fill"
+        case .retro: return "book.pages.fill"
         }
     }
 
@@ -27,6 +30,7 @@ enum ThemeMode: String, CaseIterable {
         switch self {
         case .classic: return .classic
         case .ink: return .ink
+        case .retro: return .retro
         }
     }
 }
@@ -75,6 +79,9 @@ struct ThemeStyle {
 
     /// `colorSchemeOverride == .dark` の簡易アクセス（各Viewのスタイリング分岐用）
     var forceDarkMode: Bool { colorSchemeOverride == .dark }
+
+    /// テーマが独自のsurfaceカラーを持つか（ink, retro等）
+    var usesCustomSurface: Bool { colorSchemeOverride != nil }
 
     /// sheet/fullScreenCover内で安全に使えるカラースキーム。
     /// `colorSchemeOverride` が `nil`（OS準拠）の場合、`systemColorScheme` で解決する。
@@ -157,6 +164,56 @@ extension ThemeStyle {
         heatmapColor: .green,
         onboardingColors: [.blue, .green, .orange, .purple],
         tutorialColors: (tap: .blue, read: .green, skip: .orange, undo: .secondary)
+    )
+
+    static let retro = ThemeStyle(
+        surface: Color(hex: "f5efe0"),
+        surfaceBright: Color(hex: "faf6ec"),
+        surfaceContainerHigh: Color(hex: "ebe5d5"),
+        surfaceContainerHighest: Color(hex: "ddd6c4"),
+        primary: Color(hex: "ff6b35"),
+        secondary: Color(hex: "ff6b35"),
+        tertiary: Color(hex: "5d5d69"),
+        primaryDim: Color(hex: "ab3500"),
+        onSurface: Color(hex: "1a1b25"),
+        onSurfaceVariant: Color(hex: "4a4a42"),
+        onPrimary: .white,
+        error: Color(hex: "ba1a1a"),
+        headlineFont: .system(size: 15, weight: .heavy, design: .rounded),
+        bodyFont: .system(size: 15, weight: .medium),
+        captionFont: .system(size: 12, weight: .semibold),
+        caption2Font: .system(size: 10, weight: .medium),
+        subheadlineFont: .system(size: 14, weight: .semibold),
+        title2Font: .system(size: 22, weight: .heavy, design: .rounded),
+        title3Font: .system(size: 18, weight: .heavy, design: .rounded),
+        cornerRadius: 6,
+        cardCornerRadius: 10,
+        chipShape: AnyShape(RoundedRectangle(cornerRadius: 6)),
+        iconFallbackIsCircle: false,
+        colorSchemeOverride: .light,
+        groupedBackground: Color(hex: "f5efe0"),
+        toolbarBackgroundVisibility: .visible,
+        usesScreenTone: true,
+        hasShadows: false,
+        spacingSM: 8,
+        spacingMD: 16,
+        spacingLG: 24,
+        tabSpacing: 2,
+        tabItemSpacing: 2,
+        tabFont: { isSelected in .system(size: isSelected ? 24 : 16, weight: .heavy, design: .rounded) },
+        tabItemHeight: 52,
+        tabUnreadDotSize: 6,
+        tabUnderlineHeight: 3,
+        tabUnderlineCornerRadius: 1,
+        tabSelectedRotation: -2,
+        tabSelectedScale: 1.08,
+        tabShowsTodayCircle: false,
+        badgeColor: Color(hex: "ff6b35"),
+        catchUpReadColor: Color(hex: "ff6b35"),
+        catchUpSkipColor: Color(hex: "ffd167"),
+        heatmapColor: Color(hex: "ff6b35"),
+        onboardingColors: [Color(hex: "ff6b35"), Color(hex: "ffd167"), Color(hex: "ab3500"), Color(hex: "5d5d69")],
+        tutorialColors: (tap: Color(hex: "ff6b35"), read: Color(hex: "ff6b35"), skip: Color(hex: "ffd167"), undo: Color(hex: "5d5d69"))
     )
 
     static let ink = ThemeStyle(
@@ -254,16 +311,22 @@ struct ScreenTonePattern: View {
     var opacity: Double = 0.05
     var dotSize: CGFloat = 2
     var spacing: CGFloat = 6
+    var dotColor: Color = .white
 
     var body: some View {
         Canvas { context, size in
             for x in stride(from: 0, to: size.width, by: spacing) {
                 for y in stride(from: 0, to: size.height, by: spacing) {
                     let rect = CGRect(x: x, y: y, width: dotSize, height: dotSize)
-                    context.fill(Path(ellipseIn: rect), with: .color(.white.opacity(opacity)))
+                    context.fill(Path(ellipseIn: rect), with: .color(dotColor.opacity(opacity)))
                 }
             }
         }
+    }
+
+    /// 劇画テーマ用ハーフトーン（Ben-Day dots）
+    static var halftone: ScreenTonePattern {
+        ScreenTonePattern(opacity: 0.03, dotSize: 2.5, spacing: 5, dotColor: Color(hex: "1a1b25"))
     }
 }
 

--- a/MangaLauncher/Shared/DesignSystem.swift
+++ b/MangaLauncher/Shared/DesignSystem.swift
@@ -14,7 +14,7 @@ enum ThemeMode: String, CaseIterable {
         switch self {
         case .classic: return "クラシック"
         case .ink: return "Kinetic Ink"
-        case .retro: return "劇画エディトリアル"
+        case .retro: return "レトロ"
         }
     }
 

--- a/MangaLauncher/Views/CatchUp/CatchUpCardView.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpCardView.swift
@@ -97,6 +97,30 @@ struct CatchUpCardView: View {
                     .fill(.ultraThinMaterial)
                     .shadow(color: .black.opacity(theme.hasShadows ? 0.1 : 0), radius: 8, y: 4)
             )
+
+        case .retro:
+            VStack(spacing: 0) {
+                cardCover
+
+                VStack(spacing: 4) {
+                    Text(entry.name)
+                        .font(theme.title3Font)
+                        .foregroundStyle(theme.onSurface)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.center)
+
+                    if !entry.publisher.isEmpty {
+                        Text(entry.publisher)
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundStyle(theme.onSurfaceVariant)
+                    }
+                }
+                .padding(.horizontal, theme.spacingMD)
+                .padding(.vertical, theme.spacingSM + 4)
+                .frame(maxWidth: .infinity)
+                .background(theme.surfaceContainerHigh)
+            }
+            .clipShape(UnevenRoundedRectangle(topLeadingRadius: 14, bottomLeadingRadius: 6, bottomTrailingRadius: 14, topTrailingRadius: 6))
         }
     }
 }

--- a/MangaLauncher/Views/CatchUp/CatchUpCompletedView.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpCompletedView.swift
@@ -62,6 +62,18 @@ struct CatchUpCompletedView: View {
                     }
                     .buttonStyle(.bordered)
                     .opacity(completionAnimated ? 1.0 : 0.0)
+                case .retro:
+                    Button {
+                        onRecheck()
+                    } label: {
+                        Label("未読を再チェック（\(remainingUnread)件）", systemImage: "arrow.counterclockwise")
+                            .font(theme.headlineFont)
+                            .foregroundStyle(theme.onSurface)
+                            .padding(.horizontal, 20)
+                            .padding(.vertical, 10)
+                            .background(theme.surfaceContainerHigh, in: RoundedRectangle(cornerRadius: theme.cornerRadius))
+                    }
+                    .opacity(completionAnimated ? 1.0 : 0.0)
                 }
             }
             Spacer()
@@ -109,6 +121,9 @@ struct CatchUpCompletedView: View {
                     RoundedRectangle(cornerRadius: 16)
                         .fill(.ultraThinMaterial)
                         .shadow(color: .black.opacity(0.08), radius: 4, y: 2)
+                case .retro:
+                    RoundedRectangle(cornerRadius: theme.cardCornerRadius)
+                        .fill(theme.surfaceContainerHigh)
                 }
             }
         )

--- a/MangaLauncher/Views/CatchUp/CatchUpCompletedView.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpCompletedView.swift
@@ -9,9 +9,11 @@ struct CatchUpCompletedView: View {
     @Binding var achievementAnimated: Bool
     let checkStreak: () -> Int?
     let checkMilestone: () -> Int?
+    var hasGradientBackground: Bool = false
     var onRecheck: (() -> Void)?
 
     private var theme: ThemeStyle { ThemeManager.shared.style }
+    private var textColor: Color { hasGradientBackground ? .white : theme.onSurface }
 
     private var hasAchievement: Bool {
         streakAchievement != nil || milestoneAchievement != nil
@@ -27,7 +29,7 @@ struct CatchUpCompletedView: View {
                 .opacity(completionAnimated ? 1.0 : 0.0)
             Text(message)
                 .font(theme.title2Font)
-                .foregroundStyle(theme.onSurface)
+                .foregroundStyle(textColor)
                 .opacity(completionAnimated ? 1.0 : 0.0)
 
             if hasAchievement {
@@ -107,7 +109,7 @@ struct CatchUpCompletedView: View {
                 .foregroundStyle(iconColor)
             Text(text)
                 .font(theme.headlineFont)
-                .foregroundStyle(theme.onSurface)
+                .foregroundStyle(textColor)
         }
         .padding(.horizontal, 24)
         .padding(.vertical, 14)

--- a/MangaLauncher/Views/CatchUp/CatchUpTutorialOverlay.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpTutorialOverlay.swift
@@ -68,6 +68,9 @@ struct CatchUpTutorialOverlay: View {
                     case .classic:
                         RoundedRectangle(cornerRadius: 20)
                             .fill(.ultraThinMaterial)
+                    case .retro:
+                        RoundedRectangle(cornerRadius: theme.cardCornerRadius)
+                            .fill(theme.surface)
                     }
                 }
             )

--- a/MangaLauncher/Views/CatchUp/CatchUpView.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpView.swift
@@ -56,7 +56,7 @@ struct CatchUpView: View {
                     )
                     .ignoresSafeArea()
                     .animation(.easeInOut(duration: 0.5), value: backgroundGradient)
-                } else if theme.forceDarkMode {
+                } else if theme.usesCustomSurface {
                     theme.surface.ignoresSafeArea()
                 }
             }

--- a/MangaLauncher/Views/CatchUp/CatchUpView.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpView.swift
@@ -354,7 +354,8 @@ struct CatchUpView: View {
             completionAnimated: $completionAnimated,
             achievementAnimated: $achievementAnimated,
             checkStreak: checkStreakAchievement,
-            checkMilestone: checkMilestoneAchievement
+            checkMilestone: checkMilestoneAchievement,
+            hasGradientBackground: hasGradient
         ) {
             completionAnimated = false
             achievementAnimated = false

--- a/MangaLauncher/Views/Heatmap/ReadingHeatmapView.swift
+++ b/MangaLauncher/Views/Heatmap/ReadingHeatmapView.swift
@@ -76,6 +76,8 @@ struct ReadingHeatmapView: View {
                 RoundedRectangle(cornerRadius: theme.cardCornerRadius).fill(theme.surfaceContainerHigh)
             case .classic:
                 RoundedRectangle(cornerRadius: 10).fill(.fill.tertiary)
+            case .retro:
+                RoundedRectangle(cornerRadius: theme.cardCornerRadius).fill(theme.surfaceContainerHigh)
             }
         }
     }
@@ -332,6 +334,14 @@ private struct DayActivitySheet: View {
                 .overlay {
                     Image(systemName: "book.closed")
                         .foregroundStyle(.secondary)
+                }
+        case .retro:
+            RoundedRectangle(cornerRadius: theme.cardCornerRadius)
+                .fill(theme.surfaceContainerHigh)
+                .frame(width: 40, height: 40)
+                .overlay {
+                    Image(systemName: "book.closed")
+                        .foregroundStyle(theme.onSurfaceVariant)
                 }
         }
     }

--- a/MangaLauncher/Views/Home/ContentView.swift
+++ b/MangaLauncher/Views/Home/ContentView.swift
@@ -187,17 +187,24 @@ struct ContentView: View {
             }
         }
         .background {
-            #if canImport(UIKit)
-            VisualEffectBlur(style: homeState.wallpaper.hasWallpaper
-                ? (reduceTransparency ? .systemThinMaterial : .systemUltraThinMaterial)
-                : .systemMaterial)
+            let theme = ThemeManager.shared.style
+            Group {
+                if theme.usesCustomSurface && !homeState.wallpaper.hasWallpaper {
+                    Rectangle().fill(theme.surface.opacity(0.85))
+                        .background(.ultraThinMaterial)
+                } else {
+                    #if canImport(UIKit)
+                    VisualEffectBlur(style: homeState.wallpaper.hasWallpaper
+                        ? (reduceTransparency ? .systemThinMaterial : .systemUltraThinMaterial)
+                        : .systemMaterial)
+                    #else
+                    Rectangle().fill(homeState.wallpaper.hasWallpaper
+                        ? (reduceTransparency ? AnyShapeStyle(.thinMaterial) : AnyShapeStyle(.ultraThinMaterial))
+                        : AnyShapeStyle(.regularMaterial))
+                    #endif
+                }
+            }
             .ignoresSafeArea(edges: .top)
-            #else
-            Rectangle().fill(homeState.wallpaper.hasWallpaper
-                ? (reduceTransparency ? AnyShapeStyle(.thinMaterial) : AnyShapeStyle(.ultraThinMaterial))
-                : AnyShapeStyle(.regularMaterial))
-            .ignoresSafeArea(edges: .top)
-            #endif
         }
         .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { newHeight in
             if abs(newHeight - homeState.headerHeight) > 2 {

--- a/MangaLauncher/Views/Home/DayTabBarView.swift
+++ b/MangaLauncher/Views/Home/DayTabBarView.swift
@@ -115,6 +115,7 @@ struct DayTabBarView: View {
         } else if theme.usesCustomSurface {
             if isSelected { return theme.primary }
             if hasWallpaper && isSelected { return .white }
+            if !day.isHiatus && !day.isCompleted && day == .today { return theme.primary }
             if day.isHiatus || day.isCompleted { return theme.onSurfaceVariant.opacity(0.5) }
             return theme.onSurface
         } else {

--- a/MangaLauncher/Views/Home/DayTabBarView.swift
+++ b/MangaLauncher/Views/Home/DayTabBarView.swift
@@ -40,7 +40,7 @@ struct DayTabBarView: View {
                             .background {
                                 if theme.tabShowsTodayCircle {
                                     if !day.isHiatus && !day.isCompleted && day == .today {
-                                        Circle().fill(Color.accentColor)
+                                        Circle().fill(theme.usesCustomSurface ? theme.primary : Color.accentColor)
                                     } else if hasWallpaper && isSelected {
                                         Circle().fill(Color.black.opacity(0.3))
                                     }
@@ -112,6 +112,11 @@ struct DayTabBarView: View {
             if !day.isHiatus && !day.isCompleted && day == .today { return theme.primary }
             if day.isHiatus || day.isCompleted { return theme.onSurfaceVariant.opacity(0.5) }
             return theme.onSurfaceVariant
+        } else if theme.usesCustomSurface {
+            if isSelected { return theme.primary }
+            if hasWallpaper && isSelected { return .white }
+            if day.isHiatus || day.isCompleted { return theme.onSurfaceVariant.opacity(0.5) }
+            return theme.onSurface
         } else {
             if !day.isHiatus && !day.isCompleted && day == .today { return .white }
             if hasWallpaper && isSelected { return .white }

--- a/MangaLauncher/Views/Home/EditModeButtons.swift
+++ b/MangaLauncher/Views/Home/EditModeButtons.swift
@@ -31,6 +31,14 @@ struct EditModeButtons: View {
                         .padding(.vertical, 10)
                         .foregroundStyle(theme.onSurface)
                         .background(theme.surfaceContainerHighest, in: Capsule())
+                case .retro:
+                    Label("壁紙", systemImage: "photo.artframe")
+                        .font(theme.headlineFont)
+                        .fixedSize()
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, 10)
+                        .foregroundStyle(theme.onSurface)
+                        .background(theme.surfaceContainerHigh, in: Capsule())
                 }
             }
             Button {
@@ -56,6 +64,16 @@ struct EditModeButtons: View {
                         .padding(.vertical, 10)
                         .foregroundStyle(theme.onPrimary)
                         .background(theme.primary, in: Capsule())
+                case .retro:
+                    Text("完了")
+                        .font(theme.headlineFont)
+                        .padding(.horizontal, 24)
+                        .padding(.vertical, 10)
+                        .foregroundStyle(theme.onPrimary)
+                        .background(
+                            LinearGradient(colors: [theme.primaryDim, theme.primary], startPoint: .leading, endPoint: .trailing),
+                            in: Capsule()
+                        )
                 }
             }
         }

--- a/MangaLauncher/Views/Home/EmptyStateView.swift
+++ b/MangaLauncher/Views/Home/EmptyStateView.swift
@@ -32,6 +32,10 @@ struct EmptyStateView<Content: View>: View {
                 content()
                     .padding(.top, headerHeight)
                     .background(theme.surface)
+            case .retro:
+                content()
+                    .padding(.top, headerHeight)
+                    .background(theme.surface)
             }
         }
     }

--- a/MangaLauncher/Views/MangaCell/MangaGridCell.swift
+++ b/MangaLauncher/Views/MangaCell/MangaGridCell.swift
@@ -10,6 +10,8 @@ struct MangaGridCell: View {
     @Binding var editingEntry: MangaEntry?
     let onOpenURL: (String) -> Void
 
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
     var body: some View {
         if entry.isDeleted || entry.modelContext == nil {
             EmptyView()
@@ -36,19 +38,19 @@ struct MangaGridCell: View {
                 HStack(alignment: .top, spacing: 4) {
                     if !entry.isRead {
                         Circle()
-                            .fill(Color.accentColor)
+                            .fill(theme.usesCustomSurface ? theme.badgeColor : Color.accentColor)
                             .frame(width: 6, height: 6)
                             .padding(.top, 4)
                     }
                     VStack(alignment: .leading, spacing: 2) {
                         Text(entry.name)
-                            .font(.caption)
-                            .foregroundStyle(.primary)
+                            .font(theme.captionFont)
+                            .foregroundStyle(theme.usesCustomSurface ? theme.onSurface : .primary)
                             .lineLimit(2)
                         if !entry.publisher.isEmpty {
                             Text(entry.publisher)
-                                .font(.caption2)
-                                .foregroundStyle(.secondary)
+                                .font(theme.caption2Font)
+                                .foregroundStyle(theme.usesCustomSurface ? theme.onSurfaceVariant : .secondary)
                         }
                     }
                     Spacer(minLength: 0)

--- a/MangaLauncher/Views/MangaCell/MangaGridCell.swift
+++ b/MangaLauncher/Views/MangaCell/MangaGridCell.swift
@@ -35,22 +35,23 @@ struct MangaGridCell: View {
                         }
                 }
 
+                let isRetro = theme.usesCustomSurface && !theme.forceDarkMode
                 HStack(alignment: .top, spacing: 4) {
                     if !entry.isRead {
                         Circle()
-                            .fill(theme.usesCustomSurface ? theme.badgeColor : Color.accentColor)
+                            .fill(isRetro ? theme.badgeColor : Color.accentColor)
                             .frame(width: 6, height: 6)
                             .padding(.top, 4)
                     }
                     VStack(alignment: .leading, spacing: 2) {
                         Text(entry.name)
-                            .font(theme.captionFont)
-                            .foregroundStyle(theme.usesCustomSurface ? theme.onSurface : .primary)
+                            .font(isRetro ? theme.captionFont : .caption)
+                            .foregroundStyle(isRetro ? theme.onSurface : .primary)
                             .lineLimit(2)
                         if !entry.publisher.isEmpty {
                             Text(entry.publisher)
-                                .font(theme.caption2Font)
-                                .foregroundStyle(theme.usesCustomSurface ? theme.onSurfaceVariant : .secondary)
+                                .font(isRetro ? theme.caption2Font : .caption2)
+                                .foregroundStyle(isRetro ? theme.onSurfaceVariant : .secondary)
                         }
                     }
                     Spacer(minLength: 0)

--- a/MangaLauncher/Views/MangaCell/MangaListView.swift
+++ b/MangaLauncher/Views/MangaCell/MangaListView.swift
@@ -30,15 +30,15 @@ struct MangaListView: View {
             .onMove { source, destination in
                 viewModel.moveEntries(for: day, from: source, to: destination)
             }
-            .listRowSeparator(theme.forceDarkMode ? .hidden : (hasWallpaper ? .hidden : .automatic))
-            .if(theme.forceDarkMode) { view in
+            .listRowSeparator(theme.usesCustomSurface ? .hidden : (hasWallpaper ? .hidden : .automatic))
+            .if(theme.usesCustomSurface) { view in
                 view.listRowInsets(EdgeInsets(top: 2, leading: 12, bottom: 2, trailing: 12))
             }
         }
         .listStyle(.plain)
         .contentMargins(.top, headerHeight, for: .scrollContent)
-        .scrollContentBackground(theme.forceDarkMode ? .hidden : (hasWallpaper ? .hidden : .automatic))
-        .if(theme.forceDarkMode) { view in
+        .scrollContentBackground(theme.usesCustomSurface ? .hidden : (hasWallpaper ? .hidden : .automatic))
+        .if(theme.usesCustomSurface) { view in
             view.background(theme.surface)
         }
         .simultaneousGesture(

--- a/MangaLauncher/Views/MangaCell/MangaRowCell.swift
+++ b/MangaLauncher/Views/MangaCell/MangaRowCell.swift
@@ -42,6 +42,15 @@ struct MangaRowCell: View {
                         Color.clear
                             .frame(width: 8, height: 8)
                     }
+                case .retro:
+                    if !entry.isRead {
+                        RoundedRectangle(cornerRadius: 3)
+                            .fill(LinearGradient(colors: [theme.primaryDim, theme.primary], startPoint: .leading, endPoint: .trailing))
+                            .frame(width: 8, height: 8)
+                    } else {
+                        Color.clear
+                            .frame(width: 8, height: 8)
+                    }
                 }
 
                 EntryIcon(entry: entry, size: 36)
@@ -68,10 +77,14 @@ struct MangaRowCell: View {
                     Image(systemName: "chevron.right")
                         .font(.caption)
                         .foregroundStyle(.tertiary)
+                case .retro:
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(theme.onSurfaceVariant.opacity(0.4))
                 }
             }
-            .padding(.vertical, theme.forceDarkMode ? 8 : (hasWallpaper ? 4 : 0))
-            .padding(.horizontal, theme.forceDarkMode ? 4 : 0)
+            .padding(.vertical, theme.usesCustomSurface ? 8 : (hasWallpaper ? 4 : 0))
+            .padding(.horizontal, theme.usesCustomSurface ? 4 : 0)
             .contentShape(Rectangle())
             .accessibilityElement(children: .combine)
             .accessibilityLabel("\(entry.name)\(entry.publisher.isEmpty ? "" : "、\(entry.publisher)")\(entry.isRead ? "" : "、未読")")
@@ -107,6 +120,19 @@ struct MangaRowCell: View {
                             .padding(.vertical, 2)
                         } else {
                             Color.platformBackground
+                        }
+                    case .retro:
+                        if hasWallpaper {
+                            ZStack {
+                                RoundedRectangle(cornerRadius: theme.cardCornerRadius)
+                                    .fill(theme.surfaceContainerHigh)
+                                RoundedRectangle(cornerRadius: theme.cardCornerRadius)
+                                    .fill(reduceTransparency ? .thickMaterial : .ultraThinMaterial)
+                            }
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 2)
+                        } else {
+                            theme.surface
                         }
                     }
                 }

--- a/MangaLauncher/Views/Settings/SettingsView.swift
+++ b/MangaLauncher/Views/Settings/SettingsView.swift
@@ -163,7 +163,7 @@ struct SettingsView: View {
                 } header: {
                     Text("テーマ")
                 } footer: {
-                    Text("「Kinetic Ink」はマンガ風のダークテーマ、「劇画エディトリアル」は70〜80年代の劇画誌をイメージしたレトロテーマです。")
+                    Text("「Kinetic Ink」はマンガ風のダークテーマ、「レトロ」は70〜80年代の劇画誌をイメージしたテーマです。")
                 }
 
                 Section {

--- a/MangaLauncher/Views/Settings/SettingsView.swift
+++ b/MangaLauncher/Views/Settings/SettingsView.swift
@@ -163,7 +163,7 @@ struct SettingsView: View {
                 } header: {
                     Text("テーマ")
                 } footer: {
-                    Text("「Kinetic Ink」はマンガ風のダークテーマです。")
+                    Text("「Kinetic Ink」はマンガ風のダークテーマ、「劇画エディトリアル」は70〜80年代の劇画誌をイメージしたレトロテーマです。")
                 }
 
                 Section {

--- a/docs/DESIGN_retro.md
+++ b/docs/DESIGN_retro.md
@@ -1,0 +1,80 @@
+# Design System Strategy: The Gekiga Editorial
+
+## 1. Overview & Creative North Star
+**The Creative North Star: "The Analog Serial"**
+
+This design system rejects the clinical perfection of modern SaaS interfaces in favor of the soulful, tactile imperfection of 1970s and 80s manga. We are not building a website; we are composing a digital *tankōbon*. The aesthetic is rooted in the "Gekiga" movement—dramatic, cinematic, and gritty. 
+
+To break the "template" look, we move away from symmetrical grids. Layouts should feel like a dynamic manga page: intentional overlap, varying panel widths (inspired by 4-koma structures), and "bleeding" elements that break out of their containers. We trade the sterile "digital" look for the warmth of aged paper and the weight of physical ink.
+
+---
+
+## 2. Colors & Tactility
+The palette is a curated selection of "weathered" tones that mimic the chemical aging of paper and the saturation of vintage print.
+
+### The Palette
+- **The Ground:** `surface` (#fcf9f2) acts as our aged paper base. It is never pure white.
+- **The Ink:** `on_tertiary_fixed` (#1a1b25) is our "Vintage Ink Blue." Use this for text and structural "ink" lines.
+- **The Accents:** `primary_container` (#ff6b35 / Retro Orange) and `secondary_container` (#ffd167 / Mustard Yellow) are used sparingly to highlight narrative peaks—mimicking the limited color pages of a special edition manga volume.
+
+### Rules of Engagement
+- **The "No-Line" Rule:** Standard 1px UI borders are strictly prohibited. Sectioning must be achieved through background shifts (e.g., a `surface_container_low` block resting on a `surface` background). 
+- **Surface Hierarchy & Nesting:** Treat the UI as stacked sheets of newsprint. Use `surface_container_lowest` for the most prominent "hero" panels to create a soft, natural lift. For deeper "inset" panels, use `surface_dim`.
+- **The "Ink Bleed" Gradient:** For primary CTAs, use a subtle linear gradient from `primary` (#ab3500) to `primary_container` (#ff6b35) to simulate the way heavy ink pools and thins on textured paper.
+- **Signature Textures:** Overlay a global "Halftone" pattern (Ben-Day dots) at 3% opacity over `surface_variant` areas to provide that quintessential gritty, printed feel.
+
+---
+
+## 3. Typography
+Our typography is a tension between the "Raw Narrative" and the "Editorial Commentary."
+
+- **Display & Headlines (Epilogue):** Set with high tracking and bold weights. This is our "Brush-Style" surrogate. It should feel loud and cinematic. In hero sections, use `display-lg` with a slight `-2deg` rotation to mimic hand-lettered sound effects (SFX).
+- **Titles & Body (Public Sans):** A clean, vintage-feeling sans-serif that ensures readability against the textured backgrounds. It provides the "typeset" look found in translated manga bubbles.
+- **Labels (Space Grotesk):** Used for technical metadata. These should feel like the small print found on the spine of a vintage magazine.
+
+---
+
+## 4. Elevation & Depth
+In this system, depth is not a product of light and shadow, but of **Tonal Layering** and physical stacking.
+
+- **The Layering Principle:** Avoid CSS shadows where possible. Instead, use a "double-offset" panel: a `surface_container_high` card with a 2px offset "ghost" of `on_surface_variant` behind it to simulate a physical paper cutout.
+- **Ambient Shadows:** If a floating element (like a modal) is required, use a high-spread, low-opacity (4%) shadow tinted with `tertiary` (#5d5d69) to keep the "gritty" tone.
+- **The "Ghost Border":** For interactive states, use `outline_variant` at 20% opacity. It should look like a faint pencil sketch before the ink is applied.
+- **Manga Glassmorphism:** For top navigation or floating speech bubbles, use `surface` at 85% opacity with a heavy `backdrop-blur`. This simulates the "tracing paper" used by mangaka.
+
+---
+
+## 5. Components
+
+### Buttons (Vintage Arcade/Label Style)
+- **Primary:** High-contrast `primary_container` with a bold `on_primary_container` label. Use `radius-md` (0.375rem). The hover state should increase the "Ink Bleed" gradient intensity.
+- **Tertiary:** No background. Use `label-md` in all-caps with a `primary` underline that looks hand-drawn.
+
+### Panels & Cards (Manga Frames)
+- Forbid divider lines. Separate content using the Spacing Scale (minimum 24px) or a shift to `surface_container_low`. 
+- Panels should use slightly asymmetrical rounded corners (e.g., top-left: `xl`, bottom-right: `md`) to mimic the hand-cut nature of old gekiga panels.
+
+### Speech Bubbles (The Narrative Tool)
+- A bespoke component for tooltips and callouts. Use a `surface_container_lowest` background with a small, hand-drawn vector "tail" (pointer).
+- Ensure the text has generous padding to mimic the "white space" of manga dialogue.
+
+### Input Fields
+- Avoid the "box" look. Use a `surface_dim` bottom-bar only, with a `label-sm` floating above it. 
+- Error states use `error` (#ba1a1a) with a subtle halftone pattern fill to make the error feel like a dramatic "red ink" correction.
+
+---
+
+## 6. Do’s and Don’ts
+
+### Do:
+- **Embrace Asymmetry:** Align text to the left but offset images to the right, breaking the container edge.
+- **Use Halftones:** Apply Ben-Day dot patterns to `secondary_container` elements to add "mechanical" soul.
+- **Think in Panels:** Treat every page as a vertical 4-koma strip.
+
+### Don’t:
+- **No 1px Solid Black Borders:** It kills the "aged paper" vibe. Use background tonal shifts or "ghost borders" instead.
+- **No Perfect Grids:** Avoid standard 12-column layouts. Use staggered "gutter" widths to create visual tension.
+- **No Pure Grey:** Shadows and neutrals must always be "warm" (sepia-tinted) or "cool" (ink-blue-tinted), never neutral #888888.
+
+### Accessibility Note:
+While we embrace the "faded" look, ensure all `body-md` text on `surface` backgrounds maintains a contrast ratio of at least 4.5:1 by using the `on_surface` (#1c1c18) token for all long-form reading.


### PR DESCRIPTION
## Summary
- 70〜80年代の劇画誌をイメージしたレトロテーマ「劇画エディトリアル」を追加
- セピア調の暖かいsurface色、レトロオレンジのアクセント、ヴィンテージインクブルーのテキスト
- タブバー・フィルターチップ・CatchUp・ヒートマップ等の全画面でテーマ対応

## Changes
- `ThemeMode.retro` / `ThemeStyle.retro` を追加（DesignSystem.swift）
- `usesCustomSurface` プロパティ追加で ink/retro 共通のカスタムsurface判定
- `ScreenTonePattern` にハーフトーン（Ben-Day dots）バリアント追加
- 12箇所の `switch ThemeManager.shared.mode` に `.retro` ケース追加
- ヘッダーバー背景・グリッドセル・リストビューをテーマカラー対応に更新
- 設定画面のテーマ説明文を更新

## Test plan
- [x] 設定 > テーマで「劇画エディトリアル」を選択し、各画面の表示を確認
- [x] タブバーの選択色・アンダーバー色が統一されていることを確認
- [x] グリッド表示・リスト表示の両方でテーマが適用されていることを確認
- [x] CatchUp画面でカード・完了画面・チュートリアルのテーマ適用を確認
- [x] 読書アクティビティ（ヒートマップ）画面のテーマ適用を確認
- [x] クラシック・Kinetic Ink テーマに切り替えて既存テーマが壊れていないことを確認
- [x] 壁紙設定時の表示が正常であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)