### PR TITLE
Add one-shot (読み切り) manga support

### DIFF
--- a/MangaLauncher/Intents/AddMangaIntent.swift
+++ b/MangaLauncher/Intents/AddMangaIntent.swift
@@ -80,6 +80,9 @@ struct AddMangaIntent: AppIntent {
     @Parameter(title: "画像", supportedContentTypes: [.image])
     var image: IntentFile?
 
+    @Parameter(title: "読み切り", default: false)
+    var isOneShot: Bool
+
     func perform() async throws -> some IntentResult {
         let defaults = UserDefaults(suiteName: SharedModelContainer.appGroupIdentifier)
         let intentData: [String: String] = [
@@ -88,6 +91,7 @@ struct AddMangaIntent: AppIntent {
             "dayOfWeek": String(dayOfWeek.toDayOfWeek.rawValue),
             "publisher": publisher ?? "",
             "iconColor": (iconColor ?? .blue).rawValue,
+            "isOneShot": isOneShot ? "true" : "false",
         ]
         defaults?.set(intentData, forKey: "pendingIntentData")
 

--- a/MangaLauncher/MangaLauncherApp.swift
+++ b/MangaLauncher/MangaLauncherApp.swift
@@ -39,6 +39,7 @@ struct IntentPrefill: Identifiable {
     let publisher: String
     let iconColor: String
     let imageData: Data?
+    let isOneShot: Bool
 }
 
 @main
@@ -82,7 +83,8 @@ struct MangaLauncherApp: App {
                         prefilledDay: prefill.dayOfWeek,
                         prefilledPublisher: prefill.publisher,
                         prefilledColor: prefill.iconColor,
-                        prefilledImageData: prefill.imageData
+                        prefilledImageData: prefill.imageData,
+                        prefilledIsOneShot: prefill.isOneShot
                     )
                 }
                 .onAppear {
@@ -121,7 +123,8 @@ struct MangaLauncherApp: App {
             dayOfWeek: DayOfWeek(rawValue: dayRaw) ?? .today,
             publisher: data["publisher"] ?? "",
             iconColor: data["iconColor"] ?? "blue",
-            imageData: imageData
+            imageData: imageData,
+            isOneShot: data["isOneShot"] == "true"
         )
     }
 

--- a/MangaLauncher/Models/BackupData.swift
+++ b/MangaLauncher/Models/BackupData.swift
@@ -29,8 +29,9 @@ struct BackupData: Codable {
         let nextExpectedUpdate: Date?
         let isOnHiatus: Bool?
         let isCompleted: Bool?
+        let isOneShot: Bool?
 
-        init(id: UUID, name: String, url: String, dayOfWeekRawValue: Int, sortOrder: Int, iconColor: String, publisher: String, imageData: Data?, lastReadDate: Date? = nil, updateIntervalWeeks: Int = 1, nextExpectedUpdate: Date? = nil, isOnHiatus: Bool = false, isCompleted: Bool = false) {
+        init(id: UUID, name: String, url: String, dayOfWeekRawValue: Int, sortOrder: Int, iconColor: String, publisher: String, imageData: Data?, lastReadDate: Date? = nil, updateIntervalWeeks: Int = 1, nextExpectedUpdate: Date? = nil, isOnHiatus: Bool = false, isCompleted: Bool = false, isOneShot: Bool = false) {
             self.id = id
             self.name = name
             self.url = url
@@ -44,6 +45,7 @@ struct BackupData: Codable {
             self.nextExpectedUpdate = nextExpectedUpdate
             self.isOnHiatus = isOnHiatus
             self.isCompleted = isCompleted
+            self.isOneShot = isOneShot
         }
 
         init(from decoder: Decoder) throws {
@@ -61,6 +63,7 @@ struct BackupData: Codable {
             nextExpectedUpdate = try container.decodeIfPresent(Date.self, forKey: .nextExpectedUpdate)
             isOnHiatus = try container.decodeIfPresent(Bool.self, forKey: .isOnHiatus)
             isCompleted = try container.decodeIfPresent(Bool.self, forKey: .isCompleted)
+            isOneShot = try container.decodeIfPresent(Bool.self, forKey: .isOneShot)
         }
     }
 
@@ -82,7 +85,8 @@ struct BackupData: Codable {
                     updateIntervalWeeks: $0.updateIntervalWeeks,
                     nextExpectedUpdate: $0.nextExpectedUpdate,
                     isOnHiatus: $0.isOnHiatus,
-                    isCompleted: $0.isCompleted
+                    isCompleted: $0.isCompleted,
+                    isOneShot: $0.isOneShot
                 )
             },
             activities: activities.map {

--- a/MangaLauncher/Models/MangaEntry.swift
+++ b/MangaLauncher/Models/MangaEntry.swift
@@ -62,6 +62,32 @@ enum DayOfWeek: Int, Codable, CaseIterable, Identifiable {
     }
 }
 
+enum MangaType: Int, Codable, CaseIterable {
+    case serial = 0
+    case oneShot = 1
+
+    var displayName: String {
+        switch self {
+        case .serial: "連載"
+        case .oneShot: "読み切り"
+        }
+    }
+}
+
+enum PublicationStatus: Int, Codable, CaseIterable {
+    case active = 0
+    case hiatus = 1
+    case completed = 2
+
+    var displayName: String {
+        switch self {
+        case .active: "連載中"
+        case .hiatus: "休載中"
+        case .completed: "完結"
+        }
+    }
+}
+
 @Model
 final class MangaEntry {
     var id: UUID = UUID()
@@ -77,6 +103,32 @@ final class MangaEntry {
     var nextExpectedUpdate: Date?
     var isOnHiatus: Bool = false
     var isCompleted: Bool = false
+    var isOneShot: Bool = false
+
+    @Transient
+    var mangaType: MangaType {
+        get { isOneShot ? .oneShot : .serial }
+        set {
+            isOneShot = newValue == .oneShot
+            if isOneShot {
+                isOnHiatus = false
+                isCompleted = false
+            }
+        }
+    }
+
+    @Transient
+    var publicationStatus: PublicationStatus {
+        get {
+            if isCompleted { return .completed }
+            if isOnHiatus { return .hiatus }
+            return .active
+        }
+        set {
+            isOnHiatus = newValue == .hiatus
+            isCompleted = newValue == .completed
+        }
+    }
 
     @Transient
     var cachedImageAspectRatio: CGFloat?
@@ -90,6 +142,7 @@ final class MangaEntry {
     @Transient
     var isRead: Bool {
         if isOnHiatus || isCompleted { return true }
+        if isOneShot && lastReadDate != nil { return true }
         guard let lastReadDate else { return false }
         // If next expected update is in the future, stay read
         if let nextUpdate = nextExpectedUpdate, nextUpdate > Date.now {

--- a/MangaLauncher/ViewModels/HomeState.swift
+++ b/MangaLauncher/ViewModels/HomeState.swift
@@ -52,6 +52,7 @@ final class EditState {
     #endif
     var editingEntry: MangaEntry?
     var draggingEntryID: UUID?
+    var draggingIsOneShot = false
 
     var isEditing: Bool {
         #if os(iOS) || os(visionOS)

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -60,7 +60,7 @@ final class MangaViewModel {
         save()
     }
 
-    func addEntry(name: String, url: String, days: Set<DayOfWeek>, iconColor: String, publisher: String = "", imageData: Data? = nil, updateIntervalWeeks: Int = 1, nextExpectedUpdate: Date? = nil, isOnHiatus: Bool = false) {
+    func addEntry(name: String, url: String, days: Set<DayOfWeek>, iconColor: String, publisher: String = "", imageData: Data? = nil, updateIntervalWeeks: Int = 1, nextExpectedUpdate: Date? = nil, isOnHiatus: Bool = false, isOneShot: Bool = false) {
         for day in days {
             let existingEntries = fetchEntries(for: day)
             let maxOrder = existingEntries.map(\.sortOrder).max() ?? -1
@@ -76,6 +76,7 @@ final class MangaViewModel {
             )
             entry.nextExpectedUpdate = nextExpectedUpdate
             entry.isOnHiatus = isOnHiatus
+            entry.isOneShot = isOneShot
             modelContext.insert(entry)
         }
         save()
@@ -143,6 +144,7 @@ final class MangaViewModel {
     }
 
     func moveEntryToDay(_ entry: MangaEntry, to newDay: DayOfWeek, at targetEntry: MangaEntry? = nil) {
+        if entry.isOneShot && newDay.isHiatus { return }
         if newDay.isCompleted {
             entry.isCompleted = true
             entry.isOnHiatus = false
@@ -251,6 +253,7 @@ final class MangaViewModel {
             entry.nextExpectedUpdate = backupEntry.nextExpectedUpdate
             entry.isOnHiatus = backupEntry.isOnHiatus ?? false
             entry.isCompleted = backupEntry.isCompleted ?? false
+            entry.isOneShot = backupEntry.isOneShot ?? false
             modelContext.insert(entry)
             importedCount += 1
         }
@@ -291,18 +294,26 @@ final class MangaViewModel {
 
     func markAsRead(_ entry: MangaEntry) {
         entry.lastReadDate = Date()
-        entry.advanceToNextUpdate()
+        if !entry.isOneShot {
+            entry.advanceToNextUpdate()
+        }
         let activity = ReadingActivity(
             date: Date(),
             mangaName: entry.name,
             mangaEntryID: entry.id
         )
         modelContext.insert(activity)
+        if entry.isOneShot {
+            entry.isCompleted = true
+        }
         save()
     }
 
     func markAsUnread(_ entry: MangaEntry) {
         entry.lastReadDate = nil
+        if entry.isOneShot {
+            entry.isCompleted = false
+        }
         let today = Calendar.current.startOfDay(for: Date())
         let entryID = entry.id
         let descriptor = FetchDescriptor<ReadingActivity>(

--- a/MangaLauncher/Views/Entry/EditEntryView.swift
+++ b/MangaLauncher/Views/Entry/EditEntryView.swift
@@ -30,6 +30,7 @@ struct EditEntryView: View {
     @State private var didLoadEntry = false
     @State private var isOnHiatus = false
     @State private var isCompleted = false
+    @State private var isOneShot = false
 
     private var theme: ThemeStyle { ThemeManager.shared.style }
 
@@ -111,7 +112,7 @@ struct EditEntryView: View {
         _selectedDay = State(initialValue: day)
     }
 
-    init(viewModel: MangaViewModel, prefilledName: String, prefilledURL: String, prefilledDay: DayOfWeek, prefilledPublisher: String, prefilledColor: String, prefilledImageData: Data? = nil) {
+    init(viewModel: MangaViewModel, prefilledName: String, prefilledURL: String, prefilledDay: DayOfWeek, prefilledPublisher: String, prefilledColor: String, prefilledImageData: Data? = nil, prefilledIsOneShot: Bool = false) {
         self.viewModel = viewModel
         self.entry = nil
         _name = State(initialValue: prefilledName)
@@ -120,6 +121,7 @@ struct EditEntryView: View {
         _publisher = State(initialValue: prefilledPublisher)
         _selectedColor = State(initialValue: prefilledColor)
         _imageData = State(initialValue: prefilledImageData)
+        _isOneShot = State(initialValue: prefilledIsOneShot)
     }
 
     var body: some View {
@@ -248,20 +250,43 @@ struct EditEntryView: View {
                     .padding(.vertical, 4)
                 }
 
-                Section {
-                    Toggle("休載中", isOn: $isOnHiatus)
-                        .onChange(of: isOnHiatus) { _, newValue in
-                            if newValue { isCompleted = false }
+                Section("種類") {
+                    Picker("種類", selection: $isOneShot) {
+                        Text("連載").tag(false)
+                        Text("読み切り").tag(true)
+                    }
+                    .pickerStyle(.segmented)
+                    .onChange(of: isOneShot) { oldValue, newValue in
+                        if newValue {
+                            isOnHiatus = false
+                            isCompleted = false
+                        } else if oldValue {
+                            isCompleted = false
                         }
-                    if entry != nil {
-                        Toggle("完結", isOn: $isCompleted)
-                            .onChange(of: isCompleted) { _, newValue in
-                                if newValue { isOnHiatus = false }
-                            }
                     }
                 }
 
-                Section("更新頻度") {
+                if !isOneShot {
+                    Section("掲載状態") {
+                        Picker("状態", selection: Binding(
+                            get: {
+                                if isCompleted { return PublicationStatus.completed }
+                                if isOnHiatus { return PublicationStatus.hiatus }
+                                return PublicationStatus.active
+                            },
+                            set: { newValue in
+                                isOnHiatus = newValue == .hiatus
+                                isCompleted = newValue == .completed
+                            }
+                        )) {
+                            ForEach(PublicationStatus.allCases, id: \.self) { status in
+                                Text(status.displayName).tag(status)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+                    }
+
+                    Section("更新頻度") {
                     Picker("頻度", selection: pickerValue) {
                         Text("毎週").tag(1)
                         Text("隔週").tag(2)
@@ -282,6 +307,7 @@ struct EditEntryView: View {
                         }
                     }
                 }
+                } // if !isOneShot
 
                 Section("アイコンカラー") {
                     LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 8), spacing: 12) {
@@ -364,6 +390,7 @@ struct EditEntryView: View {
                     }
                     isOnHiatus = entry.isOnHiatus
                     isCompleted = entry.isCompleted
+                    isOneShot = entry.isOneShot
                     didLoadEntry = true
                 } else if entry == nil, !didLoadEntry {
                     nextUpdateDate = nextUpdateCandidates.first ?? nextOccurrence(of: selectedDay)
@@ -411,8 +438,9 @@ struct EditEntryView: View {
             viewModel.updateEntry(entry, name: name, url: url, dayOfWeek: selectedDay, iconColor: selectedColor, publisher: publisher, imageData: imageData, updateIntervalWeeks: interval, nextExpectedUpdate: nextUpdateDate)
             entry.isOnHiatus = isOnHiatus
             entry.isCompleted = isCompleted
+            entry.isOneShot = isOneShot
         } else {
-            viewModel.addEntry(name: name, url: url, days: [selectedDay], iconColor: selectedColor, publisher: publisher, imageData: imageData, updateIntervalWeeks: interval, nextExpectedUpdate: nextUpdateDate, isOnHiatus: isOnHiatus)
+            viewModel.addEntry(name: name, url: url, days: [selectedDay], iconColor: selectedColor, publisher: publisher, imageData: imageData, updateIntervalWeeks: isOneShot ? 1 : interval, nextExpectedUpdate: isOneShot ? nil : nextUpdateDate, isOnHiatus: isOnHiatus, isOneShot: isOneShot)
         }
     }
 }

--- a/MangaLauncher/Views/Home/DayPageView.swift
+++ b/MangaLauncher/Views/Home/DayPageView.swift
@@ -101,6 +101,7 @@ struct DayPageView: View {
                                 .modifier(WiggleModifier(isActive: edit.isGridEditMode))
                                 .onDrag {
                                     edit.draggingEntryID = entry.id
+                                    edit.draggingIsOneShot = entry.isOneShot
                                     return NSItemProvider(object: entry.id.uuidString as NSString)
                                 } preview: {
                                     MangaGridCell(entry: entry, viewModel: viewModel, hasWallpaper: hasWallpaper, reduceTransparency: reduceTransparency, isGridEditMode: $edit.isGridEditMode, editingEntry: $edit.editingEntry, onOpenURL: onOpenURL)

--- a/MangaLauncher/Views/Home/DayTabBarView.swift
+++ b/MangaLauncher/Views/Home/DayTabBarView.swift
@@ -70,7 +70,13 @@ struct DayTabBarView: View {
                 )
                 .onDrop(of: [.text], isTargeted: Binding(
                     get: { dropTargetDay == day },
-                    set: { dropTargetDay = $0 ? day : nil }
+                    set: {
+                        if $0 && day.isHiatus && edit.draggingIsOneShot {
+                            dropTargetDay = nil
+                        } else {
+                            dropTargetDay = $0 ? day : nil
+                        }
+                    }
                 )) { providers in
                     dropTargetDay = nil
                     if let draggingID = edit.draggingEntryID,

--- a/MangaLauncher/Views/MangaCell/MangaContextMenu.swift
+++ b/MangaLauncher/Views/MangaCell/MangaContextMenu.swift
@@ -29,16 +29,18 @@ struct MangaContextMenu: View {
         } label: {
             Label("並び替え", systemImage: "arrow.up.arrow.down")
         }
-        Button {
-            viewModel.toggleHiatus(entry)
-        } label: {
-            Label(entry.isOnHiatus ? "連載に戻す" : "休載中にする",
-                  systemImage: entry.isOnHiatus ? "arrow.uturn.left" : "moon.zzz")
+        if !entry.isOneShot {
+            Button {
+                viewModel.toggleHiatus(entry)
+            } label: {
+                Label(entry.isOnHiatus ? "連載に戻す" : "休載中にする",
+                      systemImage: entry.isOnHiatus ? "arrow.uturn.left" : "moon.zzz")
+            }
         }
         Button {
             viewModel.toggleCompleted(entry)
         } label: {
-            Label(entry.isCompleted ? "連載に戻す" : "完結にする",
+            Label(entry.isCompleted ? (entry.isOneShot ? "元の曜日に戻す" : "連載に戻す") : "完結にする",
                   systemImage: entry.isCompleted ? "arrow.uturn.left" : "checkmark.seal")
         }
         Button(role: .destructive) {

--- a/MangaShareExtension/ShareExtensionView.swift
+++ b/MangaShareExtension/ShareExtensionView.swift
@@ -18,6 +18,7 @@ struct ShareExtensionView: View {
     @State private var imageData: Data?
     @State private var saveError: String?
     @State private var isOnHiatus = false
+    @State private var isOneShot = false
 
     private let colorOptions: [(name: String, color: Color)] = [
         ("red", .red),
@@ -123,8 +124,21 @@ struct ShareExtensionView: View {
                         .padding(.vertical, 4)
                     }
 
-                    Section {
-                        Toggle("休載中", isOn: $isOnHiatus)
+                    Section("種類") {
+                        Picker("種類", selection: $isOneShot) {
+                            Text("連載").tag(false)
+                            Text("読み切り").tag(true)
+                        }
+                        .pickerStyle(.segmented)
+                        .onChange(of: isOneShot) { _, newValue in
+                            if newValue { isOnHiatus = false }
+                        }
+                    }
+
+                    if !isOneShot {
+                        Section {
+                            Toggle("休載中", isOn: $isOnHiatus)
+                        }
                     }
 
                     Section("アイコンカラー") {
@@ -329,6 +343,7 @@ struct ShareExtensionView: View {
                 imageData: imageData
             )
             entry.isOnHiatus = isOnHiatus
+            entry.isOneShot = isOneShot
             context.insert(entry)
             try context.save()
 


### PR DESCRIPTION
Closes #153

## Summary
- 読み切り漫画を既読にしたら自動的に完結タブに移動する機能を追加
- 編集画面の休載/完結トグルを「種類」(連載/読み切り)と「掲載状態」(連載中/休載中/完結)のセグメントPickerに整理
- 読み切りでは更新頻度・掲載状態セクションを非表示
- コンテキストメニューで読み切りには「休載中にする」を非表示、完結済みは「元の曜日に戻す」と表示
- 読み切りの休載タブへのドラッグをブロック（ハイライト非表示）
- Share Extension・Shortcuts・バックアップにも読み切り対応

## Test plan
- [x] 読み切りとしてエントリを新規登録できることを確認
- [x] 読み切りを既読にすると完結タブに自動移動することを確認
- [x] 完結タブの読み切りを「元の曜日に戻す」で戻せることを確認
- [x] 読み切りのコンテキストメニューに「休載中にする」が表示されないことを確認
- [x] 読み切りを休載タブにドラッグしても移動しないことを確認
- [x] CatchUpで読み切りを既読→undo→再度既読の流れが正常に動作することを確認
- [x] 読み切り→連載への種類変更が正常に動作することを確認
- [x] 連載漫画の掲載状態Pickerが正常に動作することを確認
- [x] バックアップ・リストアでisOneShotが保持されることを確認
- [x] 全テーマでドラッグ&ドロップが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)