### PR TITLE
Fix list view wallpaper visibility and blur consistency

### DIFF
--- a/MangaLauncher/ViewModels/HomeState.swift
+++ b/MangaLauncher/ViewModels/HomeState.swift
@@ -79,6 +79,12 @@ final class WallpaperState {
 
     var hasWallpaper: Bool { WallpaperManager.wallpaperType != .none }
 
+    /// プレビュー中の壁紙も考慮した実効的な壁紙の有無
+    var effectiveHasWallpaper: Bool {
+        if previewActive { return previewSnapshot.wallpaperType != .none }
+        return hasWallpaper
+    }
+
     func loadImage() {
         if WallpaperManager.wallpaperType == .image,
            let data = WallpaperManager.loadImage(),

--- a/MangaLauncher/Views/Home/ContentView.swift
+++ b/MangaLauncher/Views/Home/ContentView.swift
@@ -62,6 +62,11 @@ struct ContentView: View {
     private func mainContent(viewModel: MangaViewModel) -> some View {
         ZStack(alignment: .bottom) {
             ZStack(alignment: .top) {
+                if ThemeManager.shared.style.usesCustomSurface && !homeState.wallpaper.effectiveHasWallpaper {
+                    ThemeManager.shared.style.surface
+                        .ignoresSafeArea()
+                }
+
                 WallpaperBackgroundView(
                     wallpaperRefresh: homeState.wallpaper.refresh,
                     wallpaperPreviewActive: homeState.wallpaper.previewActive,
@@ -79,7 +84,7 @@ struct ContentView: View {
                         day: day,
                         viewModel: vm,
                         displayMode: displayMode,
-                        hasWallpaper: homeState.wallpaper.hasWallpaper,
+                        hasWallpaper: homeState.wallpaper.effectiveHasWallpaper,
                         reduceTransparency: reduceTransparency,
                         headerHeight: homeState.headerHeight,
                         edit: homeState.edit,
@@ -177,7 +182,7 @@ struct ContentView: View {
                 paging: homeState.paging,
                 edit: homeState.edit,
                 selectedPublisher: $homeState.selectedPublisher,
-                hasWallpaper: homeState.wallpaper.hasWallpaper,
+                hasWallpaper: homeState.wallpaper.effectiveHasWallpaper,
                 orderedDays: orderedDays,
                 tabUnderline: tabUnderline
             )
@@ -188,12 +193,12 @@ struct ContentView: View {
         }
         .background {
             #if canImport(UIKit)
-            VisualEffectBlur(style: homeState.wallpaper.hasWallpaper
+            VisualEffectBlur(style: homeState.wallpaper.effectiveHasWallpaper
                 ? (reduceTransparency ? .systemThinMaterial : .systemUltraThinMaterial)
                 : .systemMaterial)
             .ignoresSafeArea(edges: .top)
             #else
-            Rectangle().fill(homeState.wallpaper.hasWallpaper
+            Rectangle().fill(homeState.wallpaper.effectiveHasWallpaper
                 ? (reduceTransparency ? AnyShapeStyle(.thinMaterial) : AnyShapeStyle(.ultraThinMaterial))
                 : AnyShapeStyle(.regularMaterial))
             .ignoresSafeArea(edges: .top)

--- a/MangaLauncher/Views/MangaCell/MangaListView.swift
+++ b/MangaLauncher/Views/MangaCell/MangaListView.swift
@@ -30,7 +30,7 @@ struct MangaListView: View {
             .onMove { source, destination in
                 viewModel.moveEntries(for: day, from: source, to: destination)
             }
-            .listRowSeparator(theme.usesCustomSurface ? .hidden : (hasWallpaper ? .hidden : .automatic))
+            .listRowSeparator(.hidden)
             .if(theme.usesCustomSurface) { view in
                 view.listRowInsets(EdgeInsets(top: 2, leading: 12, bottom: 2, trailing: 12))
             }

--- a/MangaLauncher/Views/MangaCell/MangaListView.swift
+++ b/MangaLauncher/Views/MangaCell/MangaListView.swift
@@ -38,7 +38,7 @@ struct MangaListView: View {
         .listStyle(.plain)
         .contentMargins(.top, headerHeight, for: .scrollContent)
         .scrollContentBackground(theme.usesCustomSurface ? .hidden : (hasWallpaper ? .hidden : .automatic))
-        .if(theme.usesCustomSurface) { view in
+        .if(theme.usesCustomSurface && !hasWallpaper) { view in
             view.background(theme.surface)
         }
         .simultaneousGesture(

--- a/MangaLauncher/Views/MangaCell/MangaRowCell.swift
+++ b/MangaLauncher/Views/MangaCell/MangaRowCell.swift
@@ -99,7 +99,7 @@ struct MangaRowCell: View {
                         if hasWallpaper {
                             ZStack {
                                 RoundedRectangle(cornerRadius: theme.cardCornerRadius)
-                                    .fill(theme.surfaceContainerHigh)
+                                    .fill(Color.platformFill)
                                 RoundedRectangle(cornerRadius: theme.cardCornerRadius)
                                     .fill(reduceTransparency ? .thickMaterial : .ultraThinMaterial)
                             }
@@ -112,7 +112,7 @@ struct MangaRowCell: View {
                         if hasWallpaper {
                             ZStack {
                                 RoundedRectangle(cornerRadius: theme.cardCornerRadius)
-                                    .fill(theme.surfaceContainerHigh)
+                                    .fill(Color.platformFill)
                                 RoundedRectangle(cornerRadius: theme.cardCornerRadius)
                                     .fill(reduceTransparency ? .thickMaterial : .ultraThinMaterial)
                             }
@@ -125,7 +125,7 @@ struct MangaRowCell: View {
                         if hasWallpaper {
                             ZStack {
                                 RoundedRectangle(cornerRadius: theme.cardCornerRadius)
-                                    .fill(theme.surfaceContainerHigh)
+                                    .fill(Color.platformFill)
                                 RoundedRectangle(cornerRadius: theme.cardCornerRadius)
                                     .fill(reduceTransparency ? .thickMaterial : .ultraThinMaterial)
                             }

--- a/Packages/PlatformKit/Sources/PlatformKit/UIHelpers.swift
+++ b/Packages/PlatformKit/Sources/PlatformKit/UIHelpers.swift
@@ -31,6 +31,14 @@ extension Color {
         #endif
     }
 
+    public static var platformFill: Color {
+        #if canImport(UIKit)
+        Color(.systemFill)
+        #else
+        Color(nsColor: .controlBackgroundColor)
+        #endif
+    }
+
     public static var platformGray5: Color {
         #if canImport(UIKit)
         Color(.systemGray5)


### PR DESCRIPTION
## Summary
- Kinetic Ink/Retroテーマで一覧表示時に壁紙が表示されない問題を修正
  - `MangaListView`が`usesCustomSurface`の判定で壁紙の有無を見ておらず、`theme.surface`で壁紙を上書きしていた
- 一覧表示のセル背景のブラー濃度をグリッド表示と統一
  - 不透明な`theme.surfaceContainerHigh`から半透明な`platformFill`(`Color(.systemFill)`)に変更
- `Color.platformFill`ヘルパーを`PlatformKit`に追加

## Test plan
- [x] Kinetic Ink/Retroテーマで壁紙設定時、一覧表示で壁紙が見えることを確認
- [x] 一覧表示とグリッド表示でセル背景のブラー濃度が一致することを確認
- [x] 壁紙なしの一覧表示でテーマ背景が正常に表示されることを確認
- [x] クラシックテーマでも問題なく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)