### PR TITLE
Fix wallpaper hidden by retro theme background

### DIFF
--- a/MangaLauncher/Views/Home/ContentView.swift
+++ b/MangaLauncher/Views/Home/ContentView.swift
@@ -73,7 +73,8 @@ struct ContentView: View {
                     paging: homeState.paging,
                     listEditMode: $homeState.edit.listEditMode,
                     selectedPublisher: $homeState.selectedPublisher,
-                    viewModel: viewModel
+                    viewModel: viewModel,
+                    hasWallpaper: homeState.wallpaper.hasWallpaper
                 ) { day, vm in
                     DayPageView(
                         day: day,

--- a/MangaLauncher/Views/Home/DayPagerView.swift
+++ b/MangaLauncher/Views/Home/DayPagerView.swift
@@ -7,6 +7,7 @@ struct DayPagerView<PageContent: View>: View {
     #endif
     @Binding var selectedPublisher: String?
     var viewModel: MangaViewModel
+    let hasWallpaper: Bool
     let pageContent: (DayOfWeek, MangaViewModel) -> PageContent
 
     var body: some View {
@@ -19,7 +20,7 @@ struct DayPagerView<PageContent: View>: View {
             }
         }
         .tabViewStyle(.page(indexDisplayMode: .never))
-        .if(ThemeManager.shared.style.usesCustomSurface) { view in
+        .if(ThemeManager.shared.style.usesCustomSurface && !hasWallpaper) { view in
             view.background(ThemeManager.shared.style.surface)
         }
         .onChange(of: paging.pageIndex) { oldValue, newValue in


### PR DESCRIPTION
## Summary
- DayPagerViewに`hasWallpaper`を渡し、壁紙なしのときだけTabViewにソリッド背景を設定
- 壁紙設定時はTabView背景を透明に保ち、壁紙画像が正しく表示されるように修正

## Test plan
- [ ] レトロテーマで壁紙を設定し、壁紙が表示されることを確認
- [ ] レトロテーマで壁紙なしのとき、白い隙間が出ないことを確認
- [ ] ink・クラシックテーマで壁紙の表示に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)