### PR TITLE
Add swipe-down to dismiss CatchUp screen

### DIFF
--- a/MangaLauncher/Views/CatchUp/CatchUpView.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpView.swift
@@ -129,6 +129,7 @@ struct CatchUpView: View {
                 .ignoresSafeArea()
         }
         #endif
+        .gesture(dismissDragGesture, including: isCompleted || unreadItems.isEmpty ? .all : .subviews)
         .preferredColorScheme(hasGradient ? .dark : theme.resolvedColorScheme(system: systemColorScheme))
     }
 
@@ -217,7 +218,18 @@ struct CatchUpView: View {
         .frame(maxWidth: .infinity)
     }
 
-    // MARK: - Drag Gesture
+    // MARK: - Dismiss Drag Gesture
+
+    private var dismissDragGesture: some Gesture {
+        DragGesture(minimumDistance: 50)
+            .onEnded { value in
+                if value.translation.height > 100 && value.translation.height > abs(value.translation.width) {
+                    dismiss()
+                }
+            }
+    }
+
+    // MARK: - Card Drag Gesture
 
     private var dragGesture: some Gesture {
         DragGesture()


### PR DESCRIPTION
Closes #151

## Summary
- キャッチアップ画面の完了/空状態で下スワイプにより画面を閉じれるように
- カード操作中は下スワイプdismissを無効化し、既読/スキップの横スワイプと競合しない

## Test plan
- [ ] 完了画面（「すべてチェックしました！」）で下スワイプして閉じれることを確認
- [ ] 未読なし画面で下スワイプして閉じれることを確認
- [ ] カード表示中に下スワイプしても閉じないことを確認
- [ ] カードの左右スワイプ（既読/スキップ）が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)