### PR TITLE
Remove isRetro branching in grid cell

### DIFF
--- a/MangaLauncher/Views/MangaCell/MangaGridCell.swift
+++ b/MangaLauncher/Views/MangaCell/MangaGridCell.swift
@@ -35,23 +35,22 @@ struct MangaGridCell: View {
                         }
                 }
 
-                let isRetro = theme.usesCustomSurface && !theme.forceDarkMode
                 HStack(alignment: .top, spacing: 4) {
                     if !entry.isRead {
                         Circle()
-                            .fill(isRetro ? theme.badgeColor : Color.accentColor)
+                            .fill(theme.badgeColor)
                             .frame(width: 6, height: 6)
                             .padding(.top, 4)
                     }
                     VStack(alignment: .leading, spacing: 2) {
                         Text(entry.name)
-                            .font(isRetro ? theme.captionFont : .caption)
-                            .foregroundStyle(isRetro ? theme.onSurface : .primary)
+                            .font(.caption)
+                            .foregroundStyle(theme.onSurface)
                             .lineLimit(2)
                         if !entry.publisher.isEmpty {
                             Text(entry.publisher)
-                                .font(isRetro ? theme.caption2Font : .caption2)
-                                .foregroundStyle(isRetro ? theme.onSurfaceVariant : .secondary)
+                                .font(.caption2)
+                                .foregroundStyle(theme.onSurfaceVariant)
                         }
                     }
                     Spacer(minLength: 0)


### PR DESCRIPTION
## Summary
- MangaGridCellの`isRetro`決め打ち分岐を削除
- `theme.badgeColor`・`theme.onSurface`・`theme.onSurfaceVariant`は全テーマで適切な値が入っているため、条件分岐なしで直接使用

## Test plan
- [ ] クラシック・Kinetic Ink・レトロの各テーマでグリッド表示を確認
- [ ] 未読バッジの色が各テーマで正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)