### PR TITLE
Remove dead code

### DIFF
--- a/MangaLauncher/Models/MangaEntry.swift
+++ b/MangaLauncher/Models/MangaEntry.swift
@@ -37,14 +37,6 @@ enum DayOfWeek: Int, Codable, CaseIterable, Identifiable {
         }
     }
 
-    var next: DayOfWeek {
-        DayOfWeek(rawValue: (rawValue + 1) % 7)!
-    }
-
-    var previous: DayOfWeek {
-        DayOfWeek(rawValue: (rawValue + 6) % 7)!
-    }
-
     /// Display order: completed first, then weekdays, hiatus last
     static var orderedCases: [DayOfWeek] {
         [.completed, .monday, .tuesday, .wednesday, .thursday, .friday, .saturday, .sunday, .hiatus]

--- a/MangaLauncher/Shared/DesignSystem.swift
+++ b/MangaLauncher/Shared/DesignSystem.swift
@@ -74,7 +74,6 @@ struct ThemeStyle {
     let toolbarBackgroundVisibility: Visibility
 
     // Feature flags
-    let usesScreenTone: Bool
     let hasShadows: Bool
 
     /// `colorSchemeOverride == .dark` の簡易アクセス（各Viewのスタイリング分岐用）
@@ -143,7 +142,6 @@ extension ThemeStyle {
         colorSchemeOverride: nil,
         groupedBackground: Color(UIColor.systemGroupedBackground),
         toolbarBackgroundVisibility: .automatic,
-        usesScreenTone: false,
         hasShadows: true,
         spacingSM: 8,
         spacingMD: 16,
@@ -193,7 +191,6 @@ extension ThemeStyle {
         colorSchemeOverride: .light,
         groupedBackground: Color(hex: "f5efe0"),
         toolbarBackgroundVisibility: .visible,
-        usesScreenTone: true,
         hasShadows: false,
         spacingSM: 8,
         spacingMD: 16,
@@ -243,7 +240,6 @@ extension ThemeStyle {
         colorSchemeOverride: .dark,
         groupedBackground: Color(hex: "0e0e0e"),
         toolbarBackgroundVisibility: .visible,
-        usesScreenTone: true,
         hasShadows: false,
         spacingSM: 8,
         spacingMD: 16,
@@ -305,31 +301,6 @@ extension Color {
     }
 }
 
-// MARK: - Screen-Tone Pattern
-
-struct ScreenTonePattern: View {
-    var opacity: Double = 0.05
-    var dotSize: CGFloat = 2
-    var spacing: CGFloat = 6
-    var dotColor: Color = .white
-
-    var body: some View {
-        Canvas { context, size in
-            for x in stride(from: 0, to: size.width, by: spacing) {
-                for y in stride(from: 0, to: size.height, by: spacing) {
-                    let rect = CGRect(x: x, y: y, width: dotSize, height: dotSize)
-                    context.fill(Path(ellipseIn: rect), with: .color(dotColor.opacity(opacity)))
-                }
-            }
-        }
-    }
-
-    /// 劇画テーマ用ハーフトーン（Ben-Day dots）
-    static var halftone: ScreenTonePattern {
-        ScreenTonePattern(opacity: 0.03, dotSize: 2.5, spacing: 5, dotColor: Color(hex: "1a1b25"))
-    }
-}
-
 // MARK: - Themed Navigation Style
 
 extension View {
@@ -346,20 +317,15 @@ extension View {
 // MARK: - Speech Bubble Button Style
 
 struct SpeechBubbleButtonStyle: ButtonStyle {
-    var isPrimary: Bool = true
     private var ink: ThemeStyle { .ink }
 
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .font(.headline)
-            .foregroundStyle(isPrimary ? ink.onPrimary : ink.onSurface)
+            .foregroundStyle(ink.onSurface)
             .padding(.horizontal, ink.spacingLG)
             .padding(.vertical, ink.spacingMD)
-            .background(
-                isPrimary
-                    ? AnyShapeStyle(LinearGradient(colors: [ink.primary, ink.primaryDim], startPoint: .top, endPoint: .bottom))
-                    : AnyShapeStyle(ink.surfaceBright)
-            )
+            .background(ink.surfaceBright)
             .clipShape(RoundedRectangle(cornerRadius: 16))
             .scaleEffect(configuration.isPressed ? 0.95 : 1.0)
             .animation(.easeInOut(duration: 0.1), value: configuration.isPressed)

--- a/MangaLauncher/Views/CatchUp/CatchUpCompletedView.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpCompletedView.swift
@@ -54,7 +54,7 @@ struct CatchUpCompletedView: View {
                         Label("未読を再チェック（\(remainingUnread)件）", systemImage: "arrow.counterclockwise")
                             .font(.system(size: 15, weight: .bold))
                     }
-                    .buttonStyle(SpeechBubbleButtonStyle(isPrimary: false))
+                    .buttonStyle(SpeechBubbleButtonStyle())
                     .opacity(completionAnimated ? 1.0 : 0.0)
                 case .classic:
                     Button {

--- a/MangaLauncher/Views/Home/DayPagerView.swift
+++ b/MangaLauncher/Views/Home/DayPagerView.swift
@@ -19,7 +19,7 @@ struct DayPagerView<PageContent: View>: View {
             }
         }
         .tabViewStyle(.page(indexDisplayMode: .never))
-        .onChange(of: paging.pageIndex) { oldValue, newValue in
+        .onChange(of: paging.pageIndex) { _, newValue in
             let day = paging.dayForPageIndex(newValue)
             if !paging.isAnimatingPageChange {
                 viewModel.selectedDay = day


### PR DESCRIPTION
## Summary
- 未使用の`ScreenTonePattern`構造体と`halftone`プロパティを削除
- 未使用の`usesScreenTone`フラグを`ThemeStyle`から削除
- `SpeechBubbleButtonStyle`の`isPrimary`分岐を整理（`false`のみ使用されていた）
- 未使用の`DayOfWeek.next` / `previous`プロパティを削除
- `DayPagerView.onChange`の未使用`oldValue`パラメータを`_`に置換

## Test plan
- [ ] 全テーマ（クラシック/Kinetic Ink/レトロ）で画面表示が正常であることを確認
- [ ] キャッチアップ画面の完了状態で「未読を再チェック」ボタンが正しく表示されることを確認（`SpeechBubbleButtonStyle`の変更）
- [ ] ページング動作に問題がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)