### PR TITLE
Fix drag & drop broken on ink/retro themes

### DIFF
--- a/MangaLauncher/Views/Home/ContentView.swift
+++ b/MangaLauncher/Views/Home/ContentView.swift
@@ -73,8 +73,7 @@ struct ContentView: View {
                     paging: homeState.paging,
                     listEditMode: $homeState.edit.listEditMode,
                     selectedPublisher: $homeState.selectedPublisher,
-                    viewModel: viewModel,
-                    hasWallpaper: homeState.wallpaper.hasWallpaper
+                    viewModel: viewModel
                 ) { day, vm in
                     DayPageView(
                         day: day,
@@ -188,23 +187,17 @@ struct ContentView: View {
             }
         }
         .background {
-            let theme = ThemeManager.shared.style
-            Group {
-                if theme.usesCustomSurface && !homeState.wallpaper.hasWallpaper {
-                    Rectangle().fill(theme.surface)
-                } else {
-                    #if canImport(UIKit)
-                    VisualEffectBlur(style: homeState.wallpaper.hasWallpaper
-                        ? (reduceTransparency ? .systemThinMaterial : .systemUltraThinMaterial)
-                        : .systemMaterial)
-                    #else
-                    Rectangle().fill(homeState.wallpaper.hasWallpaper
-                        ? (reduceTransparency ? AnyShapeStyle(.thinMaterial) : AnyShapeStyle(.ultraThinMaterial))
-                        : AnyShapeStyle(.regularMaterial))
-                    #endif
-                }
-            }
+            #if canImport(UIKit)
+            VisualEffectBlur(style: homeState.wallpaper.hasWallpaper
+                ? (reduceTransparency ? .systemThinMaterial : .systemUltraThinMaterial)
+                : .systemMaterial)
             .ignoresSafeArea(edges: .top)
+            #else
+            Rectangle().fill(homeState.wallpaper.hasWallpaper
+                ? (reduceTransparency ? AnyShapeStyle(.thinMaterial) : AnyShapeStyle(.ultraThinMaterial))
+                : AnyShapeStyle(.regularMaterial))
+            .ignoresSafeArea(edges: .top)
+            #endif
         }
         .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { newHeight in
             if abs(newHeight - homeState.headerHeight) > 2 {

--- a/MangaLauncher/Views/Home/DayPagerView.swift
+++ b/MangaLauncher/Views/Home/DayPagerView.swift
@@ -7,7 +7,6 @@ struct DayPagerView<PageContent: View>: View {
     #endif
     @Binding var selectedPublisher: String?
     var viewModel: MangaViewModel
-    let hasWallpaper: Bool
     let pageContent: (DayOfWeek, MangaViewModel) -> PageContent
 
     var body: some View {
@@ -20,9 +19,6 @@ struct DayPagerView<PageContent: View>: View {
             }
         }
         .tabViewStyle(.page(indexDisplayMode: .never))
-        .if(ThemeManager.shared.style.usesCustomSurface && !hasWallpaper) { view in
-            view.background(ThemeManager.shared.style.surface)
-        }
         .onChange(of: paging.pageIndex) { oldValue, newValue in
             let day = paging.dayForPageIndex(newValue)
             if !paging.isAnimatingPageChange {


### PR DESCRIPTION
## Summary
- ヘッダー背景の`Group { if ... }`条件分岐がDayTabBarViewのドロップターゲットを壊していた
- 元の`VisualEffectBlur`に戻してドラッグ&ドロップを復旧
- DayPagerViewのbackground/hasWallpaperも削除（同様の問題を防ぐため）

## Root Cause
#149 で追加したヘッダー背景の条件分岐（retro対応）が、SwiftUIのビュー階層を動的に変更し、`onDrop`のヒットテストが機能しなくなっていた。

## Test plan
- [ ] ink/retroテーマでグリッドセルをドラッグして曜日タブにドロップできることを確認
- [ ] クラシックテーマでも同様に動作することを確認
- [ ] 壁紙設定時のドラッグ&ドロップが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)