### PR TITLE
Fix CatchUp count text animation for image-less manga

### DIFF
--- a/MangaLauncher/Views/CatchUp/CatchUpView.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpView.swift
@@ -371,8 +371,11 @@ struct CatchUpView: View {
         guard currentIndex < unreadItems.count else { return }
         let entry = unreadItems[currentIndex]
         guard let imageData = entry.imageData else {
-            withAnimation(.easeInOut(duration: 0.5)) {
-                backgroundGradient = ImageColorExtractor.gradientFromColor(Color.fromName(entry.iconColor))
+            let gradient = ImageColorExtractor.gradientFromColor(Color.fromName(entry.iconColor))
+            Task { @MainActor in
+                withAnimation(.easeInOut(duration: 0.5)) {
+                    backgroundGradient = gradient
+                }
             }
             return
         }


### PR DESCRIPTION
## Summary
- 画像なしのマンガに切り替わる際、件数Textが余計にアニメーションされる問題を修正
- `updateBackgroundGradient`の同期的な`withAnimation`が`.onChange(of: currentIndex)`から呼ばれることで、currentIndexの変更が同じアニメーションに巻き込まれていた
- 画像ありの場合と同様に`Task { @MainActor in }`で次のrunloopサイクルに分離

## Test plan
- [x] 画像なしのマンガを含むキャッチアップで、カードを切り替えても件数Textがアニメーションしないことを確認
- [x] 画像ありのマンガでも背景グラデーションが正常に表示されることを確認
- [x] 画像あり/なしが混在しても両方とも正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)