### PR TITLE
Fix retro theme background consistency

### DIFF
--- a/MangaLauncher/Views/Home/ContentView.swift
+++ b/MangaLauncher/Views/Home/ContentView.swift
@@ -190,8 +190,7 @@ struct ContentView: View {
             let theme = ThemeManager.shared.style
             Group {
                 if theme.usesCustomSurface && !homeState.wallpaper.hasWallpaper {
-                    Rectangle().fill(theme.surface.opacity(0.85))
-                        .background(.ultraThinMaterial)
+                    Rectangle().fill(theme.surface)
                 } else {
                     #if canImport(UIKit)
                     VisualEffectBlur(style: homeState.wallpaper.hasWallpaper

--- a/MangaLauncher/Views/Home/DayPagerView.swift
+++ b/MangaLauncher/Views/Home/DayPagerView.swift
@@ -19,6 +19,9 @@ struct DayPagerView<PageContent: View>: View {
             }
         }
         .tabViewStyle(.page(indexDisplayMode: .never))
+        .if(ThemeManager.shared.style.usesCustomSurface) { view in
+            view.background(ThemeManager.shared.style.surface)
+        }
         .onChange(of: paging.pageIndex) { oldValue, newValue in
             let day = paging.dayForPageIndex(newValue)
             if !paging.isAnimatingPageChange {


### PR DESCRIPTION
## Summary
- ヘッダーバーの半透明マテリアルをソリッドなsurface色に変更
- TabViewの背景にsurface色を設定し、白い隙間を解消

## Test plan
- [ ] レトロテーマで全画面の背景色が均一であることを確認
- [ ] ink・クラシックテーマに影響がないことを確認
- [ ] 壁紙設定時の表示が正常であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)