### PR TITLE
Refactor state model + add Library/Search/Comment screens

### DIFF
--- a/MangaLauncher.xcodeproj/project.pbxproj
+++ b/MangaLauncher.xcodeproj/project.pbxproj
@@ -37,6 +37,10 @@
 		AA000002 /* ReadingActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000010 /* ReadingActivity.swift */; };
 		AA000003 /* ReadingActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000010 /* ReadingActivity.swift */; };
 		AA000004 /* ReadingHeatmapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000011 /* ReadingHeatmapView.swift */; };
+		BC000001 /* MangaComment.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000010 /* MangaComment.swift */; };
+		BC000002 /* MangaComment.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000010 /* MangaComment.swift */; };
+		BC000003 /* MangaComment.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000010 /* MangaComment.swift */; };
+		BB000007 /* MangaColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000107 /* MangaColor.swift */; };
 		B26E164ECFAC0FC6A4B39CC6 /* SharedModelContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C7FA9735199D021E15CEED8 /* SharedModelContainer.swift */; };
 		B31B9EA2FE243CD2D6209258 /* AddMangaIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55D3FF44BE586A52AAF2B43 /* AddMangaIntent.swift */; };
 		D43D0695E7E3840F3142A594 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDE508C489E5FAA3881A522 /* SettingsView.swift */; };
@@ -157,6 +161,8 @@
 		A576F9BEFBD3B37AA9275FAB /* MangaWidget.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = MangaWidget.entitlements; sourceTree = "<group>"; };
 		AA000010 /* ReadingActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingActivity.swift; sourceTree = "<group>"; };
 		AA000011 /* ReadingHeatmapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingHeatmapView.swift; sourceTree = "<group>"; };
+		BC000010 /* MangaComment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaComment.swift; sourceTree = "<group>"; };
+		BB000107 /* MangaColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaColor.swift; sourceTree = "<group>"; };
 		BB770326E8D34706AF8B81EC /* UniformTypeIdentifiers.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UniformTypeIdentifiers.framework; path = System/Library/Frameworks/UniformTypeIdentifiers.framework; sourceTree = SDKROOT; };
 		BC0276ADB2A6EFEC185148CA /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D899D5F8F3BA6AC39B41C8B4 /* MangaShareExtension.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = MangaShareExtension.entitlements; sourceTree = "<group>"; };
@@ -321,6 +327,7 @@
 				A2000002 /* MangaEntry.swift */,
 				3AFF912AECB7C6B219DD1600 /* BackupData.swift */,
 				AA000010 /* ReadingActivity.swift */,
+				BC000010 /* MangaComment.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -462,6 +469,7 @@
 				05365AD0D66B41D8C20EDF49 /* ImageColorExtractor.swift */,
 				EC44DD5EE5561C4C4F99C248 /* ModelContextExtensions.swift */,
 				ECFEA8472F7F6E5700CE4DC0 /* MangaURLOpener.swift */,
+				BB000107 /* MangaColor.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -609,6 +617,7 @@
 				C2C5E8A68C5957E075832254 /* ImageColorExtractor.swift in Sources */,
 				EC440D83EFDF1B4B6F95E82D /* ModelContextExtensions.swift in Sources */,
 				AA000001 /* ReadingActivity.swift in Sources */,
+				BC000001 /* MangaComment.swift in Sources */,
 				ECFEA84A2F7F6E5700CE4DC0 /* MangaURLOpener.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -626,6 +635,7 @@
 				ECCE6BE2DD70F34BA69061B3 /* DesignSystem.swift in Sources */,
 				ECFEA8962F7F93AF00CE4DC0 /* ModelContextExtensions.swift in Sources */,
 				AA000002 /* ReadingActivity.swift in Sources */,
+				BC000002 /* MangaComment.swift in Sources */,
 				ECFEA8492F7F6E5700CE4DC0 /* MangaURLOpener.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -678,6 +688,8 @@
 				ECFEA8262F7E918E00CE4DC0 /* DeleteToastView.swift in Sources */,
 				ECFEA82E2F7E91BD00CE4DC0 /* EntryIcon.swift in Sources */,
 				AA000003 /* ReadingActivity.swift in Sources */,
+				BC000003 /* MangaComment.swift in Sources */,
+				BB000007 /* MangaColor.swift in Sources */,
 				ECFEA8602F7F7E2000CE4DC0 /* DayPageView.swift in Sources */,
 				AA000004 /* ReadingHeatmapView.swift in Sources */,
 			);

--- a/MangaLauncher.xcodeproj/project.pbxproj
+++ b/MangaLauncher.xcodeproj/project.pbxproj
@@ -31,16 +31,35 @@
 		A1000003 /* MangaViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000003 /* MangaViewModel.swift */; };
 		A1000004 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000004 /* ContentView.swift */; };
 		A1000005 /* EditEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000005 /* EditEntryView.swift */; };
+		BB000002 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000102 /* SearchView.swift */; };
+		BB000003 /* RootTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000103 /* RootTabView.swift */; };
+		BB000004 /* LibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000104 /* LibraryView.swift */; };
+		BB000005 /* LibraryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000105 /* LibraryCard.swift */; };
+		BB000007 /* MangaColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000107 /* MangaColor.swift */; };
+		BB000008 /* ColorLabelSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000108 /* ColorLabelSettingsView.swift */; };
 		A1000006 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A2000006 /* Assets.xcassets */; };
 		A1A8B2ACB18D6E541985F304 /* MasonryLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96C7D9E283FFCADD60181726 /* MasonryLayout.swift */; };
 		AA000001 /* ReadingActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000010 /* ReadingActivity.swift */; };
 		AA000002 /* ReadingActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000010 /* ReadingActivity.swift */; };
 		AA000003 /* ReadingActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000010 /* ReadingActivity.swift */; };
-		AA000004 /* ReadingHeatmapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000011 /* ReadingHeatmapView.swift */; };
 		BC000001 /* MangaComment.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000010 /* MangaComment.swift */; };
 		BC000002 /* MangaComment.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000010 /* MangaComment.swift */; };
 		BC000003 /* MangaComment.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000010 /* MangaComment.swift */; };
-		BB000007 /* MangaColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB000107 /* MangaColor.swift */; };
+		BC000101 /* CommentListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000110 /* CommentListView.swift */; };
+		BC000301 /* ActivityItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000310 /* ActivityItem.swift */; };
+		BC000401 /* MangaStatusBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000410 /* MangaStatusBadgeView.swift */; };
+		BC000501 /* SectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000510 /* SectionHeaderView.swift */; };
+		BC000801 /* MangaDataChangeModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000810 /* MangaDataChangeModifier.swift */; };
+		BC000601 /* ActivityRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000610 /* ActivityRowView.swift */; };
+		BC000602 /* AllActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000620 /* AllActivityView.swift */; };
+		BC000603 /* AllPublishersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000630 /* AllPublishersView.swift */; };
+		BC000604 /* LibrarySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000640 /* LibrarySection.swift */; };
+		BC000605 /* LibrarySectionBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000650 /* LibrarySectionBuilder.swift */; };
+		BC000701 /* SearchResultRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000710 /* SearchResultRow.swift */; };
+		BC000702 /* MemoMatchRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000720 /* MemoMatchRow.swift */; };
+		BC000703 /* CommentMatchRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000730 /* CommentMatchRow.swift */; };
+		BC000704 /* SearchSnippet.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000740 /* SearchSnippet.swift */; };
+		AA000004 /* ReadingHeatmapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000011 /* ReadingHeatmapView.swift */; };
 		B26E164ECFAC0FC6A4B39CC6 /* SharedModelContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C7FA9735199D021E15CEED8 /* SharedModelContainer.swift */; };
 		B31B9EA2FE243CD2D6209258 /* AddMangaIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A55D3FF44BE586A52AAF2B43 /* AddMangaIntent.swift */; };
 		D43D0695E7E3840F3142A594 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CDE508C489E5FAA3881A522 /* SettingsView.swift */; };
@@ -155,14 +174,33 @@
 		A2000003 /* MangaViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaViewModel.swift; sourceTree = "<group>"; };
 		A2000004 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		A2000005 /* EditEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditEntryView.swift; sourceTree = "<group>"; };
+		BB000102 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
+		BB000103 /* RootTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootTabView.swift; sourceTree = "<group>"; };
+		BB000104 /* LibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryView.swift; sourceTree = "<group>"; };
+		BB000105 /* LibraryCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryCard.swift; sourceTree = "<group>"; };
+		BB000107 /* MangaColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaColor.swift; sourceTree = "<group>"; };
+		BB000108 /* ColorLabelSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorLabelSettingsView.swift; sourceTree = "<group>"; };
 		A2000006 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		A3000001 /* MangaLauncher.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MangaLauncher.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A55D3FF44BE586A52AAF2B43 /* AddMangaIntent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AddMangaIntent.swift; sourceTree = "<group>"; };
 		A576F9BEFBD3B37AA9275FAB /* MangaWidget.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = MangaWidget.entitlements; sourceTree = "<group>"; };
 		AA000010 /* ReadingActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingActivity.swift; sourceTree = "<group>"; };
-		AA000011 /* ReadingHeatmapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingHeatmapView.swift; sourceTree = "<group>"; };
 		BC000010 /* MangaComment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaComment.swift; sourceTree = "<group>"; };
-		BB000107 /* MangaColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaColor.swift; sourceTree = "<group>"; };
+		BC000110 /* CommentListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentListView.swift; sourceTree = "<group>"; };
+		BC000310 /* ActivityItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityItem.swift; sourceTree = "<group>"; };
+		BC000410 /* MangaStatusBadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaStatusBadgeView.swift; sourceTree = "<group>"; };
+		BC000510 /* SectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionHeaderView.swift; sourceTree = "<group>"; };
+		BC000810 /* MangaDataChangeModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaDataChangeModifier.swift; sourceTree = "<group>"; };
+		BC000610 /* ActivityRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityRowView.swift; sourceTree = "<group>"; };
+		BC000620 /* AllActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllActivityView.swift; sourceTree = "<group>"; };
+		BC000630 /* AllPublishersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllPublishersView.swift; sourceTree = "<group>"; };
+		BC000640 /* LibrarySection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibrarySection.swift; sourceTree = "<group>"; };
+		BC000650 /* LibrarySectionBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibrarySectionBuilder.swift; sourceTree = "<group>"; };
+		BC000710 /* SearchResultRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultRow.swift; sourceTree = "<group>"; };
+		BC000720 /* MemoMatchRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoMatchRow.swift; sourceTree = "<group>"; };
+		BC000730 /* CommentMatchRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentMatchRow.swift; sourceTree = "<group>"; };
+		BC000740 /* SearchSnippet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchSnippet.swift; sourceTree = "<group>"; };
+		AA000011 /* ReadingHeatmapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingHeatmapView.swift; sourceTree = "<group>"; };
 		BB770326E8D34706AF8B81EC /* UniformTypeIdentifiers.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UniformTypeIdentifiers.framework; path = System/Library/Frameworks/UniformTypeIdentifiers.framework; sourceTree = SDKROOT; };
 		BC0276ADB2A6EFEC185148CA /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D899D5F8F3BA6AC39B41C8B4 /* MangaShareExtension.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = MangaShareExtension.entitlements; sourceTree = "<group>"; };
@@ -328,6 +366,7 @@
 				3AFF912AECB7C6B219DD1600 /* BackupData.swift */,
 				AA000010 /* ReadingActivity.swift */,
 				BC000010 /* MangaComment.swift */,
+				BC000310 /* ActivityItem.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -335,6 +374,10 @@
 		A5000004 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				BB000203 /* Library */,
+				BB000202 /* Search */,
+				BC000200 /* Comment */,
+				BB000103 /* RootTabView.swift */,
 				ECFEA8702F7F87FE00CE4DC0 /* Common */,
 				ECFEA86F2F7F87F600CE4DC0 /* Heatmap */,
 				ECFEA86E2F7F87EF00CE4DC0 /* Settings */,
@@ -344,6 +387,40 @@
 				ECFEA8662F7F877400CE4DC0 /* MangaCell */,
 			);
 			path = Views;
+			sourceTree = "<group>";
+		};
+		BC000200 /* Comment */ = {
+			isa = PBXGroup;
+			children = (
+				BC000110 /* CommentListView.swift */,
+			);
+			path = Comment;
+			sourceTree = "<group>";
+		};
+		BB000202 /* Search */ = {
+			isa = PBXGroup;
+			children = (
+				BB000102 /* SearchView.swift */,
+				BC000710 /* SearchResultRow.swift */,
+				BC000720 /* MemoMatchRow.swift */,
+				BC000730 /* CommentMatchRow.swift */,
+				BC000740 /* SearchSnippet.swift */,
+			);
+			path = Search;
+			sourceTree = "<group>";
+		};
+		BB000203 /* Library */ = {
+			isa = PBXGroup;
+			children = (
+				BB000104 /* LibraryView.swift */,
+				BB000105 /* LibraryCard.swift */,
+				BC000610 /* ActivityRowView.swift */,
+				BC000620 /* AllActivityView.swift */,
+				BC000630 /* AllPublishersView.swift */,
+				BC000640 /* LibrarySection.swift */,
+				BC000650 /* LibrarySectionBuilder.swift */,
+			);
+			path = Library;
 			sourceTree = "<group>";
 		};
 		A5000005 /* ViewModels */ = {
@@ -436,6 +513,7 @@
 			isa = PBXGroup;
 			children = (
 				0CDE508C489E5FAA3881A522 /* SettingsView.swift */,
+				BB000108 /* ColorLabelSettingsView.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -470,6 +548,9 @@
 				EC44DD5EE5561C4C4F99C248 /* ModelContextExtensions.swift */,
 				ECFEA8472F7F6E5700CE4DC0 /* MangaURLOpener.swift */,
 				BB000107 /* MangaColor.swift */,
+				BC000410 /* MangaStatusBadgeView.swift */,
+				BC000510 /* SectionHeaderView.swift */,
+				BC000810 /* MangaDataChangeModifier.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -659,6 +740,27 @@
 				ECFEA84C2F7F741000CE4DC0 /* WallpaperBackgroundView.swift in Sources */,
 				EC04B7D82F74202400AEE45F /* SafariView.swift in Sources */,
 				A1000004 /* ContentView.swift in Sources */,
+				BB000002 /* SearchView.swift in Sources */,
+				BC000701 /* SearchResultRow.swift in Sources */,
+				BC000702 /* MemoMatchRow.swift in Sources */,
+				BC000703 /* CommentMatchRow.swift in Sources */,
+				BC000704 /* SearchSnippet.swift in Sources */,
+				BB000003 /* RootTabView.swift in Sources */,
+				BB000004 /* LibraryView.swift in Sources */,
+				BB000005 /* LibraryCard.swift in Sources */,
+				BC000601 /* ActivityRowView.swift in Sources */,
+				BC000602 /* AllActivityView.swift in Sources */,
+				BC000603 /* AllPublishersView.swift in Sources */,
+				BC000604 /* LibrarySection.swift in Sources */,
+				BC000605 /* LibrarySectionBuilder.swift in Sources */,
+				BC000101 /* CommentListView.swift in Sources */,
+				BC000301 /* ActivityItem.swift in Sources */,
+				BC000401 /* MangaStatusBadgeView.swift in Sources */,
+				BC000501 /* SectionHeaderView.swift in Sources */,
+				BC000801 /* MangaDataChangeModifier.swift in Sources */,
+				BB000007 /* MangaColor.swift in Sources */,
+				BB000008 /* ColorLabelSettingsView.swift in Sources */,
+				BB000006 /* FloatingAddButton.swift in Sources */,
 				ECFEA8742F7F8C3F00CE4DC0 /* CatchUpSwipeOverlay.swift in Sources */,
 				ECFEA8232F7E8B9D00CE4DC0 /* UserDefaultsKeys.swift in Sources */,
 				ECFEA8932F7F93AF00CE4DC0 /* AnimationTiming.swift in Sources */,
@@ -689,7 +791,6 @@
 				ECFEA82E2F7E91BD00CE4DC0 /* EntryIcon.swift in Sources */,
 				AA000003 /* ReadingActivity.swift in Sources */,
 				BC000003 /* MangaComment.swift in Sources */,
-				BB000007 /* MangaColor.swift in Sources */,
 				ECFEA8602F7F7E2000CE4DC0 /* DayPageView.swift in Sources */,
 				AA000004 /* ReadingHeatmapView.swift in Sources */,
 			);

--- a/MangaLauncher/MangaLauncherApp.swift
+++ b/MangaLauncher/MangaLauncherApp.swift
@@ -62,7 +62,7 @@ struct MangaLauncherApp: App {
 
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            RootTabView()
                 .background {
                     // Ink background applied OUTSIDE ContentView to avoid breaking drag
                     ThemeManager.shared.style.groupedBackground.ignoresSafeArea()

--- a/MangaLauncher/MangaLauncherApp.swift
+++ b/MangaLauncher/MangaLauncherApp.swift
@@ -48,21 +48,28 @@ struct MangaLauncherApp: App {
     @Environment(\.scenePhase) private var scenePhase
     @State private var intentPrefill: IntentPrefill?
     @State private var syncMonitor = CloudSyncMonitor()
+    /// アプリ全体で共有する単一の MangaViewModel。
+    /// 各タブが独自インスタンスを持つと ModelContext が分散して
+    /// CloudKit sync 時に複数 refresh が走るので、ここで 1 つだけ作る。
+    @State private var viewModel: MangaViewModel
     private let notificationDelegate = NotificationDelegate()
 
     init() {
         DataMigration.migrateToAppGroupIfNeeded()
         UNUserNotificationCenter.current().delegate = notificationDelegate
+        let container: ModelContainer
         do {
             container = try SharedModelContainer.create()
         } catch {
             fatalError("Failed to create ModelContainer: \(error)")
         }
+        self.container = container
+        self._viewModel = State(initialValue: MangaViewModel(modelContext: container.mainContext))
     }
 
     var body: some Scene {
         WindowGroup {
-            RootTabView()
+            RootTabView(viewModel: viewModel)
                 .background {
                     // Ink background applied OUTSIDE ContentView to avoid breaking drag
                     ThemeManager.shared.style.groupedBackground.ignoresSafeArea()
@@ -77,7 +84,7 @@ struct MangaLauncherApp: App {
                     NotificationCenter.default.post(name: .mangaDataDidChange, object: nil)
                 }) { prefill in
                     EditEntryView(
-                        viewModel: MangaViewModel(modelContext: container.mainContext),
+                        viewModel: viewModel,
                         prefilledName: prefill.name,
                         prefilledURL: prefill.url,
                         prefilledDay: prefill.dayOfWeek,
@@ -136,7 +143,6 @@ struct MangaLauncherApp: App {
     }
 
     private func updateBadge() {
-        let viewModel = MangaViewModel(modelContext: container.mainContext)
         let count = viewModel.unreadCount(for: .today)
         BadgeManager.updateBadge(unreadCount: count)
     }

--- a/MangaLauncher/Models/ActivityItem.swift
+++ b/MangaLauncher/Models/ActivityItem.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// ライブラリの「最近のメモ・コメント」セクションで扱う統合アイテム
+enum ActivityItem: Identifiable {
+    case memo(MangaEntry)
+    case comment(MangaComment, MangaEntry)
+
+    var id: String {
+        switch self {
+        case .memo(let entry): return "m-\(entry.id.uuidString)"
+        case .comment(let comment, _): return "c-\(comment.id.uuidString)"
+        }
+    }
+
+    var timestamp: Date {
+        switch self {
+        case .memo(let entry): return entry.memoUpdatedAt ?? .distantPast
+        case .comment(let comment, _): return comment.createdAt
+        }
+    }
+
+    var entry: MangaEntry {
+        switch self {
+        case .memo(let entry): return entry
+        case .comment(_, let entry): return entry
+        }
+    }
+}
+
+/// すでに fetch 済みの entries / comments からアクティビティを構築する純関数群。
+/// View 側で同じ allEntries() を何度も呼ばないようにするための集約点。
+enum ActivityBuilder {
+    /// 「最近のメモ・コメント」の上位 N 件
+    static func recent(entries: [MangaEntry], comments: [MangaComment], limit: Int) -> [ActivityItem] {
+        merged(entries: entries, comments: comments)
+            .prefix(limit)
+            .map { $0 }
+    }
+
+    /// 全アクティビティ（時系列降順）
+    static func all(entries: [MangaEntry], comments: [MangaComment]) -> [ActivityItem] {
+        merged(entries: entries, comments: comments)
+    }
+
+    /// メモ持ちエントリ + コメントの総数
+    static func totalCount(entries: [MangaEntry], comments: [MangaComment]) -> Int {
+        entries.filter { !$0.memo.isEmpty }.count + comments.count
+    }
+
+    private static func merged(entries: [MangaEntry], comments: [MangaComment]) -> [ActivityItem] {
+        let entriesByID = Dictionary(uniqueKeysWithValues: entries.map { ($0.id, $0) })
+        var items: [ActivityItem] = entries
+            .filter { !$0.memo.isEmpty }
+            .map { .memo($0) }
+        for comment in comments {
+            guard let entry = entriesByID[comment.mangaEntryID] else { continue }
+            items.append(.comment(comment, entry))
+        }
+        return items.sorted { $0.timestamp > $1.timestamp }
+    }
+}

--- a/MangaLauncher/Models/BackupData.swift
+++ b/MangaLauncher/Models/BackupData.swift
@@ -7,12 +7,21 @@ struct BackupData: Codable {
     let exportDate: Date
     let entries: [BackupEntry]
     let activities: [BackupActivity]?
+    let comments: [BackupComment]?
 
     struct BackupActivity: Codable {
         let id: UUID
         let date: Date
         let mangaName: String
         let mangaEntryID: UUID
+    }
+
+    struct BackupComment: Codable {
+        let id: UUID
+        let mangaEntryID: UUID
+        let content: String
+        let createdAt: Date
+        let updatedAt: Date?
     }
 
     struct BackupEntry: Codable {
@@ -27,11 +36,20 @@ struct BackupData: Codable {
         let lastReadDate: Date?
         let updateIntervalWeeks: Int
         let nextExpectedUpdate: Date?
+        let isOneShot: Bool?
+        // New schema (v6+)
+        let publicationStatusRawValue: Int?
+        let readingStateRawValue: Int?
+        // v7+
+        let memo: String?
+        // v8+
+        let memoUpdatedAt: Date?
+        // Legacy fields (kept for backward-compat with v5 backups)
         let isOnHiatus: Bool?
         let isCompleted: Bool?
-        let isOneShot: Bool?
+        let isBacklog: Bool?
 
-        init(id: UUID, name: String, url: String, dayOfWeekRawValue: Int, sortOrder: Int, iconColor: String, publisher: String, imageData: Data?, lastReadDate: Date? = nil, updateIntervalWeeks: Int = 1, nextExpectedUpdate: Date? = nil, isOnHiatus: Bool = false, isCompleted: Bool = false, isOneShot: Bool = false) {
+        init(id: UUID, name: String, url: String, dayOfWeekRawValue: Int, sortOrder: Int, iconColor: String, publisher: String, imageData: Data?, lastReadDate: Date? = nil, updateIntervalWeeks: Int = 1, nextExpectedUpdate: Date? = nil, isOneShot: Bool = false, publicationStatusRawValue: Int = 0, readingStateRawValue: Int = 0, memo: String = "", memoUpdatedAt: Date? = nil) {
             self.id = id
             self.name = name
             self.url = url
@@ -43,9 +61,14 @@ struct BackupData: Codable {
             self.lastReadDate = lastReadDate
             self.updateIntervalWeeks = updateIntervalWeeks
             self.nextExpectedUpdate = nextExpectedUpdate
-            self.isOnHiatus = isOnHiatus
-            self.isCompleted = isCompleted
             self.isOneShot = isOneShot
+            self.publicationStatusRawValue = publicationStatusRawValue
+            self.readingStateRawValue = readingStateRawValue
+            self.memo = memo
+            self.memoUpdatedAt = memoUpdatedAt
+            self.isOnHiatus = nil
+            self.isCompleted = nil
+            self.isBacklog = nil
         }
 
         init(from decoder: Decoder) throws {
@@ -61,15 +84,20 @@ struct BackupData: Codable {
             lastReadDate = try container.decodeIfPresent(Date.self, forKey: .lastReadDate)
             updateIntervalWeeks = try container.decodeIfPresent(Int.self, forKey: .updateIntervalWeeks) ?? 1
             nextExpectedUpdate = try container.decodeIfPresent(Date.self, forKey: .nextExpectedUpdate)
+            isOneShot = try container.decodeIfPresent(Bool.self, forKey: .isOneShot)
+            publicationStatusRawValue = try container.decodeIfPresent(Int.self, forKey: .publicationStatusRawValue)
+            readingStateRawValue = try container.decodeIfPresent(Int.self, forKey: .readingStateRawValue)
+            memo = try container.decodeIfPresent(String.self, forKey: .memo)
+            memoUpdatedAt = try container.decodeIfPresent(Date.self, forKey: .memoUpdatedAt)
             isOnHiatus = try container.decodeIfPresent(Bool.self, forKey: .isOnHiatus)
             isCompleted = try container.decodeIfPresent(Bool.self, forKey: .isCompleted)
-            isOneShot = try container.decodeIfPresent(Bool.self, forKey: .isOneShot)
+            isBacklog = try container.decodeIfPresent(Bool.self, forKey: .isBacklog)
         }
     }
 
-    static func from(_ entries: [MangaEntry], activities: [ReadingActivity] = []) -> BackupData {
+    static func from(_ entries: [MangaEntry], activities: [ReadingActivity] = [], comments: [MangaComment] = []) -> BackupData {
         BackupData(
-            version: 5,
+            version: 8,
             exportDate: Date(),
             entries: entries.map {
                 BackupEntry(
@@ -84,9 +112,11 @@ struct BackupData: Codable {
                     lastReadDate: $0.lastReadDate,
                     updateIntervalWeeks: $0.updateIntervalWeeks,
                     nextExpectedUpdate: $0.nextExpectedUpdate,
-                    isOnHiatus: $0.isOnHiatus,
-                    isCompleted: $0.isCompleted,
-                    isOneShot: $0.isOneShot
+                    isOneShot: $0.isOneShot,
+                    publicationStatusRawValue: $0.publicationStatusRawValue,
+                    readingStateRawValue: $0.readingStateRawValue,
+                    memo: $0.memo,
+                    memoUpdatedAt: $0.memoUpdatedAt
                 )
             },
             activities: activities.map {
@@ -95,6 +125,15 @@ struct BackupData: Codable {
                     date: $0.date,
                     mangaName: $0.mangaName,
                     mangaEntryID: $0.mangaEntryID
+                )
+            },
+            comments: comments.map {
+                BackupComment(
+                    id: $0.id,
+                    mangaEntryID: $0.mangaEntryID,
+                    content: $0.content,
+                    createdAt: $0.createdAt,
+                    updatedAt: $0.updatedAt
                 )
             }
         )

--- a/MangaLauncher/Models/MangaComment.swift
+++ b/MangaLauncher/Models/MangaComment.swift
@@ -1,0 +1,20 @@
+import Foundation
+import SwiftData
+
+/// マンガに紐付くタイムスタンプ付きコメント（投稿型）
+@Model
+final class MangaComment {
+    var id: UUID = UUID()
+    var mangaEntryID: UUID = UUID()
+    var content: String = ""
+    var createdAt: Date = Date()
+    var updatedAt: Date?
+
+    init(mangaEntryID: UUID, content: String, createdAt: Date = Date()) {
+        self.id = UUID()
+        self.mangaEntryID = mangaEntryID
+        self.content = content
+        self.createdAt = createdAt
+        self.updatedAt = nil
+    }
+}

--- a/MangaLauncher/Models/MangaEntry.swift
+++ b/MangaLauncher/Models/MangaEntry.swift
@@ -2,12 +2,9 @@ import Foundation
 import SwiftData
 
 enum DayOfWeek: Int, Codable, CaseIterable, Identifiable {
-    case sunday = 0, monday, tuesday, wednesday, thursday, friday, saturday, hiatus, completed
+    case sunday = 0, monday, tuesday, wednesday, thursday, friday, saturday
 
     var id: Int { rawValue }
-
-    var isHiatus: Bool { self == .hiatus }
-    var isCompleted: Bool { self == .completed }
 
     var shortName: String {
         switch self {
@@ -18,8 +15,6 @@ enum DayOfWeek: Int, Codable, CaseIterable, Identifiable {
         case .thursday: "木"
         case .friday: "金"
         case .saturday: "土"
-        case .hiatus: "休"
-        case .completed: "完"
         }
     }
 
@@ -32,17 +27,10 @@ enum DayOfWeek: Int, Codable, CaseIterable, Identifiable {
         case .thursday: "木曜日"
         case .friday: "金曜日"
         case .saturday: "土曜日"
-        case .hiatus: "休載中"
-        case .completed: "完結"
         }
     }
 
-    /// Display order: completed first, then weekdays, hiatus last
-    static var orderedCases: [DayOfWeek] {
-        [.completed, .monday, .tuesday, .wednesday, .thursday, .friday, .saturday, .sunday, .hiatus]
-    }
-
-    /// Days only (excludes hiatus)
+    /// Days only (Mon → Sun ordering for tabs)
     static var orderedDays: [DayOfWeek] {
         [.monday, .tuesday, .wednesday, .thursday, .friday, .saturday, .sunday]
     }
@@ -66,16 +54,36 @@ enum MangaType: Int, Codable, CaseIterable {
     }
 }
 
-enum PublicationStatus: Int, Codable, CaseIterable {
-    case active = 0
-    case hiatus = 1
-    case completed = 2
+/// 作品の掲載状況（出版社・作者側の状態）
+enum PublicationStatus: Int, Codable, CaseIterable, Identifiable {
+    case active = 0      // 連載中
+    case hiatus = 1      // 休載中
+    case finished = 2    // 完結
+
+    var id: Int { rawValue }
 
     var displayName: String {
         switch self {
         case .active: "連載中"
         case .hiatus: "休載中"
-        case .completed: "完結"
+        case .finished: "完結"
+        }
+    }
+}
+
+/// 読者の読書状況（ユーザー側の進捗）
+enum ReadingState: Int, Codable, CaseIterable, Identifiable {
+    case following = 0   // 連載追っかけ中
+    case backlog = 1     // 積読中
+    case archived = 2    // 読了（アーカイブ）
+
+    var id: Int { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .following: "追っかけ中"
+        case .backlog: "積読"
+        case .archived: "読了"
         }
     }
 }
@@ -93,9 +101,23 @@ final class MangaEntry {
     var lastReadDate: Date?
     var updateIntervalWeeks: Int = 1
     var nextExpectedUpdate: Date?
+    var isOneShot: Bool = false
+    /// 1作品に1つの長文メモ
+    var memo: String = ""
+    /// メモの最終更新日時。並び替え用。
+    var memoUpdatedAt: Date?
+
+    /// 掲載状況の Int 値（PublicationStatus.rawValue）
+    var publicationStatusRawValue: Int = 0
+    /// 読書状況の Int 値（ReadingState.rawValue）
+    var readingStateRawValue: Int = 0
+    /// マイグレーションバージョン（0=未移行、1=新モデル）
+    var stateMigrationVersion: Int = 0
+
+    // MARK: - Legacy fields (kept for backward-compat / one-time migration only)
     var isOnHiatus: Bool = false
     var isCompleted: Bool = false
-    var isOneShot: Bool = false
+    var isBacklog: Bool = false
 
     @Transient
     var mangaType: MangaType {
@@ -103,23 +125,25 @@ final class MangaEntry {
         set {
             isOneShot = newValue == .oneShot
             if isOneShot {
-                isOnHiatus = false
-                isCompleted = false
+                publicationStatusRawValue = PublicationStatus.active.rawValue
+                // 読み切りは追っかけ概念がないので following or archived
+                if readingState == .backlog {
+                    readingStateRawValue = ReadingState.following.rawValue
+                }
             }
         }
     }
 
     @Transient
     var publicationStatus: PublicationStatus {
-        get {
-            if isCompleted { return .completed }
-            if isOnHiatus { return .hiatus }
-            return .active
-        }
-        set {
-            isOnHiatus = newValue == .hiatus
-            isCompleted = newValue == .completed
-        }
+        get { PublicationStatus(rawValue: publicationStatusRawValue) ?? .active }
+        set { publicationStatusRawValue = newValue.rawValue }
+    }
+
+    @Transient
+    var readingState: ReadingState {
+        get { ReadingState(rawValue: readingStateRawValue) ?? .following }
+        set { readingStateRawValue = newValue.rawValue }
     }
 
     @Transient
@@ -131,12 +155,21 @@ final class MangaEntry {
         set { dayOfWeekRawValue = newValue.rawValue }
     }
 
+    /// 既読扱いか否か（カレンダーベースの未読サイクル含む）
     @Transient
     var isRead: Bool {
-        if isOnHiatus || isCompleted { return true }
-        if isOneShot && lastReadDate != nil { return true }
+        // 読了アーカイブ: 常に既読
+        if readingState == .archived { return true }
+        // 掲載休載中: 次の更新まで既読据え置き
+        if publicationStatus == .hiatus { return true }
+        // 掲載完結: 一度読んだら既読のまま戻らない
+        if publicationStatus == .finished {
+            return lastReadDate != nil
+        }
+        // 読み切り: 1度読んだら既読
+        if isOneShot { return lastReadDate != nil }
+        // 通常: 曜日サイクル
         guard let lastReadDate else { return false }
-        // If next expected update is in the future, stay read
         if let nextUpdate = nextExpectedUpdate, nextUpdate > Date.now {
             return true
         }
@@ -167,6 +200,30 @@ final class MangaEntry {
         nextExpectedUpdate = nextDay
     }
 
+    /// 旧 Bool フィールド（isOnHiatus / isCompleted / isBacklog）から
+    /// 新しい publicationStatus / readingState へ移行する。
+    /// 一度移行されると stateMigrationVersion=1 になり再実行されない。
+    func migrateLegacyStateIfNeeded() {
+        guard stateMigrationVersion < 1 else { return }
+        if isCompleted {
+            // 旧「完結タブ」は実質「読了アーカイブ」として運用されていた
+            readingStateRawValue = ReadingState.archived.rawValue
+            publicationStatusRawValue = PublicationStatus.active.rawValue
+        } else if isBacklog {
+            readingStateRawValue = ReadingState.backlog.rawValue
+            publicationStatusRawValue = isOnHiatus
+                ? PublicationStatus.hiatus.rawValue
+                : PublicationStatus.active.rawValue
+        } else if isOnHiatus {
+            readingStateRawValue = ReadingState.following.rawValue
+            publicationStatusRawValue = PublicationStatus.hiatus.rawValue
+        } else {
+            readingStateRawValue = ReadingState.following.rawValue
+            publicationStatusRawValue = PublicationStatus.active.rawValue
+        }
+        stateMigrationVersion = 1
+    }
+
     init(
         id: UUID = UUID(),
         name: String = "",
@@ -187,5 +244,7 @@ final class MangaEntry {
         self.publisher = publisher
         self.imageData = imageData
         self.updateIntervalWeeks = updateIntervalWeeks
+        // 新規作成時は移行済み扱い
+        self.stateMigrationVersion = 1
     }
 }

--- a/MangaLauncher/Shared/MangaColor.swift
+++ b/MangaLauncher/Shared/MangaColor.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+import PlatformKit
+
+struct MangaColor: Identifiable, Hashable {
+    let name: String
+    let displayName: String
+
+    var id: String { name }
+    var color: Color { Color.fromName(name) }
+
+    static let all: [MangaColor] = [
+        MangaColor(name: "red", displayName: "赤"),
+        MangaColor(name: "orange", displayName: "オレンジ"),
+        MangaColor(name: "yellow", displayName: "黄"),
+        MangaColor(name: "green", displayName: "緑"),
+        MangaColor(name: "blue", displayName: "青"),
+        MangaColor(name: "purple", displayName: "紫"),
+        MangaColor(name: "pink", displayName: "ピンク"),
+        MangaColor(name: "teal", displayName: "ティール"),
+    ]
+
+    static func displayName(for name: String) -> String {
+        all.first { $0.name == name }?.displayName ?? name
+    }
+}
+
+@Observable
+final class ColorLabelStore {
+    static let shared = ColorLabelStore()
+
+    private let key = "colorLabels"
+    private(set) var labels: [String: String] = [:]
+
+    private init() {
+        load()
+    }
+
+    func load() {
+        labels = UserDefaults.standard.dictionary(forKey: key) as? [String: String] ?? [:]
+    }
+
+    func setLabel(_ label: String, for colorName: String) {
+        let trimmed = label.trimmingCharacters(in: .whitespaces)
+        if trimmed.isEmpty {
+            labels.removeValue(forKey: colorName)
+        } else {
+            labels[colorName] = trimmed
+        }
+        UserDefaults.standard.set(labels, forKey: key)
+    }
+
+    func label(for colorName: String) -> String? {
+        labels[colorName]
+    }
+
+    /// ラベルがあればラベル、なければカラー名（赤、青等）を返す
+    func displayLabel(for colorName: String) -> String {
+        labels[colorName] ?? MangaColor.displayName(for: colorName)
+    }
+}

--- a/MangaLauncher/Shared/MangaDataChangeModifier.swift
+++ b/MangaLauncher/Shared/MangaDataChangeModifier.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+/// `mangaDataDidChange` 通知（CloudKit インポート完了 / 復帰 / Intent 経由更新時）を受信して
+/// View 側で refresh をトリガーするためのモディファイア。
+///
+/// なぜ必要か:
+/// - SwiftData の @Observable 追跡はローカルの mutation しか拾わない
+/// - CloudKit インポートは persistence 層で行われるため Observation は反応しない
+/// - 各画面が独立した `MangaViewModel` を持つため、それぞれで `refresh()` する必要がある
+struct MangaDataChangeModifier: ViewModifier {
+    let onChange: () -> Void
+
+    func body(content: Content) -> some View {
+        content.onReceive(NotificationCenter.default.publisher(for: .mangaDataDidChange)) { _ in
+            onChange()
+        }
+    }
+}
+
+extension View {
+    /// マンガデータが外部要因で変更されたとき（CloudKit sync など）に refresh を実行する。
+    func onMangaDataChange(_ action: @escaping () -> Void) -> some View {
+        modifier(MangaDataChangeModifier(onChange: action))
+    }
+}

--- a/MangaLauncher/Shared/MangaStatusBadgeView.swift
+++ b/MangaLauncher/Shared/MangaStatusBadgeView.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+
+/// マンガの状態（読了 / 完結 / 休載 / 積読 / 読み切り）を 1 個のバッジで表示する。
+/// 優先度: 読了 > 掲載完結 > 休載 > 積読 > 読み切り
+/// 該当する状態が無ければ何も描画しない。
+struct MangaStatusBadgeView: View {
+    enum Style {
+        /// "読" "完" "休" "積" "切" などの 1 文字
+        case short
+        /// "読了" "完結" "休載" "積読" "読切" などの全名
+        case full
+    }
+
+    let entry: MangaEntry
+    var style: Style = .full
+    var fontSize: CGFloat = 9
+
+    var body: some View {
+        if let badge = badge(for: entry) {
+            Text(badge.text)
+                .font(.system(size: fontSize, weight: .bold))
+                .foregroundStyle(.white)
+                .padding(.horizontal, 5)
+                .padding(.vertical, 2)
+                .background(badge.color)
+                .clipShape(RoundedRectangle(cornerRadius: 3))
+        }
+    }
+
+    private func badge(for entry: MangaEntry) -> (text: String, color: Color)? {
+        if entry.readingState == .archived {
+            return (style == .short ? "読" : "読了", .green)
+        }
+        if entry.publicationStatus == .finished {
+            return (style == .short ? "完" : "完結", .blue)
+        }
+        if entry.publicationStatus == .hiatus {
+            return (style == .short ? "休" : "休載", .orange)
+        }
+        if entry.readingState == .backlog {
+            return (style == .short ? "積" : "積読", ThemeManager.shared.style.primary)
+        }
+        if entry.isOneShot {
+            return (style == .short ? "切" : "読切", .purple)
+        }
+        return nil
+    }
+}

--- a/MangaLauncher/Shared/SectionHeaderView.swift
+++ b/MangaLauncher/Shared/SectionHeaderView.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+/// セクションヘッダーの共通コンポーネント。
+/// アイコン + タイトル + 件数バッジ + （任意）「すべて表示」リンク。
+struct SectionHeaderView<Destination: Hashable>: View {
+    let title: String
+    var icon: String? = nil
+    var iconColor: Color? = nil
+    var count: Int? = nil
+    var badgeColor: Color? = nil
+    var seeAll: Destination? = nil
+
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            if let icon {
+                Image(systemName: icon)
+                    .font(theme.headlineFont)
+                    .foregroundStyle(iconColor ?? theme.primary)
+            }
+            Text(title)
+                .font(theme.title3Font)
+                .foregroundStyle(theme.onSurface)
+            if let count {
+                Text("\(count)")
+                    .font(.system(size: 13, weight: .bold))
+                    .foregroundStyle(theme.onPrimary)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 2)
+                    .background(badgeColor ?? theme.primary)
+                    .clipShape(Capsule())
+            }
+            Spacer()
+            if let seeAll {
+                NavigationLink(value: seeAll) {
+                    HStack(spacing: 2) {
+                        Text("すべて表示")
+                            .font(theme.captionFont)
+                        Image(systemName: "chevron.right")
+                            .font(.caption2)
+                    }
+                    .foregroundStyle(theme.primary)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+}
+
+extension SectionHeaderView where Destination == LibraryDestination {
+    /// 「すべて表示」リンクが不要なケース用
+    init(title: String, icon: String? = nil, iconColor: Color? = nil, count: Int? = nil, badgeColor: Color? = nil) {
+        self.title = title
+        self.icon = icon
+        self.iconColor = iconColor
+        self.count = count
+        self.badgeColor = badgeColor
+        self.seeAll = nil
+    }
+}

--- a/MangaLauncher/Shared/SharedModelContainer.swift
+++ b/MangaLauncher/Shared/SharedModelContainer.swift
@@ -11,7 +11,7 @@ enum SharedModelContainer {
     #endif
 
     static func create() throws -> ModelContainer {
-        let schema = Schema([MangaEntry.self, ReadingActivity.self])
+        let schema = Schema([MangaEntry.self, ReadingActivity.self, MangaComment.self])
         let config = ModelConfiguration(
             "MangaLauncher",
             schema: schema,

--- a/MangaLauncher/ViewModels/HomeState.swift
+++ b/MangaLauncher/ViewModels/HomeState.swift
@@ -11,7 +11,7 @@ final class HomeState {
     var edit = EditState()
 
     // MARK: - Wallpaper
-    var wallpaper = WallpaperState()
+    var wallpaper = WallpaperState.shared
 
     // MARK: - Sheets
     var sheets = SheetState()
@@ -20,6 +20,7 @@ final class HomeState {
     var headerHeight: CGFloat = 50
     var selectedPublisher: String?
     var safariURL: URL?
+    var commentingEntry: MangaEntry?
 }
 
 @Observable
@@ -27,10 +28,11 @@ final class PagingState {
     var pageIndex: Int = 0
     var isAnimatingPageChange = false
 
-    private let orderedDays = DayOfWeek.orderedCases
+    private let orderedDays = DayOfWeek.orderedDays
 
     func dayForPageIndex(_ index: Int) -> DayOfWeek {
-        let clamped = ((index - 1) % 9 + 9) % 9
+        let count = orderedDays.count
+        let clamped = ((index - 1) % count + count) % count
         return orderedDays[clamped]
     }
 
@@ -52,7 +54,6 @@ final class EditState {
     #endif
     var editingEntry: MangaEntry?
     var draggingEntryID: UUID?
-    var draggingIsOneShot = false
 
     var isEditing: Bool {
         #if os(iOS) || os(visionOS)
@@ -72,6 +73,10 @@ final class EditState {
 
 @Observable
 final class WallpaperState {
+    static let shared = WallpaperState()
+
+    private init() {}
+
     var refresh = false
     var cachedWallpaperImage: Image?
     var previewActive = false

--- a/MangaLauncher/ViewModels/HomeState.swift
+++ b/MangaLauncher/ViewModels/HomeState.swift
@@ -25,10 +25,21 @@ final class HomeState {
 
 @Observable
 final class PagingState {
-    var pageIndex: Int = 0
+    /// 初期値を今日の曜日に合わせることで、onAppear での pageIndex 変更による
+    /// 不要なタブアニメーションを防止する。
+    var pageIndex: Int
     var isAnimatingPageChange = false
 
     private let orderedDays = DayOfWeek.orderedDays
+
+    init() {
+        let days = DayOfWeek.orderedDays
+        if let index = days.firstIndex(of: .today) {
+            pageIndex = index + 1
+        } else {
+            pageIndex = 1
+        }
+    }
 
     func dayForPageIndex(_ index: Int) -> DayOfWeek {
         let count = orderedDays.count

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -7,6 +7,7 @@ import WidgetKit
 #endif
 
 @Observable
+@MainActor
 final class MangaViewModel {
     var selectedDay: DayOfWeek = .today
     private(set) var refreshCounter = 0
@@ -17,28 +18,61 @@ final class MangaViewModel {
 
     init(modelContext: ModelContext) {
         self.modelContext = modelContext
+        migrateLegacyStateIfNeeded()
+        backfillMemoUpdatedAtIfNeeded()
     }
 
+    /// 旧 Bool 状態（isOnHiatus / isCompleted / isBacklog）を
+    /// publicationStatus / readingState に一括移行する。
+    private func migrateLegacyStateIfNeeded() {
+        let descriptor = FetchDescriptor<MangaEntry>(
+            predicate: #Predicate { $0.stateMigrationVersion < 1 }
+        )
+        let pending = (try? modelContext.fetch(descriptor)) ?? []
+        guard !pending.isEmpty else { return }
+        for entry in pending {
+            entry.migrateLegacyStateIfNeeded()
+        }
+        do {
+            try modelContext.save()
+        } catch {
+            print("[MangaViewModel] state migration save failed: \(error)")
+        }
+    }
+
+    /// memoUpdatedAt 追加前に書かれたメモには nil が入っているので、
+    /// 起動時に一度だけ現在時刻でバックフィルする。
+    /// （正確な編集日時は分からないが、次の編集で正しい値に上書きされる）
+    private func backfillMemoUpdatedAtIfNeeded() {
+        let descriptor = FetchDescriptor<MangaEntry>(
+            predicate: #Predicate { $0.memo != "" && $0.memoUpdatedAt == nil }
+        )
+        let pending = (try? modelContext.fetch(descriptor)) ?? []
+        guard !pending.isEmpty else { return }
+        let now = Date()
+        for entry in pending {
+            entry.memoUpdatedAt = now
+        }
+        do {
+            try modelContext.save()
+        } catch {
+            print("[MangaViewModel] memo backfill save failed: \(error)")
+        }
+    }
+
+    /// 曜日ごとの「今追っかけている」エントリを取得する。
+    /// 連載中 × 追っかけ中のみ。完結/休載/読了/積読 はホームの曜日タブには出さない。
     func fetchEntries(for day: DayOfWeek) -> [MangaEntry] {
         let _ = refreshCounter
-        let descriptor: FetchDescriptor<MangaEntry>
-        if day.isCompleted {
-            descriptor = FetchDescriptor<MangaEntry>(
-                predicate: #Predicate { $0.isCompleted },
-                sortBy: [SortDescriptor(\.sortOrder)]
-            )
-        } else if day.isHiatus {
-            descriptor = FetchDescriptor<MangaEntry>(
-                predicate: #Predicate { $0.isOnHiatus && !$0.isCompleted },
-                sortBy: [SortDescriptor(\.sortOrder)]
-            )
-        } else {
-            let dayRawValue = day.rawValue
-            descriptor = FetchDescriptor<MangaEntry>(
-                predicate: #Predicate { $0.dayOfWeekRawValue == dayRawValue && !$0.isOnHiatus && !$0.isCompleted },
-                sortBy: [SortDescriptor(\.sortOrder)]
-            )
-        }
+        let dayRawValue = day.rawValue
+        let descriptor = FetchDescriptor<MangaEntry>(
+            predicate: #Predicate {
+                $0.dayOfWeekRawValue == dayRawValue
+                    && $0.readingStateRawValue == 0  // following only
+                    && $0.publicationStatusRawValue == 0  // active only
+            },
+            sortBy: [SortDescriptor(\.sortOrder)]
+        )
         let results = modelContext.fetchLogged(descriptor)
         let pendingIDs = Set(pendingDeleteEntries.map(\.id))
         var seenIDs = Set<UUID>()
@@ -48,19 +82,19 @@ final class MangaViewModel {
         }
     }
 
-    func toggleHiatus(_ entry: MangaEntry) {
-        entry.isOnHiatus.toggle()
-        if entry.isOnHiatus { entry.isCompleted = false }
+    /// 掲載状況の付け替え
+    func setPublicationStatus(_ entry: MangaEntry, to status: PublicationStatus) {
+        entry.publicationStatus = status
         save()
     }
 
-    func toggleCompleted(_ entry: MangaEntry) {
-        entry.isCompleted.toggle()
-        if entry.isCompleted { entry.isOnHiatus = false }
+    /// 読書状況の付け替え
+    func setReadingState(_ entry: MangaEntry, to state: ReadingState) {
+        entry.readingState = state
         save()
     }
 
-    func addEntry(name: String, url: String, days: Set<DayOfWeek>, iconColor: String, publisher: String = "", imageData: Data? = nil, updateIntervalWeeks: Int = 1, nextExpectedUpdate: Date? = nil, isOnHiatus: Bool = false, isOneShot: Bool = false) {
+    func addEntry(name: String, url: String, days: Set<DayOfWeek>, iconColor: String, publisher: String = "", imageData: Data? = nil, updateIntervalWeeks: Int = 1, nextExpectedUpdate: Date? = nil, publicationStatus: PublicationStatus = .active, readingState: ReadingState = .following, isOneShot: Bool = false, memo: String = "") {
         for day in days {
             let existingEntries = fetchEntries(for: day)
             let maxOrder = existingEntries.map(\.sortOrder).max() ?? -1
@@ -75,8 +109,13 @@ final class MangaViewModel {
                 updateIntervalWeeks: updateIntervalWeeks
             )
             entry.nextExpectedUpdate = nextExpectedUpdate
-            entry.isOnHiatus = isOnHiatus
+            entry.publicationStatus = publicationStatus
+            entry.readingState = readingState
             entry.isOneShot = isOneShot
+            entry.memo = memo
+            if !memo.isEmpty {
+                entry.memoUpdatedAt = Date()
+            }
             modelContext.insert(entry)
         }
         save()
@@ -97,6 +136,19 @@ final class MangaViewModel {
     func publishers(for day: DayOfWeek) -> [String] {
         let entries = fetchEntries(for: day)
         return Set(entries.map(\.publisher)).filter { !$0.isEmpty }.sorted()
+    }
+
+    func allEntries() -> [MangaEntry] {
+        let _ = refreshCounter
+        let descriptor = FetchDescriptor<MangaEntry>(
+            sortBy: [SortDescriptor(\.lastReadDate, order: .reverse), SortDescriptor(\.name)]
+        )
+        let pendingIDs = Set(pendingDeleteEntries.map(\.id))
+        var seenIDs = Set<UUID>()
+        return modelContext.fetchLogged(descriptor).filter { entry in
+            guard !pendingIDs.contains(entry.id) else { return false }
+            return seenIDs.insert(entry.id).inserted
+        }
     }
 
     func allPublishers() -> [String] {
@@ -143,20 +195,10 @@ final class MangaViewModel {
         }
     }
 
+    /// 別の曜日に移動。曜日のみ変更し、状態は触らない。
     func moveEntryToDay(_ entry: MangaEntry, to newDay: DayOfWeek, at targetEntry: MangaEntry? = nil) {
-        if entry.isOneShot && newDay.isHiatus { return }
-        if newDay.isCompleted {
-            entry.isCompleted = true
-            entry.isOnHiatus = false
-        } else if newDay.isHiatus {
-            entry.isOnHiatus = true
-            entry.isCompleted = false
-        } else {
-            entry.isOnHiatus = false
-            entry.isCompleted = false
-            entry.dayOfWeek = newDay
-            entry.resetNextUpdate()
-        }
+        entry.dayOfWeek = newDay
+        entry.resetNextUpdate()
         var entries = fetchEntries(for: newDay)
         if !entries.contains(where: { $0.id == entry.id }) {
             if let targetEntry, let targetIndex = entries.firstIndex(where: { $0.id == targetEntry.id }) {
@@ -222,7 +264,9 @@ final class MangaViewModel {
         guard !entries.isEmpty else { return nil }
         let activityDescriptor = FetchDescriptor<ReadingActivity>(sortBy: [SortDescriptor(\.date)])
         let activities = modelContext.fetchLogged(activityDescriptor)
-        let backup = BackupData.from(entries, activities: activities)
+        let commentDescriptor = FetchDescriptor<MangaComment>(sortBy: [SortDescriptor(\.createdAt)])
+        let comments = modelContext.fetchLogged(commentDescriptor)
+        let backup = BackupData.from(entries, activities: activities, comments: comments)
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return try? encoder.encode(backup)
@@ -251,11 +295,38 @@ final class MangaViewModel {
             )
             entry.lastReadDate = backupEntry.lastReadDate
             entry.nextExpectedUpdate = backupEntry.nextExpectedUpdate
-            entry.isOnHiatus = backupEntry.isOnHiatus ?? false
-            entry.isCompleted = backupEntry.isCompleted ?? false
             entry.isOneShot = backupEntry.isOneShot ?? false
+            entry.memo = backupEntry.memo ?? ""
+            entry.memoUpdatedAt = backupEntry.memoUpdatedAt
+            // 新フィールドが backup に含まれていればそれを使う、無ければ legacy から導出
+            if let pubRaw = backupEntry.publicationStatusRawValue,
+               let readRaw = backupEntry.readingStateRawValue {
+                entry.publicationStatusRawValue = pubRaw
+                entry.readingStateRawValue = readRaw
+            } else {
+                entry.isOnHiatus = backupEntry.isOnHiatus ?? false
+                entry.isCompleted = backupEntry.isCompleted ?? false
+                entry.isBacklog = backupEntry.isBacklog ?? false
+                entry.stateMigrationVersion = 0
+                entry.migrateLegacyStateIfNeeded()
+            }
             modelContext.insert(entry)
             importedCount += 1
+        }
+        if let backupComments = backup.comments {
+            let existingCommentIDs = Set(modelContext.fetchLogged(FetchDescriptor<MangaComment>()).map(\.id))
+            for backupComment in backupComments {
+                guard !existingCommentIDs.contains(backupComment.id) else { continue }
+                let comment = MangaComment(
+                    mangaEntryID: backupComment.mangaEntryID,
+                    content: backupComment.content,
+                    createdAt: backupComment.createdAt
+                )
+                comment.id = backupComment.id
+                comment.updatedAt = backupComment.updatedAt
+                modelContext.insert(comment)
+                importedCount += 1
+            }
         }
         if let backupActivities = backup.activities {
             let existingActivityIDs = Set(modelContext.fetchLogged(FetchDescriptor<ReadingActivity>()).map(\.id))
@@ -303,8 +374,9 @@ final class MangaViewModel {
             mangaEntryID: entry.id
         )
         modelContext.insert(activity)
+        // 読み切りを既読にしたら自動で読了アーカイブへ
         if entry.isOneShot {
-            entry.isCompleted = true
+            entry.readingState = .archived
         }
         save()
     }
@@ -312,7 +384,7 @@ final class MangaViewModel {
     func markAsUnread(_ entry: MangaEntry) {
         entry.lastReadDate = nil
         if entry.isOneShot {
-            entry.isCompleted = false
+            entry.readingState = .following
         }
         let today = Calendar.current.startOfDay(for: Date())
         let entryID = entry.id
@@ -328,6 +400,72 @@ final class MangaViewModel {
 
     func unreadEntries(for day: DayOfWeek) -> [MangaEntry] {
         fetchEntries(for: day).filter { !$0.isRead }
+    }
+
+    // MARK: - Memo
+
+    func updateMemo(_ entry: MangaEntry, memo: String) {
+        let changed = entry.memo != memo
+        entry.memo = memo
+        if changed && !memo.isEmpty {
+            entry.memoUpdatedAt = Date()
+        } else if memo.isEmpty {
+            entry.memoUpdatedAt = nil
+        }
+        save()
+    }
+
+    // 注意: アクティビティ・メモ集約は ActivityBuilder に移譲。
+    // ここに recentActivity / allActivity / memoEntryCount などを置かないこと（N+1 fetch の温床になる）。
+
+    // MARK: - Comments
+
+    func addComment(_ entry: MangaEntry, content: String) {
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        let comment = MangaComment(mangaEntryID: entry.id, content: trimmed)
+        modelContext.insert(comment)
+        save()
+    }
+
+    func updateComment(_ comment: MangaComment, content: String) {
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        comment.content = trimmed
+        comment.updatedAt = Date()
+        save()
+    }
+
+    func deleteComment(_ comment: MangaComment) {
+        modelContext.delete(comment)
+        save()
+    }
+
+    func fetchComments(for entry: MangaEntry) -> [MangaComment] {
+        let _ = refreshCounter
+        let entryID = entry.id
+        let descriptor = FetchDescriptor<MangaComment>(
+            predicate: #Predicate { $0.mangaEntryID == entryID },
+            sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
+        )
+        return modelContext.fetchLogged(descriptor)
+    }
+
+    func recentComments(limit: Int = 10) -> [MangaComment] {
+        let _ = refreshCounter
+        var descriptor = FetchDescriptor<MangaComment>(
+            sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
+        )
+        descriptor.fetchLimit = limit
+        return modelContext.fetchLogged(descriptor)
+    }
+
+    func allComments() -> [MangaComment] {
+        let _ = refreshCounter
+        let descriptor = FetchDescriptor<MangaComment>(
+            sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
+        )
+        return modelContext.fetchLogged(descriptor)
     }
 
     func unreadCount(for day: DayOfWeek) -> Int {

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -28,7 +28,13 @@ final class MangaViewModel {
         let descriptor = FetchDescriptor<MangaEntry>(
             predicate: #Predicate { $0.stateMigrationVersion < 1 }
         )
-        let pending = (try? modelContext.fetch(descriptor)) ?? []
+        let pending: [MangaEntry]
+        do {
+            pending = try modelContext.fetch(descriptor)
+        } catch {
+            print("[MangaViewModel] state migration fetch failed: \(error)")
+            return
+        }
         guard !pending.isEmpty else { return }
         for entry in pending {
             entry.migrateLegacyStateIfNeeded()
@@ -47,7 +53,13 @@ final class MangaViewModel {
         let descriptor = FetchDescriptor<MangaEntry>(
             predicate: #Predicate { $0.memo != "" && $0.memoUpdatedAt == nil }
         )
-        let pending = (try? modelContext.fetch(descriptor)) ?? []
+        let pending: [MangaEntry]
+        do {
+            pending = try modelContext.fetch(descriptor)
+        } catch {
+            print("[MangaViewModel] memo backfill fetch failed: \(error)")
+            return
+        }
         guard !pending.isEmpty else { return }
         let now = Date()
         for entry in pending {
@@ -65,11 +77,14 @@ final class MangaViewModel {
     func fetchEntries(for day: DayOfWeek) -> [MangaEntry] {
         let _ = refreshCounter
         let dayRawValue = day.rawValue
+        // #Predicate は enum case を直接受け付けないので、ローカル let でキャプチャして意味を明示する
+        let followingRaw = ReadingState.following.rawValue
+        let activeRaw = PublicationStatus.active.rawValue
         let descriptor = FetchDescriptor<MangaEntry>(
             predicate: #Predicate {
                 $0.dayOfWeekRawValue == dayRawValue
-                    && $0.readingStateRawValue == 0  // following only
-                    && $0.publicationStatusRawValue == 0  // active only
+                    && $0.readingStateRawValue == followingRaw
+                    && $0.publicationStatusRawValue == activeRaw
             },
             sortBy: [SortDescriptor(\.sortOrder)]
         )
@@ -121,7 +136,22 @@ final class MangaViewModel {
         save()
     }
 
-    func updateEntry(_ entry: MangaEntry, name: String, url: String, dayOfWeek: DayOfWeek, iconColor: String, publisher: String = "", imageData: Data? = nil, updateIntervalWeeks: Int = 1, nextExpectedUpdate: Date? = nil) {
+    func updateEntry(
+        _ entry: MangaEntry,
+        name: String,
+        url: String,
+        dayOfWeek: DayOfWeek,
+        iconColor: String,
+        publisher: String = "",
+        imageData: Data? = nil,
+        updateIntervalWeeks: Int = 1,
+        nextExpectedUpdate: Date? = nil,
+        isOneShot: Bool,
+        publicationStatus: PublicationStatus,
+        readingState: ReadingState,
+        memo: String
+    ) {
+        let memoChanged = entry.memo != memo
         entry.name = name
         entry.url = url
         entry.dayOfWeek = dayOfWeek
@@ -130,6 +160,14 @@ final class MangaViewModel {
         entry.imageData = imageData
         entry.updateIntervalWeeks = updateIntervalWeeks
         entry.nextExpectedUpdate = nextExpectedUpdate
+        entry.isOneShot = isOneShot
+        // 読み切りは掲載状況の概念がないので強制的に active へ
+        entry.publicationStatus = isOneShot ? .active : publicationStatus
+        entry.readingState = readingState
+        entry.memo = memo
+        if memoChanged {
+            entry.memoUpdatedAt = memo.isEmpty ? nil : Date()
+        }
         save()
     }
 
@@ -368,12 +406,21 @@ final class MangaViewModel {
         if !entry.isOneShot {
             entry.advanceToNextUpdate()
         }
-        let activity = ReadingActivity(
-            date: Date(),
-            mangaName: entry.name,
-            mangaEntryID: entry.id
+        // 同日・同エントリのアクティビティが既に存在する場合は再 insert しない
+        let today = Calendar.current.startOfDay(for: Date())
+        let entryID = entry.id
+        let existingDescriptor = FetchDescriptor<ReadingActivity>(
+            predicate: #Predicate { $0.date == today && $0.mangaEntryID == entryID }
         )
-        modelContext.insert(activity)
+        let hasExisting = !modelContext.fetchLogged(existingDescriptor).isEmpty
+        if !hasExisting {
+            let activity = ReadingActivity(
+                date: Date(),
+                mangaName: entry.name,
+                mangaEntryID: entry.id
+            )
+            modelContext.insert(activity)
+        }
         // 読み切りを既読にしたら自動で読了アーカイブへ
         if entry.isOneShot {
             entry.readingState = .archived

--- a/MangaLauncher/Views/CatchUp/CatchUpView.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpView.swift
@@ -108,7 +108,7 @@ struct CatchUpView: View {
                 updateBackgroundGradient()
             }
         }
-        .onReceive(NotificationCenter.default.publisher(for: .mangaDataDidChange)) { _ in
+        .onMangaDataChange {
             reloadEntries()
         }
         .overlay {

--- a/MangaLauncher/Views/Comment/CommentListView.swift
+++ b/MangaLauncher/Views/Comment/CommentListView.swift
@@ -1,0 +1,156 @@
+import SwiftUI
+
+struct CommentListView: View {
+    @Environment(\.dismiss) private var dismiss
+    let entry: MangaEntry
+    var viewModel: MangaViewModel
+
+    @State private var draft: String = ""
+    @State private var editingComment: MangaComment?
+    @State private var editingContent: String = ""
+    @FocusState private var composerFocused: Bool
+
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
+    var body: some View {
+        NavigationStack {
+            let _ = viewModel.refreshCounter
+            let comments = viewModel.fetchComments(for: entry)
+
+            ZStack {
+                if theme.usesCustomSurface {
+                    theme.surface.ignoresSafeArea()
+                }
+
+                VStack(spacing: 0) {
+                    if comments.isEmpty {
+                        ContentUnavailableView {
+                            Label("コメントがありません", systemImage: "bubble.left.and.bubble.right")
+                                .foregroundStyle(theme.onSurfaceVariant)
+                        } description: {
+                            Text("感想や話ごとのメモを下から投稿できます")
+                                .foregroundStyle(theme.onSurfaceVariant.opacity(0.7))
+                        }
+                        .frame(maxHeight: .infinity)
+                    } else {
+                        List {
+                            ForEach(comments, id: \.id) { comment in
+                                commentRow(comment)
+                                    .listRowBackground(Color.clear)
+                            }
+                        }
+                        .listStyle(.plain)
+                        .scrollContentBackground(.hidden)
+                    }
+
+                    composer
+                }
+            }
+            .navigationTitle(entry.name)
+            #if os(iOS) || os(visionOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("閉じる") { dismiss() }
+                }
+            }
+            .sheet(item: $editingComment) { comment in
+                editSheet(for: comment)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func commentRow(_ comment: MangaComment) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(comment.content)
+                .font(theme.bodyFont)
+                .foregroundStyle(theme.onSurface)
+                .textSelection(.enabled)
+            HStack(spacing: 6) {
+                Text(comment.createdAt.formatted(.dateTime.year().month().day().hour().minute()))
+                if comment.updatedAt != nil {
+                    Text("· 編集済み")
+                }
+            }
+            .font(theme.caption2Font)
+            .foregroundStyle(theme.onSurfaceVariant)
+        }
+        .padding(.vertical, 4)
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+            Button(role: .destructive) {
+                viewModel.deleteComment(comment)
+            } label: {
+                Label("削除", systemImage: "trash")
+            }
+            Button {
+                editingContent = comment.content
+                editingComment = comment
+            } label: {
+                Label("編集", systemImage: "pencil")
+            }
+            .tint(theme.primary)
+        }
+    }
+
+    @ViewBuilder
+    private var composer: some View {
+        Divider()
+        HStack(alignment: .bottom, spacing: 8) {
+            TextField("コメントを書く…", text: $draft, axis: .vertical)
+                .lineLimit(1...5)
+                .focused($composerFocused)
+                .padding(10)
+                .background(theme.surfaceContainerHigh, in: RoundedRectangle(cornerRadius: 12))
+                #if os(iOS) || os(visionOS)
+                .textInputAutocapitalization(.none)
+                #endif
+            Button {
+                viewModel.addComment(entry, content: draft)
+                draft = ""
+                composerFocused = false
+            } label: {
+                Image(systemName: "paperplane.fill")
+                    .font(.title3)
+                    .foregroundStyle(canSubmit ? theme.primary : theme.onSurfaceVariant.opacity(0.4))
+            }
+            .disabled(!canSubmit)
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+        .background(.regularMaterial)
+    }
+
+    private var canSubmit: Bool {
+        !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    @ViewBuilder
+    private func editSheet(for comment: MangaComment) -> some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextField("コメント", text: $editingContent, axis: .vertical)
+                        .lineLimit(3...10)
+                }
+            }
+            .navigationTitle("コメントを編集")
+            #if os(iOS) || os(visionOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("キャンセル") { editingComment = nil }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("保存") {
+                        viewModel.updateComment(comment, content: editingContent)
+                        editingComment = nil
+                    }
+                    .disabled(editingContent.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            }
+        }
+    }
+}

--- a/MangaLauncher/Views/Entry/EditEntryView.swift
+++ b/MangaLauncher/Views/Entry/EditEntryView.swift
@@ -471,21 +471,36 @@ struct EditEntryView: View {
     private func saveEntry() {
         let interval = actualIntervalWeeks
         if let entry {
-            let memoChanged = entry.memo != memo
-            viewModel.updateEntry(entry, name: name, url: url, dayOfWeek: selectedDay, iconColor: selectedColor, publisher: publisher, imageData: imageData, updateIntervalWeeks: interval, nextExpectedUpdate: nextUpdateDate)
-            entry.isOneShot = isOneShot
-            entry.publicationStatus = isOneShot ? .active : publicationStatus
-            entry.readingState = readingState
-            entry.memo = memo
-            if memoChanged {
-                if memo.isEmpty {
-                    entry.memoUpdatedAt = nil
-                } else {
-                    entry.memoUpdatedAt = Date()
-                }
-            }
+            viewModel.updateEntry(
+                entry,
+                name: name,
+                url: url,
+                dayOfWeek: selectedDay,
+                iconColor: selectedColor,
+                publisher: publisher,
+                imageData: imageData,
+                updateIntervalWeeks: interval,
+                nextExpectedUpdate: nextUpdateDate,
+                isOneShot: isOneShot,
+                publicationStatus: publicationStatus,
+                readingState: readingState,
+                memo: memo
+            )
         } else {
-            viewModel.addEntry(name: name, url: url, days: [selectedDay], iconColor: selectedColor, publisher: publisher, imageData: imageData, updateIntervalWeeks: isOneShot ? 1 : interval, nextExpectedUpdate: isOneShot ? nil : nextUpdateDate, publicationStatus: isOneShot ? .active : publicationStatus, readingState: readingState, isOneShot: isOneShot, memo: memo)
+            viewModel.addEntry(
+                name: name,
+                url: url,
+                days: [selectedDay],
+                iconColor: selectedColor,
+                publisher: publisher,
+                imageData: imageData,
+                updateIntervalWeeks: isOneShot ? 1 : interval,
+                nextExpectedUpdate: isOneShot ? nil : nextUpdateDate,
+                publicationStatus: isOneShot ? .active : publicationStatus,
+                readingState: readingState,
+                isOneShot: isOneShot,
+                memo: memo
+            )
         }
     }
 }

--- a/MangaLauncher/Views/Entry/EditEntryView.swift
+++ b/MangaLauncher/Views/Entry/EditEntryView.swift
@@ -28,9 +28,10 @@ struct EditEntryView: View {
     @State private var ogpFetchFailed = false
     @State private var showingCropView = false
     @State private var didLoadEntry = false
-    @State private var isOnHiatus = false
-    @State private var isCompleted = false
+    @State private var publicationStatus: PublicationStatus = .active
+    @State private var readingState: ReadingState = .following
     @State private var isOneShot = false
+    @State private var memo: String = ""
 
     private var theme: ThemeStyle { ThemeManager.shared.style }
 
@@ -256,60 +257,83 @@ struct EditEntryView: View {
                         Text("読み切り").tag(true)
                     }
                     .pickerStyle(.segmented)
-                    .onChange(of: isOneShot) { oldValue, newValue in
+                    .onChange(of: isOneShot) { _, newValue in
                         if newValue {
-                            isOnHiatus = false
-                            isCompleted = false
-                        } else if oldValue {
-                            isCompleted = false
+                            publicationStatus = .active
+                            if readingState == .backlog {
+                                readingState = .following
+                            }
                         }
                     }
                 }
 
                 if !isOneShot {
-                    Section("掲載状態") {
-                        Picker("状態", selection: Binding(
-                            get: {
-                                if isCompleted { return PublicationStatus.completed }
-                                if isOnHiatus { return PublicationStatus.hiatus }
-                                return PublicationStatus.active
-                            },
-                            set: { newValue in
-                                isOnHiatus = newValue == .hiatus
-                                isCompleted = newValue == .completed
-                            }
-                        )) {
-                            ForEach(PublicationStatus.allCases, id: \.self) { status in
+                    Section {
+                        Picker("掲載状況", selection: $publicationStatus) {
+                            ForEach(PublicationStatus.allCases) { status in
                                 Text(status.displayName).tag(status)
                             }
                         }
                         .pickerStyle(.segmented)
+                    } header: {
+                        Text("掲載状況")
+                    } footer: {
+                        Text("作品自体の状態。連載中／休載中／完結。")
                     }
+                }
 
+                if !isOneShot {
+                    Section {
+                        Picker("読書状況", selection: $readingState) {
+                            ForEach(ReadingState.allCases) { state in
+                                Text(state.displayName).tag(state)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+                    } header: {
+                        Text("読書状況")
+                    } footer: {
+                        Text("自分の進捗。追っかけ中／積読／読了。読了にすると常に既読扱いになります。")
+                    }
+                }
+
+                if !isOneShot && publicationStatus == .active && readingState == .following {
                     Section("更新頻度") {
-                    Picker("頻度", selection: pickerValue) {
-                        Text("毎週").tag(1)
-                        Text("隔週").tag(2)
-                        Text("3週ごと").tag(3)
-                        Text("月1回").tag(4)
-                        Text("2ヶ月ごと").tag(8)
-                        Text("カスタム").tag(-1)
-                    }
-                    if isCustomInterval {
-                        Stepper("\(updateIntervalWeeks)週ごと", value: $updateIntervalWeeks, in: 1...52)
-                    }
-                    if actualIntervalWeeks >= 1 {
-                        Picker("次の更新日", selection: $nextUpdateDate) {
-                            ForEach(nextUpdateCandidates, id: \.self) { date in
-                                Text(date.formatted(.dateTime.month().day().weekday()))
-                                    .tag(date)
+                        Picker("頻度", selection: pickerValue) {
+                            Text("毎週").tag(1)
+                            Text("隔週").tag(2)
+                            Text("3週ごと").tag(3)
+                            Text("月1回").tag(4)
+                            Text("2ヶ月ごと").tag(8)
+                            Text("カスタム").tag(-1)
+                        }
+                        if isCustomInterval {
+                            Stepper("\(updateIntervalWeeks)週ごと", value: $updateIntervalWeeks, in: 1...52)
+                        }
+                        if actualIntervalWeeks >= 1 {
+                            Picker("次の更新日", selection: $nextUpdateDate) {
+                                ForEach(nextUpdateCandidates, id: \.self) { date in
+                                    Text(date.formatted(.dateTime.month().day().weekday()))
+                                        .tag(date)
+                                }
                             }
                         }
                     }
                 }
-                } // if !isOneShot
 
-                Section("アイコンカラー") {
+                Section {
+                    TextField("メモ（あらすじ・キャラ相関図など）", text: $memo, axis: .vertical)
+                        .lineLimit(3...10)
+                        #if os(iOS) || os(visionOS)
+                        .textInputAutocapitalization(.none)
+                        #endif
+                } header: {
+                    Text("メモ")
+                } footer: {
+                    Text("作品ごとに 1 つの長文メモを保存できます。コメントとは別物です。")
+                }
+
+                Section {
                     LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 8), spacing: 12) {
                         ForEach(colorOptions, id: \.name) { option in
                             Circle()
@@ -328,6 +352,17 @@ struct EditEntryView: View {
                         }
                     }
                     .padding(.vertical, 4)
+                    if let label = ColorLabelStore.shared.label(for: selectedColor) {
+                        HStack {
+                            Text("ラベル")
+                                .foregroundStyle(theme.onSurfaceVariant)
+                            Spacer()
+                            Text(label)
+                                .foregroundStyle(theme.onSurface)
+                        }
+                    }
+                } header: {
+                    Text("アイコンカラー")
                 }
 
                 if isEditing && showsDeleteButton {
@@ -388,9 +423,10 @@ struct EditEntryView: View {
                     } else {
                         nextUpdateDate = candidates.first ?? nextOccurrence(of: entry.dayOfWeek)
                     }
-                    isOnHiatus = entry.isOnHiatus
-                    isCompleted = entry.isCompleted
+                    publicationStatus = entry.publicationStatus
+                    readingState = entry.readingState
                     isOneShot = entry.isOneShot
+                    memo = entry.memo
                     didLoadEntry = true
                 } else if entry == nil, !didLoadEntry {
                     nextUpdateDate = nextUpdateCandidates.first ?? nextOccurrence(of: selectedDay)
@@ -435,12 +471,21 @@ struct EditEntryView: View {
     private func saveEntry() {
         let interval = actualIntervalWeeks
         if let entry {
+            let memoChanged = entry.memo != memo
             viewModel.updateEntry(entry, name: name, url: url, dayOfWeek: selectedDay, iconColor: selectedColor, publisher: publisher, imageData: imageData, updateIntervalWeeks: interval, nextExpectedUpdate: nextUpdateDate)
-            entry.isOnHiatus = isOnHiatus
-            entry.isCompleted = isCompleted
             entry.isOneShot = isOneShot
+            entry.publicationStatus = isOneShot ? .active : publicationStatus
+            entry.readingState = readingState
+            entry.memo = memo
+            if memoChanged {
+                if memo.isEmpty {
+                    entry.memoUpdatedAt = nil
+                } else {
+                    entry.memoUpdatedAt = Date()
+                }
+            }
         } else {
-            viewModel.addEntry(name: name, url: url, days: [selectedDay], iconColor: selectedColor, publisher: publisher, imageData: imageData, updateIntervalWeeks: isOneShot ? 1 : interval, nextExpectedUpdate: isOneShot ? nil : nextUpdateDate, isOnHiatus: isOnHiatus, isOneShot: isOneShot)
+            viewModel.addEntry(name: name, url: url, days: [selectedDay], iconColor: selectedColor, publisher: publisher, imageData: imageData, updateIntervalWeeks: isOneShot ? 1 : interval, nextExpectedUpdate: isOneShot ? nil : nextUpdateDate, publicationStatus: isOneShot ? .active : publicationStatus, readingState: readingState, isOneShot: isOneShot, memo: memo)
         }
     }
 }

--- a/MangaLauncher/Views/Entry/ImageCropView.swift
+++ b/MangaLauncher/Views/Entry/ImageCropView.swift
@@ -10,14 +10,17 @@ struct ImageCropView: UIViewControllerRepresentable {
     let onCancel: () -> Void
 
     func makeUIViewController(context: Context) -> CropWrapperViewController {
+        let wrapper = CropWrapperViewController()
         guard let uiImage = UIImage(data: imageData) else {
-            fatalError("Invalid image data")
+            // 画像データが破損していた場合はクラッシュせず、空の wrapper を返して即時キャンセル
+            let cancel = onCancel
+            DispatchQueue.main.async { cancel() }
+            return wrapper
         }
 
         let cropVC = Mantis.cropViewController(image: uiImage)
         cropVC.delegate = context.coordinator
 
-        let wrapper = CropWrapperViewController()
         wrapper.addChild(cropVC)
         wrapper.view.addSubview(cropVC.view)
         cropVC.view.translatesAutoresizingMaskIntoConstraints = false

--- a/MangaLauncher/Views/Home/ContentToolbar.swift
+++ b/MangaLauncher/Views/Home/ContentToolbar.swift
@@ -10,7 +10,6 @@ struct ContentToolbar: ToolbarContent {
     var onCatchUp: () -> Void
     var onToggleDisplayMode: () -> Void
     var onAdd: () -> Void
-    var onSettings: () -> Void
 
     private var theme: ThemeStyle { ThemeManager.shared.style }
 
@@ -38,7 +37,7 @@ struct ContentToolbar: ToolbarContent {
                     }
                 }
             }
-            .disabled(unreadCount == 0 || edit.isEditing || paging.currentDay.isHiatus || paging.currentDay.isCompleted)
+            .disabled(unreadCount == 0 || edit.isEditing)
         }
         ToolbarItem(placement: .automatic) {
             Button {
@@ -53,14 +52,6 @@ struct ContentToolbar: ToolbarContent {
                 onAdd()
             } label: {
                 Image(systemName: "plus")
-            }
-            .disabled(edit.isEditing || paging.currentDay.isHiatus || paging.currentDay.isCompleted)
-        }
-        ToolbarItem(placement: .automatic) {
-            Button {
-                onSettings()
-            } label: {
-                Image(systemName: "gearshape")
             }
             .disabled(edit.isEditing)
         }

--- a/MangaLauncher/Views/Home/ContentView.swift
+++ b/MangaLauncher/Views/Home/ContentView.swift
@@ -11,11 +11,10 @@ extension URL: @retroactive Identifiable {
 }
 
 struct ContentView: View {
-    @Environment(\.modelContext) private var modelContext
     @Environment(\.openURL) private var openURL
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
 
-    @State private var viewModel: MangaViewModel?
+    var viewModel: MangaViewModel
     @State private var homeState = HomeState()
     @AppStorage("hasSeenOnboarding") private var hasSeenOnboarding = false
     @AppStorage("displayMode") private var displayMode: DisplayMode = .grid
@@ -32,23 +31,17 @@ struct ContentView: View {
             }
         } else {
             NavigationStack {
-                if let viewModel {
-                    mainContent(viewModel: viewModel)
-                }
+                mainContent(viewModel: viewModel)
             }
             .onAppear {
-                if viewModel == nil {
-                    viewModel = MangaViewModel(modelContext: modelContext)
-                }
                 homeState.wallpaper.loadImage()
             }
             .onMangaDataChange {
-                viewModel?.refresh()
+                viewModel.refresh()
             }
             .onReceive(NotificationCenter.default.publisher(for: .switchToDay)) { notification in
                 if let rawValue = notification.object as? Int,
-                   let day = DayOfWeek(rawValue: rawValue),
-                   let viewModel {
+                   let day = DayOfWeek(rawValue: rawValue) {
                     viewModel.selectedDay = day
                     homeState.paging.pageIndex = homeState.paging.pageIndexForDay(day)
                 }
@@ -108,13 +101,7 @@ struct ContentView: View {
                 )
                 .transition(.move(edge: .bottom).combined(with: .opacity))
             }
-
-            if !viewModel.pendingDeleteEntries.isEmpty {
-                DeleteToastView(viewModel: viewModel)
-                    .transition(.move(edge: .bottom).combined(with: .opacity))
-            }
         }
-        .animation(.easeInOut(duration: 0.3), value: viewModel.pendingDeleteEntries.isEmpty)
         .animation(.easeInOut(duration: 0.2), value: homeState.edit.isGridEditMode)
         .animation(.easeInOut(duration: 0.2), value: homeState.edit.listEditMode)
         .toolbar {
@@ -221,6 +208,7 @@ struct ContentView: View {
 }
 
 #Preview {
-    ContentView()
-        .modelContainer(for: MangaEntry.self, inMemory: true)
+    let container = try! ModelContainer(for: MangaEntry.self, configurations: ModelConfiguration(isStoredInMemoryOnly: true))
+    ContentView(viewModel: MangaViewModel(modelContext: container.mainContext))
+        .modelContainer(container)
 }

--- a/MangaLauncher/Views/Home/ContentView.swift
+++ b/MangaLauncher/Views/Home/ContentView.swift
@@ -23,7 +23,7 @@ struct ContentView: View {
 
     @Namespace private var tabUnderline
 
-    private let orderedDays = DayOfWeek.orderedCases
+    private let orderedDays = DayOfWeek.orderedDays
 
     var body: some View {
         if !hasSeenOnboarding {
@@ -83,13 +83,16 @@ struct ContentView: View {
                     DayPageView(
                         day: day,
                         viewModel: vm,
-                        displayMode: displayMode,
-                        hasWallpaper: homeState.wallpaper.effectiveHasWallpaper,
-                        reduceTransparency: reduceTransparency,
-                        headerHeight: homeState.headerHeight,
+                        display: DayPageDisplayContext(
+                            displayMode: displayMode,
+                            hasWallpaper: homeState.wallpaper.effectiveHasWallpaper,
+                            reduceTransparency: reduceTransparency,
+                            headerHeight: homeState.headerHeight
+                        ),
                         edit: homeState.edit,
                         selectedPublisher: $homeState.selectedPublisher,
                         showingAddSheet: $homeState.sheets.showingAddSheet,
+                        commentingEntry: $homeState.commentingEntry,
                         onOpenURL: { openMangaURL($0) }
                     )
                 }
@@ -129,8 +132,7 @@ struct ContentView: View {
                         displayMode = displayMode == .list ? .grid : .list
                     }
                 },
-                onAdd: { homeState.sheets.showingAddSheet = true },
-                onSettings: { homeState.sheets.showingSettings = true }
+                onAdd: { homeState.sheets.showingAddSheet = true }
             )
         }
         .toolbarBackgroundVisibility(.hidden, for: .navigationBar)
@@ -149,9 +151,6 @@ struct ContentView: View {
         }
         .sheet(item: $homeState.edit.editingEntry, onDismiss: { homeState.edit.editingEntry = nil }) { entry in
             EditEntryView(viewModel: viewModel, entry: entry)
-        }
-        .sheet(isPresented: $homeState.sheets.showingSettings) {
-            SettingsView(viewModel: viewModel)
         }
         .fullScreenCover(isPresented: $homeState.sheets.showingCatchUp, onDismiss: {
             viewModel.notifyChange()

--- a/MangaLauncher/Views/Home/ContentView.swift
+++ b/MangaLauncher/Views/Home/ContentView.swift
@@ -42,7 +42,7 @@ struct ContentView: View {
                 }
                 homeState.wallpaper.loadImage()
             }
-            .onReceive(NotificationCenter.default.publisher(for: .mangaDataDidChange)) { _ in
+            .onMangaDataChange {
                 viewModel?.refresh()
             }
             .onReceive(NotificationCenter.default.publisher(for: .switchToDay)) { notification in
@@ -151,6 +151,9 @@ struct ContentView: View {
         }
         .sheet(item: $homeState.edit.editingEntry, onDismiss: { homeState.edit.editingEntry = nil }) { entry in
             EditEntryView(viewModel: viewModel, entry: entry)
+        }
+        .sheet(item: $homeState.commentingEntry, onDismiss: { homeState.commentingEntry = nil }) { entry in
+            CommentListView(entry: entry, viewModel: viewModel)
         }
         .fullScreenCover(isPresented: $homeState.sheets.showingCatchUp, onDismiss: {
             viewModel.notifyChange()

--- a/MangaLauncher/Views/Home/DayPageView.swift
+++ b/MangaLauncher/Views/Home/DayPageView.swift
@@ -92,7 +92,7 @@ struct DayPageView: View {
                                     edit.draggingEntryID = entry.id
                                     return NSItemProvider(object: entry.id.uuidString as NSString)
                                 } preview: {
-                                    MangaGridCell(entry: entry, viewModel: viewModel, hasWallpaper: display.hasWallpaper, reduceTransparency: display.reduceTransparency, isGridEditMode: $edit.isGridEditMode, editingEntry: $edit.editingEntry, onOpenURL: onOpenURL)
+                                    MangaGridCell(entry: entry, viewModel: viewModel, hasWallpaper: display.hasWallpaper, reduceTransparency: display.reduceTransparency, isGridEditMode: $edit.isGridEditMode, editingEntry: $edit.editingEntry, commentingEntry: $commentingEntry, onOpenURL: onOpenURL)
                                         .frame(width: 120)
                                 }
                                 .onDrop(of: [.text], delegate: GridDropDelegate(

--- a/MangaLauncher/Views/Home/DayPageView.swift
+++ b/MangaLauncher/Views/Home/DayPageView.swift
@@ -1,15 +1,22 @@
 import SwiftUI
 
-struct DayPageView: View {
-    let day: DayOfWeek
-    var viewModel: MangaViewModel
+/// DayPageView の表示構成・装飾系の値をひとまとめにした context。
+/// 親 View からの props drilling を 1 つの引数に集約するためのもの。
+struct DayPageDisplayContext {
     let displayMode: DisplayMode
     let hasWallpaper: Bool
     let reduceTransparency: Bool
     let headerHeight: CGFloat
+}
+
+struct DayPageView: View {
+    let day: DayOfWeek
+    var viewModel: MangaViewModel
+    let display: DayPageDisplayContext
     @Bindable var edit: EditState
     @Binding var selectedPublisher: String?
     @Binding var showingAddSheet: Bool
+    @Binding var commentingEntry: MangaEntry?
     let onOpenURL: (String) -> Void
 
     private var theme: ThemeStyle { ThemeManager.shared.style }
@@ -23,48 +30,30 @@ struct DayPageView: View {
             allEntries
         }
 
-        if displayMode == .list && !allEntries.isEmpty && !entries.isEmpty {
-            MangaListView(entries: entries, day: day, viewModel: viewModel, hasWallpaper: hasWallpaper, reduceTransparency: reduceTransparency, headerHeight: headerHeight, editingEntry: $edit.editingEntry, listEditMode: $edit.listEditMode, onOpenURL: onOpenURL)
+        if display.displayMode == .list && !allEntries.isEmpty && !entries.isEmpty {
+            MangaListView(entries: entries, day: day, viewModel: viewModel, hasWallpaper: display.hasWallpaper, reduceTransparency: display.reduceTransparency, headerHeight: display.headerHeight, editingEntry: $edit.editingEntry, commentingEntry: $commentingEntry, listEditMode: $edit.listEditMode, onOpenURL: onOpenURL)
         } else {
             GeometryReader { geo in
                 ScrollView {
                     if allEntries.isEmpty {
-                        EmptyStateView(hasWallpaper: hasWallpaper, reduceTransparency: reduceTransparency, headerHeight: headerHeight) {
-                            if day.isCompleted {
-                                ContentUnavailableView {
-                                    Label("完結したマンガはありません", systemImage: "checkmark.seal")
-                                        .modifier(ThemedLabelModifier())
-                                } description: {
-                                    Text("コンテキストメニューや編集画面から\n「完結にする」でここに移動できます")
-                                        .modifier(ThemedDescriptionModifier())
+                        EmptyStateView(hasWallpaper: display.hasWallpaper, reduceTransparency: display.reduceTransparency, headerHeight: display.headerHeight) {
+                            ContentUnavailableView {
+                                Label("エントリなし", systemImage: "book.closed")
+                                    .modifier(ThemedLabelModifier())
+                            } description: {
+                                Text("\(day.displayName)に登録されたマンガはありません")
+                                    .modifier(ThemedDescriptionModifier())
+                            } actions: {
+                                Button("追加する") {
+                                    showingAddSheet = true
                                 }
-                            } else if day.isHiatus {
-                                ContentUnavailableView {
-                                    Label("休載中のマンガはありません", systemImage: "moon.zzz")
-                                        .modifier(ThemedLabelModifier())
-                                } description: {
-                                    Text("コンテキストメニューや編集画面から\n「休載中にする」でここに移動できます")
-                                        .modifier(ThemedDescriptionModifier())
-                                }
-                            } else {
-                                ContentUnavailableView {
-                                    Label("エントリなし", systemImage: "book.closed")
-                                        .modifier(ThemedLabelModifier())
-                                } description: {
-                                    Text("\(day.displayName)に登録されたマンガはありません")
-                                        .modifier(ThemedDescriptionModifier())
-                                } actions: {
-                                    Button("追加する") {
-                                        showingAddSheet = true
-                                    }
-                                    .modifier(ThemedActionModifier())
-                                }
+                                .modifier(ThemedActionModifier())
                             }
                         }
                         .frame(maxWidth: 600)
-                        .frame(maxWidth: .infinity, minHeight: geo.size.height - headerHeight)
+                        .frame(maxWidth: .infinity, minHeight: geo.size.height - display.headerHeight)
                     } else if entries.isEmpty {
-                        EmptyStateView(hasWallpaper: hasWallpaper, reduceTransparency: reduceTransparency, headerHeight: headerHeight) {
+                        EmptyStateView(hasWallpaper: display.hasWallpaper, reduceTransparency: display.reduceTransparency, headerHeight: display.headerHeight) {
                             ContentUnavailableView {
                                 Label("該当なし", systemImage: "line.3.horizontal.decrease.circle")
                                     .modifier(ThemedLabelModifier())
@@ -79,10 +68,10 @@ struct DayPageView: View {
                             }
                         }
                         .frame(maxWidth: 600)
-                        .frame(maxWidth: .infinity, minHeight: geo.size.height - headerHeight)
+                        .frame(maxWidth: .infinity, minHeight: geo.size.height - display.headerHeight)
                     } else {
                         MasonryLayout(entries: entries, availableWidth: geo.size.width - 32) { entry in
-                            MangaGridCell(entry: entry, viewModel: viewModel, hasWallpaper: hasWallpaper, reduceTransparency: reduceTransparency, isGridEditMode: $edit.isGridEditMode, editingEntry: $edit.editingEntry, onOpenURL: onOpenURL)
+                            MangaGridCell(entry: entry, viewModel: viewModel, hasWallpaper: display.hasWallpaper, reduceTransparency: display.reduceTransparency, isGridEditMode: $edit.isGridEditMode, editingEntry: $edit.editingEntry, commentingEntry: $commentingEntry, onOpenURL: onOpenURL)
                                 .overlay(alignment: .topLeading) {
                                     if edit.isGridEditMode {
                                         Button {
@@ -101,10 +90,9 @@ struct DayPageView: View {
                                 .modifier(WiggleModifier(isActive: edit.isGridEditMode))
                                 .onDrag {
                                     edit.draggingEntryID = entry.id
-                                    edit.draggingIsOneShot = entry.isOneShot
                                     return NSItemProvider(object: entry.id.uuidString as NSString)
                                 } preview: {
-                                    MangaGridCell(entry: entry, viewModel: viewModel, hasWallpaper: hasWallpaper, reduceTransparency: reduceTransparency, isGridEditMode: $edit.isGridEditMode, editingEntry: $edit.editingEntry, onOpenURL: onOpenURL)
+                                    MangaGridCell(entry: entry, viewModel: viewModel, hasWallpaper: display.hasWallpaper, reduceTransparency: display.reduceTransparency, isGridEditMode: $edit.isGridEditMode, editingEntry: $edit.editingEntry, onOpenURL: onOpenURL)
                                         .frame(width: 120)
                                 }
                                 .onDrop(of: [.text], delegate: GridDropDelegate(
@@ -118,7 +106,7 @@ struct DayPageView: View {
                         .padding()
                     }
                 }
-                .contentMargins(.top, headerHeight, for: .scrollContent)
+                .contentMargins(.top, display.headerHeight, for: .scrollContent)
                 .scrollContentBackground(.hidden)
                 .contentShape(Rectangle())
                 .simultaneousGesture(

--- a/MangaLauncher/Views/Home/DayPagerView.swift
+++ b/MangaLauncher/Views/Home/DayPagerView.swift
@@ -9,10 +9,13 @@ struct DayPagerView<PageContent: View>: View {
     var viewModel: MangaViewModel
     let pageContent: (DayOfWeek, MangaViewModel) -> PageContent
 
+    private var dayCount: Int { DayOfWeek.orderedDays.count }
+    private var totalPages: Int { dayCount + 2 } // +2 for wraparound
+
     var body: some View {
         #if os(iOS) || os(visionOS)
         TabView(selection: $paging.pageIndex) {
-            ForEach(0..<11, id: \.self) { index in
+            ForEach(0..<totalPages, id: \.self) { index in
                 pageContent(paging.dayForPageIndex(index), viewModel)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .tag(index)
@@ -27,13 +30,14 @@ struct DayPagerView<PageContent: View>: View {
                 selectedPublisher = nil
             }
 
+            // Wraparound: page 0 → last real page, page (count+1) → first real page
             if newValue == 0 {
                 DispatchQueue.main.asyncAfter(deadline: .now() + AnimationTiming.pageLoop) {
                     withAnimation(.none) {
-                        paging.pageIndex = 9
+                        paging.pageIndex = dayCount
                     }
                 }
-            } else if newValue == 10 {
+            } else if newValue == dayCount + 1 {
                 DispatchQueue.main.asyncAfter(deadline: .now() + AnimationTiming.pageLoop) {
                     withAnimation(.none) {
                         paging.pageIndex = 1

--- a/MangaLauncher/Views/Home/DayTabBarView.swift
+++ b/MangaLauncher/Views/Home/DayTabBarView.swift
@@ -30,7 +30,7 @@ struct DayTabBarView: View {
                     }
                 } label: {
                     let isSelected = currentDay == day
-                    let hasUnread = !day.isHiatus && !day.isCompleted && viewModel.unreadCount(for: day) > 0
+                    let hasUnread = viewModel.unreadCount(for: day) > 0
                     VStack(spacing: theme.tabItemSpacing) {
                         Text(day.shortName)
                             .font(theme.tabFont(isSelected))
@@ -39,7 +39,7 @@ struct DayTabBarView: View {
                                    height: theme.tabShowsTodayCircle ? 32 : nil)
                             .background {
                                 if theme.tabShowsTodayCircle {
-                                    if !day.isHiatus && !day.isCompleted && day == .today {
+                                    if day == .today {
                                         Circle().fill(theme.usesCustomSurface ? theme.primary : Color.accentColor)
                                     } else if hasWallpaper && isSelected {
                                         Circle().fill(Color.black.opacity(0.3))
@@ -70,13 +70,7 @@ struct DayTabBarView: View {
                 )
                 .onDrop(of: [.text], isTargeted: Binding(
                     get: { dropTargetDay == day },
-                    set: {
-                        if $0 && day.isHiatus && edit.draggingIsOneShot {
-                            dropTargetDay = nil
-                        } else {
-                            dropTargetDay = $0 ? day : nil
-                        }
-                    }
+                    set: { dropTargetDay = $0 ? day : nil }
                 )) { providers in
                     dropTargetDay = nil
                     if let draggingID = edit.draggingEntryID,
@@ -115,20 +109,17 @@ struct DayTabBarView: View {
     private func tabTextColor(day: DayOfWeek, isSelected: Bool) -> Color {
         if theme.forceDarkMode {
             if isSelected { return theme.secondary }
-            if !day.isHiatus && !day.isCompleted && day == .today { return theme.primary }
-            if day.isHiatus || day.isCompleted { return theme.onSurfaceVariant.opacity(0.5) }
+            if day == .today { return theme.primary }
             return theme.onSurfaceVariant
         } else if theme.usesCustomSurface {
             if isSelected { return theme.primary }
             if hasWallpaper && isSelected { return .white }
-            if !day.isHiatus && !day.isCompleted && day == .today { return theme.primary }
-            if day.isHiatus || day.isCompleted { return theme.onSurfaceVariant.opacity(0.5) }
+            if day == .today { return theme.primary }
             return theme.onSurface
         } else {
-            if !day.isHiatus && !day.isCompleted && day == .today { return .white }
+            if day == .today { return .white }
             if hasWallpaper && isSelected { return .white }
             if isSelected { return Color.accentColor }
-            if day.isHiatus || day.isCompleted { return .secondary }
             return .primary
         }
     }

--- a/MangaLauncher/Views/Library/ActivityRowView.swift
+++ b/MangaLauncher/Views/Library/ActivityRowView.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+
+/// 「最近のメモ・コメント」セクションで使う 1 行 UI。
+/// メモかコメントかで色とアイコンが切り替わる。
+struct ActivityRowView: View {
+    enum Kind { case memo, comment }
+
+    let kind: Kind
+    let title: String
+    let content: String
+    let timestamp: Date?
+
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
+    private var accentColor: Color {
+        switch kind {
+        case .memo: return .orange
+        case .comment: return .blue
+        }
+    }
+
+    private var iconName: String {
+        switch kind {
+        case .memo: return "note.text"
+        case .comment: return "bubble.left.fill"
+        }
+    }
+
+    private var kindLabel: String {
+        switch kind {
+        case .memo: return "メモ"
+        case .comment: return "コメント"
+        }
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 0) {
+            Rectangle()
+                .fill(accentColor)
+                .frame(width: 3)
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 6) {
+                    Image(systemName: iconName)
+                        .font(.caption2)
+                        .foregroundStyle(accentColor)
+                    Text(kindLabel)
+                        .font(.system(size: 9, weight: .bold))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 1)
+                        .background(accentColor)
+                        .clipShape(Capsule())
+                    Text(title)
+                        .font(theme.subheadlineFont.bold())
+                        .foregroundStyle(theme.onSurface)
+                        .lineLimit(1)
+                    Spacer()
+                    if let timestamp {
+                        Text(timestamp.formatted(.relative(presentation: .named)))
+                            .font(theme.caption2Font)
+                            .foregroundStyle(theme.onSurfaceVariant)
+                    }
+                }
+                Text(content)
+                    .font(theme.captionFont)
+                    .foregroundStyle(theme.onSurfaceVariant)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
+            }
+            .padding(10)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(theme.surfaceContainerHigh, in: RoundedRectangle(cornerRadius: 10))
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(accentColor.opacity(0.15), lineWidth: 0.5)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+    }
+}
+
+extension ActivityRowView {
+    /// ActivityItem から直接行を作る便利初期化
+    init(item: ActivityItem) {
+        switch item {
+        case .memo(let entry):
+            self.init(kind: .memo, title: entry.name, content: entry.memo, timestamp: entry.memoUpdatedAt)
+        case .comment(let comment, let entry):
+            self.init(kind: .comment, title: entry.name, content: comment.content, timestamp: comment.createdAt)
+        }
+    }
+}

--- a/MangaLauncher/Views/Library/AllActivityView.swift
+++ b/MangaLauncher/Views/Library/AllActivityView.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+/// ライブラリの「最近のメモ・コメント」セクションから「すべて表示」した先の画面。
+/// メモとコメントの全件を時系列ミックスで表示する。
+struct AllActivityView: View {
+    var viewModel: MangaViewModel
+    @Binding var editingEntry: MangaEntry?
+    @Binding var commentingEntry: MangaEntry?
+
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
+    private var items: [ActivityItem] {
+        let _ = viewModel.refreshCounter
+        return ActivityBuilder.all(
+            entries: viewModel.allEntries(),
+            comments: viewModel.allComments()
+        )
+    }
+
+    var body: some View {
+        ZStack {
+            if theme.usesCustomSurface {
+                theme.surface.ignoresSafeArea()
+            }
+            List {
+                ForEach(items) { item in
+                    Button {
+                        switch item {
+                        case .memo(let entry):
+                            editingEntry = entry
+                        case .comment(_, let entry):
+                            commentingEntry = entry
+                        }
+                    } label: {
+                        ActivityRowView(item: item)
+                    }
+                    .buttonStyle(.plain)
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
+                }
+            }
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+        }
+        .navigationTitle("メモ・コメント")
+        #if os(iOS) || os(visionOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+    }
+}

--- a/MangaLauncher/Views/Library/AllPublishersView.swift
+++ b/MangaLauncher/Views/Library/AllPublishersView.swift
@@ -1,0 +1,120 @@
+import SwiftUI
+
+/// ライブラリの「掲載誌別」セクションから「すべて表示」した先の画面。
+/// 全掲載誌を登録数の多い順に表示。タップで該当誌の作品一覧へ。
+struct AllPublishersView: View {
+    var viewModel: MangaViewModel
+    @Binding var editingEntry: MangaEntry?
+    @Binding var commentingEntry: MangaEntry?
+    let onOpenURL: (String) -> Void
+
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
+    private var publisherCounts: [(publisher: String, count: Int)] {
+        let _ = viewModel.refreshCounter
+        return PublisherIndex.counts(from: viewModel.allEntries())
+    }
+
+    var body: some View {
+        ZStack {
+            if theme.usesCustomSurface {
+                theme.surface.ignoresSafeArea()
+            }
+            List {
+                ForEach(publisherCounts, id: \.publisher) { item in
+                    NavigationLink(value: PublisherSelection(name: item.publisher)) {
+                        HStack {
+                            Image(systemName: "magazine")
+                                .foregroundStyle(theme.primary)
+                            Text(item.publisher)
+                                .font(theme.bodyFont)
+                                .foregroundStyle(theme.onSurface)
+                            Spacer()
+                            Text("\(item.count)")
+                                .font(.system(size: 12, weight: .bold))
+                                .foregroundStyle(theme.onPrimary)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 1)
+                                .background(theme.primary)
+                                .clipShape(Capsule())
+                        }
+                    }
+                    .listRowBackground(Color.clear)
+                }
+            }
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+        }
+        .navigationTitle("掲載誌")
+        #if os(iOS) || os(visionOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .navigationDestination(for: PublisherSelection.self) { selection in
+            PublisherEntriesView(
+                publisher: selection.name,
+                viewModel: viewModel,
+                editingEntry: $editingEntry,
+                commentingEntry: $commentingEntry,
+                onOpenURL: onOpenURL
+            )
+        }
+    }
+}
+
+struct PublisherSelection: Hashable {
+    let name: String
+}
+
+/// 個別の掲載誌に紐付くマンガ一覧画面
+struct PublisherEntriesView: View {
+    let publisher: String
+    var viewModel: MangaViewModel
+    @Binding var editingEntry: MangaEntry?
+    @Binding var commentingEntry: MangaEntry?
+    let onOpenURL: (String) -> Void
+
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
+    private var entries: [MangaEntry] {
+        let _ = viewModel.refreshCounter
+        return viewModel.allEntries().filter { $0.publisher == publisher }
+    }
+
+    var body: some View {
+        ZStack {
+            if theme.usesCustomSurface {
+                theme.surface.ignoresSafeArea()
+            }
+            List {
+                ForEach(entries, id: \.id) { entry in
+                    Button {
+                        onOpenURL(entry.url)
+                    } label: {
+                        HStack(spacing: 12) {
+                            EntryIcon(entry: entry, size: 40)
+                            Text(entry.name)
+                                .font(theme.bodyFont)
+                                .foregroundStyle(theme.onSurface)
+                            Spacer()
+                            Image(systemName: "chevron.right")
+                                .font(.caption)
+                                .foregroundStyle(theme.onSurfaceVariant.opacity(0.5))
+                        }
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .listRowBackground(Color.clear)
+                    .contextMenu {
+                        MangaContextMenu(entry: entry, viewModel: viewModel, editingEntry: $editingEntry, commentingEntry: $commentingEntry)
+                    }
+                }
+            }
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+        }
+        .navigationTitle(publisher)
+        #if os(iOS) || os(visionOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+    }
+}

--- a/MangaLauncher/Views/Library/LibraryCard.swift
+++ b/MangaLauncher/Views/Library/LibraryCard.swift
@@ -5,7 +5,7 @@ struct LibraryCard: View {
     let entry: MangaEntry
     var viewModel: MangaViewModel
     @Binding var editingEntry: MangaEntry?
-    var commentingEntry: Binding<MangaEntry?>? = nil
+    @Binding var commentingEntry: MangaEntry?
     let onOpenURL: (String) -> Void
 
     private var theme: ThemeStyle { ThemeManager.shared.style }
@@ -49,7 +49,7 @@ struct LibraryCard: View {
         }
         .buttonStyle(.plain)
         .contextMenu {
-            MangaContextMenu(entry: entry, viewModel: viewModel, editingEntry: $editingEntry, commentingEntry: commentingEntry)
+            MangaContextMenu(entry: entry, viewModel: viewModel, editingEntry: $editingEntry, commentingEntry: $commentingEntry)
         }
     }
 

--- a/MangaLauncher/Views/Library/LibraryCard.swift
+++ b/MangaLauncher/Views/Library/LibraryCard.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+import PlatformKit
+
+struct LibraryCard: View {
+    let entry: MangaEntry
+    var viewModel: MangaViewModel
+    @Binding var editingEntry: MangaEntry?
+    var commentingEntry: Binding<MangaEntry?>? = nil
+    let onOpenURL: (String) -> Void
+
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+    private let cardWidth: CGFloat = 130
+
+    var body: some View {
+        Button {
+            onOpenURL(entry.url)
+        } label: {
+            VStack(alignment: .leading, spacing: 6) {
+                cardImage
+                    .frame(width: cardWidth, height: cardWidth * 3 / 4)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .overlay(alignment: .topLeading) {
+                        if !entry.isRead {
+                            Circle()
+                                .fill(theme.badgeColor)
+                                .frame(width: 8, height: 8)
+                                .padding(6)
+                        }
+                    }
+                    .overlay(alignment: .bottomTrailing) {
+                        MangaStatusBadgeView(entry: entry, fontSize: 10)
+                            .padding(4)
+                    }
+
+                Text(entry.name)
+                    .font(theme.captionFont)
+                    .foregroundStyle(theme.onSurface)
+                    .lineLimit(1)
+                    .frame(width: cardWidth, alignment: .leading)
+
+                if !entry.publisher.isEmpty {
+                    Text(entry.publisher)
+                        .font(theme.caption2Font)
+                        .foregroundStyle(theme.onSurfaceVariant)
+                        .lineLimit(1)
+                        .frame(width: cardWidth, alignment: .leading)
+                }
+            }
+        }
+        .buttonStyle(.plain)
+        .contextMenu {
+            MangaContextMenu(entry: entry, viewModel: viewModel, editingEntry: $editingEntry, commentingEntry: commentingEntry)
+        }
+    }
+
+    @ViewBuilder
+    private var cardImage: some View {
+        if let imageData = entry.imageData, let image = imageData.toSwiftUIImage() {
+            image
+                .resizable()
+                .scaledToFill()
+        } else {
+            Color.fromName(entry.iconColor)
+                .overlay {
+                    Text(entry.name)
+                        .font(.headline.bold())
+                        .foregroundStyle(.white)
+                        .multilineTextAlignment(.center)
+                        .lineLimit(2)
+                        .padding(6)
+                }
+        }
+    }
+
+}

--- a/MangaLauncher/Views/Library/LibrarySection.swift
+++ b/MangaLauncher/Views/Library/LibrarySection.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+/// ライブラリ画面の各セクションを表すデータ構造
+struct LibrarySection: Identifiable {
+    let id = UUID()
+    let title: String
+    let icon: String?
+    let iconColor: Color?
+    let entries: [MangaEntry]
+    let totalCount: Int
+    let seeAll: LibraryDestination?
+
+    init(title: String, icon: String?, iconColor: Color? = nil, entries: [MangaEntry], totalCount: Int? = nil, seeAll: LibraryDestination? = nil) {
+        self.title = title
+        self.icon = icon
+        self.iconColor = iconColor
+        self.entries = entries
+        self.totalCount = totalCount ?? entries.count
+        self.seeAll = seeAll
+    }
+}
+
+/// ライブラリ画面内の navigationDestination 用の値型
+enum LibraryDestination: Hashable {
+    case allActivity
+    case allPublishers
+}

--- a/MangaLauncher/Views/Library/LibrarySection.swift
+++ b/MangaLauncher/Views/Library/LibrarySection.swift
@@ -2,7 +2,10 @@ import SwiftUI
 
 /// ライブラリ画面の各セクションを表すデータ構造
 struct LibrarySection: Identifiable {
-    let id = UUID()
+    /// セクションを一意に識別する stable ID（タイトルから導出）。
+    /// 再描画ごとに新しい UUID を生成すると ForEach/LazyVStack がセクションを
+    /// tear down してスクロール位置が失われるので、タイトルベースで固定する。
+    let id: String
     let title: String
     let icon: String?
     let iconColor: Color?
@@ -11,6 +14,7 @@ struct LibrarySection: Identifiable {
     let seeAll: LibraryDestination?
 
     init(title: String, icon: String?, iconColor: Color? = nil, entries: [MangaEntry], totalCount: Int? = nil, seeAll: LibraryDestination? = nil) {
+        self.id = title
         self.title = title
         self.icon = icon
         self.iconColor = iconColor

--- a/MangaLauncher/Views/Library/LibrarySectionBuilder.swift
+++ b/MangaLauncher/Views/Library/LibrarySectionBuilder.swift
@@ -132,12 +132,19 @@ struct LibrarySectionBuilder {
 
 /// 掲載誌ごとの集計を構築する純関数群。
 enum PublisherIndex {
-    /// 登録数の多い順に並べた (掲載誌, 件数) 配列
+    /// 登録数の多い順に並べた (掲載誌, 件数) 配列。
+    /// 同数の場合は掲載誌名の辞書順を tiebreaker に使うことで、
+    /// Dictionary の列挙順の非決定性に左右されない安定した順序を返す。
     static func counts(from entries: [MangaEntry]) -> [(publisher: String, count: Int)] {
         let grouped = Dictionary(grouping: entries.filter { !$0.publisher.isEmpty }) { $0.publisher }
             .mapValues { $0.count }
         return grouped
-            .sorted { $0.value > $1.value }
+            .sorted { lhs, rhs in
+                if lhs.value != rhs.value {
+                    return lhs.value > rhs.value
+                }
+                return lhs.key.localizedStandardCompare(rhs.key) == .orderedAscending
+            }
             .map { (publisher: $0.key, count: $0.value) }
     }
 }

--- a/MangaLauncher/Views/Library/LibrarySectionBuilder.swift
+++ b/MangaLauncher/Views/Library/LibrarySectionBuilder.swift
@@ -1,0 +1,143 @@
+import SwiftUI
+
+/// allEntries から LibrarySection の配列を組み立てる責務をライブラリ画面から分離。
+/// 各セクションごとに小さなメソッドに分かれており、追加・削除がしやすい。
+struct LibrarySectionBuilder {
+    let allEntries: [MangaEntry]
+
+    func build() -> [LibrarySection] {
+        var sections: [LibrarySection] = []
+        sections.append(contentsOf: [
+            recentSection(),
+            unreadSection(),
+            backlogSection(),
+        ].compactMap { $0 })
+        sections.append(contentsOf: colorLabelSections())
+        sections.append(contentsOf: [
+            serialSection(),
+            oneShotSection(),
+            hiatusSection(),
+            publicationFinishedSection(),
+            archivedSection(),
+        ].compactMap { $0 })
+        sections.append(contentsOf: publisherSections())
+        return sections
+    }
+
+    // MARK: - Sections
+
+    /// 最近読んだ（直近 2 週間）
+    private func recentSection() -> LibrarySection? {
+        let twoWeeksAgo = Calendar.current.date(byAdding: .day, value: -14, to: Date()) ?? .distantPast
+        let recent = allEntries
+            .filter { ($0.lastReadDate ?? .distantPast) >= twoWeeksAgo }
+            .sorted { ($0.lastReadDate ?? .distantPast) > ($1.lastReadDate ?? .distantPast) }
+        guard !recent.isEmpty else { return nil }
+        return LibrarySection(title: "最近読んだ", icon: "clock.arrow.circlepath", entries: recent)
+    }
+
+    /// 未読（追っかけ中・連載中のみ）
+    private func unreadSection() -> LibrarySection? {
+        let unread = allEntries.filter {
+            !$0.isRead
+                && $0.readingState == .following
+                && $0.publicationStatus == .active
+        }
+        guard !unread.isEmpty else { return nil }
+        return LibrarySection(title: "未読", icon: "envelope.badge", entries: unread)
+    }
+
+    /// 積読
+    private func backlogSection() -> LibrarySection? {
+        let backlog = allEntries.filter { $0.readingState == .backlog }
+        guard !backlog.isEmpty else { return nil }
+        return LibrarySection(title: "積読", icon: "books.vertical", entries: backlog)
+    }
+
+    /// カラーラベル別（ラベル設定済みのもののみ）
+    private func colorLabelSections() -> [LibrarySection] {
+        let colorLabels = ColorLabelStore.shared.labels
+        return MangaColor.all.compactMap { mangaColor in
+            guard let label = colorLabels[mangaColor.name], !label.isEmpty else { return nil }
+            let entries = allEntries.filter { $0.iconColor == mangaColor.name }
+            guard !entries.isEmpty else { return nil }
+            return LibrarySection(
+                title: label,
+                icon: "tag.fill",
+                iconColor: mangaColor.color,
+                entries: entries
+            )
+        }
+    }
+
+    /// 連載中（追っかけ中のみ）
+    private func serialSection() -> LibrarySection? {
+        let serial = allEntries.filter {
+            !$0.isOneShot
+                && $0.publicationStatus == .active
+                && $0.readingState == .following
+        }
+        guard !serial.isEmpty else { return nil }
+        return LibrarySection(title: "連載中", icon: "book", entries: serial)
+    }
+
+    /// 読み切り（読了以外）
+    private func oneShotSection() -> LibrarySection? {
+        let oneShot = allEntries.filter { $0.isOneShot && $0.readingState != .archived }
+        guard !oneShot.isEmpty else { return nil }
+        return LibrarySection(title: "読み切り", icon: "doc.text", entries: oneShot)
+    }
+
+    /// 休載中
+    private func hiatusSection() -> LibrarySection? {
+        let hiatus = allEntries.filter {
+            $0.publicationStatus == .hiatus && $0.readingState != .archived
+        }
+        guard !hiatus.isEmpty else { return nil }
+        return LibrarySection(title: "休載中", icon: "moon.zzz", entries: hiatus)
+    }
+
+    /// 完結（掲載が完結している作品。読了アーカイブとは別軸）
+    private func publicationFinishedSection() -> LibrarySection? {
+        let finished = allEntries.filter {
+            $0.publicationStatus == .finished && $0.readingState != .archived
+        }
+        guard !finished.isEmpty else { return nil }
+        return LibrarySection(title: "完結", icon: "flag.checkered", entries: finished)
+    }
+
+    /// 読了（読書アーカイブ）
+    private func archivedSection() -> LibrarySection? {
+        let archived = allEntries.filter { $0.readingState == .archived }
+        guard !archived.isEmpty else { return nil }
+        return LibrarySection(title: "読了", icon: "checkmark.seal", entries: archived)
+    }
+
+    /// 掲載誌別（登録数の多い順、上位5誌のみ。最初のセクションだけに「すべて表示」を付ける）
+    private func publisherSections() -> [LibrarySection] {
+        let sortedPublishers = PublisherIndex.counts(from: allEntries)
+        let hasMore = sortedPublishers.count > 5
+        return sortedPublishers.prefix(5).enumerated().compactMap { (index, item) -> LibrarySection? in
+            let entries = allEntries.filter { $0.publisher == item.publisher }
+            guard !entries.isEmpty else { return nil }
+            return LibrarySection(
+                title: item.publisher,
+                icon: "magazine",
+                entries: entries,
+                seeAll: (index == 0 && hasMore) ? .allPublishers : nil
+            )
+        }
+    }
+}
+
+/// 掲載誌ごとの集計を構築する純関数群。
+enum PublisherIndex {
+    /// 登録数の多い順に並べた (掲載誌, 件数) 配列
+    static func counts(from entries: [MangaEntry]) -> [(publisher: String, count: Int)] {
+        let grouped = Dictionary(grouping: entries.filter { !$0.publisher.isEmpty }) { $0.publisher }
+            .mapValues { $0.count }
+        return grouped
+            .sorted { $0.value > $1.value }
+            .map { (publisher: $0.key, count: $0.value) }
+    }
+}

--- a/MangaLauncher/Views/Library/LibrarySectionBuilder.swift
+++ b/MangaLauncher/Views/Library/LibrarySectionBuilder.swift
@@ -81,27 +81,23 @@ struct LibrarySectionBuilder {
         return LibrarySection(title: "連載中", icon: "book", entries: serial)
     }
 
-    /// 読み切り（読了以外）
+    /// 読み切り（読書状況に関係なく全て。読了と重複表示 OK）
     private func oneShotSection() -> LibrarySection? {
-        let oneShot = allEntries.filter { $0.isOneShot && $0.readingState != .archived }
+        let oneShot = allEntries.filter { $0.isOneShot }
         guard !oneShot.isEmpty else { return nil }
         return LibrarySection(title: "読み切り", icon: "doc.text", entries: oneShot)
     }
 
-    /// 休載中
+    /// 休載中（読書状況に関係なく全て。読了と重複表示 OK）
     private func hiatusSection() -> LibrarySection? {
-        let hiatus = allEntries.filter {
-            $0.publicationStatus == .hiatus && $0.readingState != .archived
-        }
+        let hiatus = allEntries.filter { $0.publicationStatus == .hiatus }
         guard !hiatus.isEmpty else { return nil }
         return LibrarySection(title: "休載中", icon: "moon.zzz", entries: hiatus)
     }
 
-    /// 完結（掲載が完結している作品。読了アーカイブとは別軸）
+    /// 完結（読書状況に関係なく全て。読了と重複表示 OK）
     private func publicationFinishedSection() -> LibrarySection? {
-        let finished = allEntries.filter {
-            $0.publicationStatus == .finished && $0.readingState != .archived
-        }
+        let finished = allEntries.filter { $0.publicationStatus == .finished }
         guard !finished.isEmpty else { return nil }
         return LibrarySection(title: "完結", icon: "flag.checkered", entries: finished)
     }

--- a/MangaLauncher/Views/Library/LibraryView.swift
+++ b/MangaLauncher/Views/Library/LibraryView.swift
@@ -3,10 +3,9 @@ import SwiftData
 import PlatformKit
 
 struct LibraryView: View {
-    @Environment(\.modelContext) private var modelContext
     @Environment(\.openURL) private var openURL
 
-    @State private var viewModel: MangaViewModel?
+    var viewModel: MangaViewModel
     @State private var editingEntry: MangaEntry?
     @State private var commentingEntry: MangaEntry?
     @State private var safariURL: URL?
@@ -23,9 +22,7 @@ struct LibraryView: View {
                         .ignoresSafeArea()
                 }
 
-                if let viewModel {
-                    content(viewModel: viewModel)
-                }
+                content(viewModel: viewModel)
             }
             .navigationTitle("ライブラリ")
             #if os(iOS) || os(visionOS)
@@ -41,19 +38,13 @@ struct LibraryView: View {
                 }
             }
             .sheet(isPresented: $showingAddSheet) {
-                if let viewModel {
-                    EditEntryView(viewModel: viewModel, day: .today)
-                }
+                EditEntryView(viewModel: viewModel, day: .today)
             }
             .sheet(item: $editingEntry) { entry in
-                if let viewModel {
-                    EditEntryView(viewModel: viewModel, entry: entry)
-                }
+                EditEntryView(viewModel: viewModel, entry: entry)
             }
             .sheet(item: $commentingEntry) { entry in
-                if let viewModel {
-                    CommentListView(entry: entry, viewModel: viewModel)
-                }
+                CommentListView(entry: entry, viewModel: viewModel)
             }
             #if canImport(UIKit)
             .sheet(item: $safariURL) { url in
@@ -62,13 +53,8 @@ struct LibraryView: View {
             }
             #endif
         }
-        .onAppear {
-            if viewModel == nil {
-                viewModel = MangaViewModel(modelContext: modelContext)
-            }
-        }
         .onMangaDataChange {
-            viewModel?.refresh()
+            viewModel.refresh()
         }
     }
 

--- a/MangaLauncher/Views/Library/LibraryView.swift
+++ b/MangaLauncher/Views/Library/LibraryView.swift
@@ -1,0 +1,197 @@
+import SwiftUI
+import SwiftData
+import PlatformKit
+
+struct LibraryView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.openURL) private var openURL
+
+    @State private var viewModel: MangaViewModel?
+    @State private var editingEntry: MangaEntry?
+    @State private var commentingEntry: MangaEntry?
+    @State private var safariURL: URL?
+    @State private var showingAddSheet = false
+    @AppStorage("browserMode") private var browserMode: String = "external"
+
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                if ThemeManager.shared.style.usesCustomSurface {
+                    ThemeManager.shared.style.surface
+                        .ignoresSafeArea()
+                }
+
+                if let viewModel {
+                    content(viewModel: viewModel)
+                }
+            }
+            .navigationTitle("ライブラリ")
+            #if os(iOS) || os(visionOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        showingAddSheet = true
+                    } label: {
+                        Image(systemName: "plus")
+                    }
+                }
+            }
+            .sheet(isPresented: $showingAddSheet) {
+                if let viewModel {
+                    EditEntryView(viewModel: viewModel, day: .today)
+                }
+            }
+            .sheet(item: $editingEntry) { entry in
+                if let viewModel {
+                    EditEntryView(viewModel: viewModel, entry: entry)
+                }
+            }
+            .sheet(item: $commentingEntry) { entry in
+                if let viewModel {
+                    CommentListView(entry: entry, viewModel: viewModel)
+                }
+            }
+            #if canImport(UIKit)
+            .sheet(item: $safariURL) { url in
+                SafariView(url: url)
+                    .ignoresSafeArea()
+            }
+            #endif
+        }
+        .onAppear {
+            if viewModel == nil {
+                viewModel = MangaViewModel(modelContext: modelContext)
+            }
+        }
+        .onMangaDataChange {
+            viewModel?.refresh()
+        }
+    }
+
+    @ViewBuilder
+    private func content(viewModel: MangaViewModel) -> some View {
+        let _ = viewModel.refreshCounter
+        // 1 度だけ fetch して使い回す（N+1 fetch を避ける）
+        let allEntries = viewModel.allEntries()
+        let allComments = viewModel.allComments()
+        let sections = LibrarySectionBuilder(allEntries: allEntries).build()
+        let recentActivity = ActivityBuilder.recent(entries: allEntries, comments: allComments, limit: 8)
+        let totalActivityCount = ActivityBuilder.totalCount(entries: allEntries, comments: allComments)
+
+        if sections.isEmpty && recentActivity.isEmpty {
+            ContentUnavailableView {
+                Label("ライブラリは空です", systemImage: "books.vertical")
+                    .foregroundStyle(theme.onSurfaceVariant)
+            } description: {
+                Text("マンガを追加するとここに表示されます")
+                    .foregroundStyle(theme.onSurfaceVariant.opacity(0.7))
+            }
+        } else {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 24) {
+                    if !recentActivity.isEmpty {
+                        recentActivitySection(items: recentActivity, totalCount: totalActivityCount)
+                    }
+                    ForEach(sections) { section in
+                        sectionView(section: section, viewModel: viewModel)
+                    }
+                }
+                .padding(.vertical)
+            }
+            .navigationDestination(for: LibraryDestination.self) { destination in
+                libraryDestinationView(destination, viewModel: viewModel)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func libraryDestinationView(_ destination: LibraryDestination, viewModel: MangaViewModel) -> some View {
+        switch destination {
+        case .allActivity:
+            AllActivityView(
+                viewModel: viewModel,
+                editingEntry: $editingEntry,
+                commentingEntry: $commentingEntry
+            )
+        case .allPublishers:
+            AllPublishersView(
+                viewModel: viewModel,
+                editingEntry: $editingEntry,
+                commentingEntry: $commentingEntry,
+                onOpenURL: { openMangaURL($0) }
+            )
+        }
+    }
+
+    @ViewBuilder
+    private func recentActivitySection(items: [ActivityItem], totalCount: Int) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            SectionHeaderView(
+                title: "最近のメモ・コメント",
+                icon: "square.and.pencil",
+                iconColor: .purple,
+                count: totalCount,
+                badgeColor: .purple,
+                seeAll: totalCount > items.count ? LibraryDestination.allActivity : nil
+            )
+            .padding(.horizontal)
+
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach(items) { item in
+                    activityRow(item)
+                }
+            }
+            .padding(.horizontal)
+        }
+    }
+
+    @ViewBuilder
+    private func activityRow(_ item: ActivityItem) -> some View {
+        Button {
+            switch item {
+            case .memo(let entry): editingEntry = entry
+            case .comment(_, let entry): commentingEntry = entry
+            }
+        } label: {
+            ActivityRowView(item: item)
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private func sectionView(section: LibrarySection, viewModel: MangaViewModel) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            SectionHeaderView(
+                title: section.title,
+                icon: section.icon,
+                iconColor: section.iconColor,
+                count: section.totalCount,
+                seeAll: section.seeAll
+            )
+            .padding(.horizontal)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(alignment: .top, spacing: 12) {
+                    ForEach(section.entries, id: \.id) { entry in
+                        LibraryCard(
+                            entry: entry,
+                            viewModel: viewModel,
+                            editingEntry: $editingEntry,
+                            commentingEntry: $commentingEntry,
+                            onOpenURL: { openMangaURL($0) }
+                        )
+                    }
+                }
+                .padding(.horizontal)
+            }
+        }
+    }
+
+    private func openMangaURL(_ urlString: String) {
+        MangaURLOpener(browserMode: browserMode, openURL: openURL) { safariURL = $0 }.open(urlString)
+    }
+}

--- a/MangaLauncher/Views/MangaCell/MangaContextMenu.swift
+++ b/MangaLauncher/Views/MangaCell/MangaContextMenu.swift
@@ -4,7 +4,7 @@ struct MangaContextMenu: View {
     let entry: MangaEntry
     var viewModel: MangaViewModel
     @Binding var editingEntry: MangaEntry?
-    var commentingEntry: Binding<MangaEntry?>? = nil
+    @Binding var commentingEntry: MangaEntry?
     var onReorder: (() -> Void)? = nil
 
     var body: some View {
@@ -33,12 +33,10 @@ struct MangaContextMenu: View {
             Label("編集", systemImage: "pencil")
         }
 
-        if let commentingEntry {
-            Button {
-                commentingEntry.wrappedValue = entry
-            } label: {
-                Label("コメント", systemImage: "bubble.left.and.bubble.right")
-            }
+        Button {
+            commentingEntry = entry
+        } label: {
+            Label("コメント", systemImage: "bubble.left.and.bubble.right")
         }
 
         if let onReorder {

--- a/MangaLauncher/Views/MangaCell/MangaContextMenu.swift
+++ b/MangaLauncher/Views/MangaCell/MangaContextMenu.swift
@@ -4,10 +4,12 @@ struct MangaContextMenu: View {
     let entry: MangaEntry
     var viewModel: MangaViewModel
     @Binding var editingEntry: MangaEntry?
-    var onReorder: () -> Void
+    var commentingEntry: Binding<MangaEntry?>? = nil
+    var onReorder: (() -> Void)? = nil
 
     var body: some View {
-        if !entry.isOnHiatus {
+        // 既読/未読トグル（休載・読了は対象外）
+        if entry.publicationStatus != .hiatus && entry.readingState != .archived {
             Button {
                 if entry.isRead {
                     viewModel.markAsUnread(entry)
@@ -15,34 +17,81 @@ struct MangaContextMenu: View {
                     viewModel.markAsRead(entry)
                 }
             } label: {
-                Label(entry.isRead ? "未読にする" : "既読にする",
-                      systemImage: entry.isRead ? "envelope.badge" : "envelope.open")
+                if entry.readingState == .backlog {
+                    Label(entry.isRead ? "取り消す" : "今日読んだ",
+                          systemImage: entry.isRead ? "arrow.uturn.backward" : "checkmark")
+                } else {
+                    Label(entry.isRead ? "未読にする" : "既読にする",
+                          systemImage: entry.isRead ? "envelope.badge" : "envelope.open")
+                }
             }
         }
+
         Button {
             editingEntry = entry
         } label: {
             Label("編集", systemImage: "pencil")
         }
-        Button {
-            onReorder()
-        } label: {
-            Label("並び替え", systemImage: "arrow.up.arrow.down")
-        }
-        if !entry.isOneShot {
+
+        if let commentingEntry {
             Button {
-                viewModel.toggleHiatus(entry)
+                commentingEntry.wrappedValue = entry
             } label: {
-                Label(entry.isOnHiatus ? "連載に戻す" : "休載中にする",
-                      systemImage: entry.isOnHiatus ? "arrow.uturn.left" : "moon.zzz")
+                Label("コメント", systemImage: "bubble.left.and.bubble.right")
             }
         }
-        Button {
-            viewModel.toggleCompleted(entry)
-        } label: {
-            Label(entry.isCompleted ? (entry.isOneShot ? "元の曜日に戻す" : "連載に戻す") : "完結にする",
-                  systemImage: entry.isCompleted ? "arrow.uturn.left" : "checkmark.seal")
+
+        if let onReorder {
+            Button {
+                onReorder()
+            } label: {
+                Label("並び替え", systemImage: "arrow.up.arrow.down")
+            }
         }
+
+        // 積読 → 追っかけ中（追いついた）
+        if entry.readingState == .backlog {
+            Button {
+                viewModel.setReadingState(entry, to: .following)
+            } label: {
+                Label("追いついた", systemImage: "checkmark.circle")
+            }
+        }
+
+        // 掲載状況の変更（読み切り・読了は対象外）
+        if !entry.isOneShot && entry.readingState != .archived {
+            if entry.publicationStatus != .active {
+                Button {
+                    viewModel.setPublicationStatus(entry, to: .active)
+                } label: {
+                    Label("連載に戻す", systemImage: "arrow.uturn.left")
+                }
+            }
+            if entry.publicationStatus != .hiatus {
+                Button {
+                    viewModel.setPublicationStatus(entry, to: .hiatus)
+                } label: {
+                    Label("休載中にする", systemImage: "moon.zzz")
+                }
+            }
+            if entry.publicationStatus != .finished {
+                Button {
+                    viewModel.setPublicationStatus(entry, to: .finished)
+                } label: {
+                    Label("完結にする", systemImage: "flag.checkered")
+                }
+            }
+        }
+
+        // 読了 ↔ 戻す
+        Button {
+            let newState: ReadingState = entry.readingState == .archived ? .following : .archived
+            viewModel.setReadingState(entry, to: newState)
+        } label: {
+            Label(entry.readingState == .archived ? "読了を取り消す" : "読了にする",
+                  systemImage: entry.readingState == .archived ? "arrow.uturn.left" : "checkmark.seal")
+        }
+
         Button(role: .destructive) {
             viewModel.queueDelete(entry)
         } label: {

--- a/MangaLauncher/Views/MangaCell/MangaContextMenu.swift
+++ b/MangaLauncher/Views/MangaCell/MangaContextMenu.swift
@@ -18,7 +18,7 @@ struct MangaContextMenu: View {
                 }
             } label: {
                 if entry.readingState == .backlog {
-                    Label(entry.isRead ? "取り消す" : "今日読んだ",
+                    Label(entry.isRead ? "今日読んだを取り消す" : "今日読んだ",
                           systemImage: entry.isRead ? "arrow.uturn.backward" : "checkmark")
                 } else {
                     Label(entry.isRead ? "未読にする" : "既読にする",

--- a/MangaLauncher/Views/MangaCell/MangaGridCell.swift
+++ b/MangaLauncher/Views/MangaCell/MangaGridCell.swift
@@ -8,7 +8,7 @@ struct MangaGridCell: View {
     let reduceTransparency: Bool
     @Binding var isGridEditMode: Bool
     @Binding var editingEntry: MangaEntry?
-    var commentingEntry: Binding<MangaEntry?>? = nil
+    @Binding var commentingEntry: MangaEntry?
     let onOpenURL: (String) -> Void
 
     private var theme: ThemeStyle { ThemeManager.shared.style }
@@ -83,7 +83,7 @@ struct MangaGridCell: View {
                 }
             }
             .contextMenu {
-                MangaContextMenu(entry: entry, viewModel: viewModel, editingEntry: $editingEntry, commentingEntry: commentingEntry) {
+                MangaContextMenu(entry: entry, viewModel: viewModel, editingEntry: $editingEntry, commentingEntry: $commentingEntry) {
                     withAnimation(.easeInOut(duration: 0.2)) {
                         isGridEditMode = true
                     }

--- a/MangaLauncher/Views/MangaCell/MangaGridCell.swift
+++ b/MangaLauncher/Views/MangaCell/MangaGridCell.swift
@@ -8,6 +8,7 @@ struct MangaGridCell: View {
     let reduceTransparency: Bool
     @Binding var isGridEditMode: Bool
     @Binding var editingEntry: MangaEntry?
+    var commentingEntry: Binding<MangaEntry?>? = nil
     let onOpenURL: (String) -> Void
 
     private var theme: ThemeStyle { ThemeManager.shared.style }
@@ -82,7 +83,7 @@ struct MangaGridCell: View {
                 }
             }
             .contextMenu {
-                MangaContextMenu(entry: entry, viewModel: viewModel, editingEntry: $editingEntry) {
+                MangaContextMenu(entry: entry, viewModel: viewModel, editingEntry: $editingEntry, commentingEntry: commentingEntry) {
                     withAnimation(.easeInOut(duration: 0.2)) {
                         isGridEditMode = true
                     }

--- a/MangaLauncher/Views/MangaCell/MangaListView.swift
+++ b/MangaLauncher/Views/MangaCell/MangaListView.swift
@@ -9,6 +9,7 @@ struct MangaListView: View {
     let reduceTransparency: Bool
     let headerHeight: CGFloat
     @Binding var editingEntry: MangaEntry?
+    @Binding var commentingEntry: MangaEntry?
     #if os(iOS) || os(visionOS)
     @Binding var listEditMode: EditMode
     #endif
@@ -19,7 +20,7 @@ struct MangaListView: View {
     var body: some View {
         List {
             ForEach(entries, id: \.id) { entry in
-                MangaRowCell(entry: entry, viewModel: viewModel, hasWallpaper: hasWallpaper, reduceTransparency: reduceTransparency, editingEntry: $editingEntry, listEditMode: $listEditMode, onOpenURL: onOpenURL)
+                MangaRowCell(entry: entry, viewModel: viewModel, hasWallpaper: hasWallpaper, reduceTransparency: reduceTransparency, editingEntry: $editingEntry, commentingEntry: $commentingEntry, listEditMode: $listEditMode, onOpenURL: onOpenURL)
             }
             .onDelete { indexSet in
                 let entriesToDelete = indexSet.map { entries[$0] }

--- a/MangaLauncher/Views/MangaCell/MangaRowCell.swift
+++ b/MangaLauncher/Views/MangaCell/MangaRowCell.swift
@@ -7,7 +7,7 @@ struct MangaRowCell: View {
     let hasWallpaper: Bool
     let reduceTransparency: Bool
     @Binding var editingEntry: MangaEntry?
-    var commentingEntry: Binding<MangaEntry?>? = nil
+    @Binding var commentingEntry: MangaEntry?
     #if os(iOS) || os(visionOS)
     @Binding var listEditMode: EditMode
     #endif
@@ -139,7 +139,7 @@ struct MangaRowCell: View {
                 }
             )
             .contextMenu {
-                MangaContextMenu(entry: entry, viewModel: viewModel, editingEntry: $editingEntry, commentingEntry: commentingEntry) {
+                MangaContextMenu(entry: entry, viewModel: viewModel, editingEntry: $editingEntry, commentingEntry: $commentingEntry) {
                     #if os(iOS) || os(visionOS)
                     withAnimation(.easeInOut(duration: 0.2)) {
                         listEditMode = .active

--- a/MangaLauncher/Views/MangaCell/MangaRowCell.swift
+++ b/MangaLauncher/Views/MangaCell/MangaRowCell.swift
@@ -7,6 +7,7 @@ struct MangaRowCell: View {
     let hasWallpaper: Bool
     let reduceTransparency: Bool
     @Binding var editingEntry: MangaEntry?
+    var commentingEntry: Binding<MangaEntry?>? = nil
     #if os(iOS) || os(visionOS)
     @Binding var listEditMode: EditMode
     #endif
@@ -138,7 +139,7 @@ struct MangaRowCell: View {
                 }
             )
             .contextMenu {
-                MangaContextMenu(entry: entry, viewModel: viewModel, editingEntry: $editingEntry) {
+                MangaContextMenu(entry: entry, viewModel: viewModel, editingEntry: $editingEntry, commentingEntry: commentingEntry) {
                     #if os(iOS) || os(visionOS)
                     withAnimation(.easeInOut(duration: 0.2)) {
                         listEditMode = .active

--- a/MangaLauncher/Views/RootTabView.swift
+++ b/MangaLauncher/Views/RootTabView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+struct RootTabView: View {
+    @Environment(\.modelContext) private var modelContext
+    @State private var settingsViewModel: MangaViewModel?
+
+    var body: some View {
+        TabView {
+            Tab("ホーム", systemImage: "house.fill") {
+                ContentView()
+            }
+
+            Tab("ライブラリ", systemImage: "books.vertical.fill") {
+                LibraryView()
+            }
+
+            Tab("設定", systemImage: "gearshape.fill") {
+                if let settingsViewModel {
+                    SettingsView(viewModel: settingsViewModel, showsCloseButton: false)
+                }
+            }
+
+            Tab(role: .search) {
+                SearchView()
+            }
+        }
+        .onAppear {
+            if settingsViewModel == nil {
+                settingsViewModel = MangaViewModel(modelContext: modelContext)
+            }
+        }
+    }
+}

--- a/MangaLauncher/Views/RootTabView.swift
+++ b/MangaLauncher/Views/RootTabView.swift
@@ -1,33 +1,34 @@
 import SwiftUI
 
 struct RootTabView: View {
-    @Environment(\.modelContext) private var modelContext
-    @State private var settingsViewModel: MangaViewModel?
+    var viewModel: MangaViewModel
 
     var body: some View {
         TabView {
             Tab("ホーム", systemImage: "house.fill") {
-                ContentView()
+                ContentView(viewModel: viewModel)
             }
 
             Tab("ライブラリ", systemImage: "books.vertical.fill") {
-                LibraryView()
+                LibraryView(viewModel: viewModel)
             }
 
             Tab("設定", systemImage: "gearshape.fill") {
-                if let settingsViewModel {
-                    SettingsView(viewModel: settingsViewModel, showsCloseButton: false)
-                }
+                SettingsView(viewModel: viewModel, showsCloseButton: false)
             }
 
             Tab(role: .search) {
-                SearchView()
+                SearchView(viewModel: viewModel)
             }
         }
-        .onAppear {
-            if settingsViewModel == nil {
-                settingsViewModel = MangaViewModel(modelContext: modelContext)
+        // どのタブから削除してもトーストが表示されるように全体 overlay で保持
+        .overlay(alignment: .bottom) {
+            if !viewModel.pendingDeleteEntries.isEmpty {
+                DeleteToastView(viewModel: viewModel)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                    .padding(.bottom, 80) // ボトムタブを避ける
             }
         }
+        .animation(.easeInOut(duration: 0.3), value: viewModel.pendingDeleteEntries.isEmpty)
     }
 }

--- a/MangaLauncher/Views/Search/CommentMatchRow.swift
+++ b/MangaLauncher/Views/Search/CommentMatchRow.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+/// 検索結果「コメント」セクションの 1 行。タップで該当作品の CommentListView へ。
+struct CommentMatchRow: View {
+    let comment: MangaComment
+    let entry: MangaEntry
+    let query: String
+    @Binding var commentingEntry: MangaEntry?
+
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
+    var body: some View {
+        Button {
+            commentingEntry = entry
+        } label: {
+            HStack(alignment: .top, spacing: 12) {
+                EntryIcon(entry: entry, size: 36)
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(spacing: 6) {
+                        Text(entry.name)
+                            .font(theme.subheadlineFont.bold())
+                            .foregroundStyle(theme.onSurface)
+                            .lineLimit(1)
+                        Spacer()
+                        Text(comment.createdAt.formatted(.relative(presentation: .named)))
+                            .font(theme.caption2Font)
+                            .foregroundStyle(theme.onSurfaceVariant)
+                    }
+                    Text(SearchSnippet.make(from: comment.content, query: query))
+                        .font(theme.captionFont)
+                        .foregroundStyle(theme.onSurfaceVariant)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.leading)
+                }
+                Image(systemName: "bubble.left")
+                    .font(.caption)
+                    .foregroundStyle(theme.onSurfaceVariant.opacity(0.5))
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .listRowBackground(Color.clear)
+    }
+}

--- a/MangaLauncher/Views/Search/CommentMatchRow.swift
+++ b/MangaLauncher/Views/Search/CommentMatchRow.swift
@@ -40,5 +40,6 @@ struct CommentMatchRow: View {
         }
         .buttonStyle(.plain)
         .listRowBackground(Color.clear)
+        .listRowSeparator(.hidden)
     }
 }

--- a/MangaLauncher/Views/Search/MemoMatchRow.swift
+++ b/MangaLauncher/Views/Search/MemoMatchRow.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+/// 検索結果「メモ」セクションの 1 行。タップで編集画面へ。
+struct MemoMatchRow: View {
+    let entry: MangaEntry
+    let query: String
+    @Binding var editingEntry: MangaEntry?
+
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
+    var body: some View {
+        Button {
+            editingEntry = entry
+        } label: {
+            HStack(alignment: .top, spacing: 12) {
+                EntryIcon(entry: entry, size: 36)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(entry.name)
+                        .font(theme.subheadlineFont.bold())
+                        .foregroundStyle(theme.onSurface)
+                        .lineLimit(1)
+                    Text(SearchSnippet.make(from: entry.memo, query: query))
+                        .font(theme.captionFont)
+                        .foregroundStyle(theme.onSurfaceVariant)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.leading)
+                }
+                Spacer()
+                Image(systemName: "note.text")
+                    .font(.caption)
+                    .foregroundStyle(theme.onSurfaceVariant.opacity(0.5))
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .listRowBackground(Color.clear)
+    }
+}

--- a/MangaLauncher/Views/Search/MemoMatchRow.swift
+++ b/MangaLauncher/Views/Search/MemoMatchRow.swift
@@ -34,5 +34,6 @@ struct MemoMatchRow: View {
         }
         .buttonStyle(.plain)
         .listRowBackground(Color.clear)
+        .listRowSeparator(.hidden)
     }
 }

--- a/MangaLauncher/Views/Search/SearchResultRow.swift
+++ b/MangaLauncher/Views/Search/SearchResultRow.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+
+/// 検索結果「マンガ」セクションの 1 行
+struct SearchResultRow: View {
+    let entry: MangaEntry
+    var viewModel: MangaViewModel
+    @Binding var editingEntry: MangaEntry?
+    @Binding var commentingEntry: MangaEntry?
+    let onOpenURL: (String) -> Void
+
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
+    var body: some View {
+        Button {
+            onOpenURL(entry.url)
+        } label: {
+            HStack(spacing: 12) {
+                EntryIcon(entry: entry, size: 44)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(spacing: 6) {
+                        if !entry.isRead {
+                            Circle()
+                                .fill(theme.badgeColor)
+                                .frame(width: 6, height: 6)
+                        }
+                        Text(entry.name)
+                            .font(theme.bodyFont)
+                            .foregroundStyle(theme.onSurface)
+                            .lineLimit(1)
+                    }
+
+                    HStack(spacing: 6) {
+                        if !entry.publisher.isEmpty {
+                            Text(entry.publisher)
+                                .font(theme.captionFont)
+                                .foregroundStyle(theme.onSurfaceVariant)
+                        }
+                        MangaStatusBadgeView(entry: entry, fontSize: 9)
+                        if !hasAnyStatus(entry) {
+                            dayBadge(entry.dayOfWeek.shortName)
+                        }
+                    }
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundStyle(theme.onSurfaceVariant.opacity(0.5))
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .listRowBackground(Color.clear)
+        .contextMenu {
+            MangaContextMenu(entry: entry, viewModel: viewModel, editingEntry: $editingEntry, commentingEntry: $commentingEntry)
+        }
+    }
+
+    /// マンガに状態バッジが付くか（連載追っかけ中なら付かない）
+    private func hasAnyStatus(_ entry: MangaEntry) -> Bool {
+        entry.readingState == .archived
+            || entry.publicationStatus == .finished
+            || entry.publicationStatus == .hiatus
+            || entry.readingState == .backlog
+            || entry.isOneShot
+    }
+
+    private func dayBadge(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 9, weight: .bold))
+            .foregroundStyle(.white)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 2)
+            .background(theme.onSurfaceVariant.opacity(0.5))
+            .clipShape(RoundedRectangle(cornerRadius: 3))
+    }
+}

--- a/MangaLauncher/Views/Search/SearchResultRow.swift
+++ b/MangaLauncher/Views/Search/SearchResultRow.swift
@@ -53,6 +53,7 @@ struct SearchResultRow: View {
         }
         .buttonStyle(.plain)
         .listRowBackground(Color.clear)
+        .listRowSeparator(.hidden)
         .contextMenu {
             MangaContextMenu(entry: entry, viewModel: viewModel, editingEntry: $editingEntry, commentingEntry: $commentingEntry)
         }

--- a/MangaLauncher/Views/Search/SearchSnippet.swift
+++ b/MangaLauncher/Views/Search/SearchSnippet.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// 検索クエリのマッチ箇所周辺を抜き出して短い断片を返す。
+/// 長文のメモやコメントから「ヒット箇所はこの辺」を可視化するために使う。
+enum SearchSnippet {
+    static func make(from text: String, query: String, padding: Int = 20) -> String {
+        guard !query.isEmpty,
+              let range = text.range(of: query, options: .caseInsensitive) else {
+            return text
+        }
+        let lowerOffset = text.distance(from: text.startIndex, to: range.lowerBound)
+        let startOffset = max(0, lowerOffset - padding)
+        let startIndex = text.index(text.startIndex, offsetBy: startOffset)
+        let prefix = startOffset > 0 ? "…" : ""
+        let snippet = text[startIndex...]
+        return prefix + String(snippet)
+    }
+}

--- a/MangaLauncher/Views/Search/SearchView.swift
+++ b/MangaLauncher/Views/Search/SearchView.swift
@@ -178,7 +178,7 @@ struct SearchView: View {
             #if os(iOS) || os(visionOS)
             .navigationBarTitleDisplayMode(.inline)
             #endif
-            .searchable(text: $searchText, prompt: "マンガ名・掲載誌で検索")
+            .searchable(text: $searchText, prompt: "マンガ・メモ・コメントを検索")
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     Menu {

--- a/MangaLauncher/Views/Search/SearchView.swift
+++ b/MangaLauncher/Views/Search/SearchView.swift
@@ -7,7 +7,13 @@ struct SearchView: View {
 
     var viewModel: MangaViewModel
     @State private var searchText: String = ""
-    @State private var selectedScope: SearchScope = .all
+
+    // MARK: - 2 軸フィルタ（各グループ内は単一選択）
+    @State private var publicationFilter: PublicationStatus? = nil
+    @State private var readingFilter: ReadingState? = nil
+    @State private var showOneShotOnly = false
+    @State private var contentMode: SearchContentMode = .entries
+
     @State private var selectedDay: DayOfWeek? = nil
     @State private var selectedColors: Set<String> = []
     @State private var safariURL: URL?
@@ -16,70 +22,40 @@ struct SearchView: View {
     @AppStorage("browserMode") private var browserMode: String = "external"
 
     private let colorLabelStore = ColorLabelStore.shared
-
     private var theme: ThemeStyle { ThemeManager.shared.style }
 
-    enum SearchScope: String, CaseIterable, Identifiable {
-        case all = "すべて"
-        case unread = "未読"
-        case backlog = "積読"
-        case serial = "連載中"
-        case hiatus = "休載"
-        case publicationFinished = "完結"
-        case archived = "読了"
-        case oneShot = "読み切り"
-        case memo = "メモ"
-        case comment = "コメント"
-
-        var id: String { rawValue }
-
-        var systemImage: String {
-            switch self {
-            case .all: "tray.full"
-            case .unread: "envelope.badge"
-            case .backlog: "books.vertical"
-            case .serial: "book"
-            case .hiatus: "moon.zzz"
-            case .publicationFinished: "flag.checkered"
-            case .archived: "checkmark.seal"
-            case .oneShot: "doc.text"
-            case .memo: "note.text"
-            case .comment: "bubble.left.and.bubble.right"
-            }
-        }
+    enum SearchContentMode {
+        case entries, memo, comment
     }
 
-    /// 検索結果を 3 セクション（マンガ / メモ / コメント）に分類
+    // MARK: - Search Results
+
     private struct SearchResults {
         var entries: [MangaEntry]
         var memos: [MangaEntry]
         var comments: [(comment: MangaComment, entry: MangaEntry)]
 
         var isEmpty: Bool { entries.isEmpty && memos.isEmpty && comments.isEmpty }
-        var totalCount: Int { entries.count + memos.count + comments.count }
     }
 
     private var searchResults: SearchResults {
         let allEntries = viewModel.allEntries()
-        let scoped = applyScope(to: allEntries)
-        let dayFiltered = applyDayFilter(to: scoped)
-        let candidates = applyColorFilter(to: dayFiltered)
+        let dayFiltered = applyDayFilter(to: allEntries)
+        let colorFiltered = applyColorFilter(to: dayFiltered)
 
         let trimmed = searchText.trimmingCharacters(in: .whitespaces)
-        let candidateIDs = Set(candidates.map(\.id))
-        let entriesByID = Dictionary(uniqueKeysWithValues: candidates.map { ($0.id, $0) })
 
-        // メモスコープ: メモを持つエントリだけをメモセクションに表示
-        if selectedScope == .memo {
-            let memoMatched = candidates.filter {
+        if contentMode == .memo {
+            let memoMatched = colorFiltered.filter {
                 !$0.memo.isEmpty
                     && (trimmed.isEmpty || $0.memo.localizedCaseInsensitiveContains(trimmed))
             }
             return SearchResults(entries: [], memos: memoMatched, comments: [])
         }
 
-        // コメントスコープ: コメントだけをコメントセクションに表示
-        if selectedScope == .comment {
+        if contentMode == .comment {
+            let candidateIDs = Set(colorFiltered.map(\.id))
+            let entriesByID = Dictionary(uniqueKeysWithValues: colorFiltered.map { ($0.id, $0) })
             let allComments = viewModel.allComments()
             let commentMatched: [(MangaComment, MangaEntry)] = allComments.compactMap { comment in
                 guard candidateIDs.contains(comment.mangaEntryID),
@@ -93,28 +69,25 @@ struct SearchView: View {
             return SearchResults(entries: [], memos: [], comments: commentMatched)
         }
 
-        // クエリ未入力時はマンガセクションだけ
+        let candidates = applyEntryFilters(to: colorFiltered)
+
         guard !trimmed.isEmpty else {
             return SearchResults(entries: candidates, memos: [], comments: [])
         }
 
-        // 通常スコープ: 3 セクションに分類
-        // 1. マンガ名/掲載誌マッチ
         let nameMatched = candidates.filter {
             $0.name.localizedCaseInsensitiveContains(trimmed)
                 || $0.publisher.localizedCaseInsensitiveContains(trimmed)
         }
-
-        // 2. メモマッチ（マンガ名にヒットしていても独立して表示する）
         let memoMatched = candidates.filter {
             !$0.memo.isEmpty
                 && $0.memo.localizedCaseInsensitiveContains(trimmed)
         }
-
-        // 3. コメントマッチ
+        let filteredIDs = Set(candidates.map(\.id))
+        let entriesByID = Dictionary(uniqueKeysWithValues: candidates.map { ($0.id, $0) })
         let allComments = viewModel.allComments()
         let commentMatched: [(MangaComment, MangaEntry)] = allComments.compactMap { comment in
-            guard candidateIDs.contains(comment.mangaEntryID),
+            guard filteredIDs.contains(comment.mangaEntryID),
                   comment.content.localizedCaseInsensitiveContains(trimmed),
                   let entry = entriesByID[comment.mangaEntryID] else { return nil }
             return (comment, entry)
@@ -123,40 +96,33 @@ struct SearchView: View {
         return SearchResults(entries: nameMatched, memos: memoMatched, comments: commentMatched)
     }
 
+    // MARK: - Filter Logic
+
+    private func applyEntryFilters(to entries: [MangaEntry]) -> [MangaEntry] {
+        var filtered = entries
+        if let pub = publicationFilter {
+            filtered = filtered.filter { $0.publicationStatus == pub }
+        }
+        if let read = readingFilter {
+            filtered = filtered.filter { $0.readingState == read }
+        }
+        if showOneShotOnly {
+            filtered = filtered.filter { $0.isOneShot }
+        }
+        return filtered
+    }
+
     private func applyColorFilter(to entries: [MangaEntry]) -> [MangaEntry] {
         guard !selectedColors.isEmpty else { return entries }
         return entries.filter { selectedColors.contains($0.iconColor) }
-    }
-
-    private func applyScope(to entries: [MangaEntry]) -> [MangaEntry] {
-        switch selectedScope {
-        case .all: return entries
-        case .unread: return entries.filter { !$0.isRead }
-        case .backlog: return entries.filter { $0.readingState == .backlog }
-        case .serial: return entries.filter {
-            !$0.isOneShot
-                && $0.publicationStatus == .active
-                && $0.readingState == .following
-        }
-        case .hiatus: return entries.filter {
-            $0.publicationStatus == .hiatus && $0.readingState != .archived
-        }
-        case .publicationFinished: return entries.filter {
-            $0.publicationStatus == .finished && $0.readingState != .archived
-        }
-        case .archived: return entries.filter { $0.readingState == .archived }
-        case .oneShot: return entries.filter {
-            $0.isOneShot && $0.readingState != .archived
-        }
-        // メモ・コメントスコープはエントリ自体は絞り込まない（曜日/カラーのみ）
-        case .memo, .comment: return entries
-        }
     }
 
     private func applyDayFilter(to entries: [MangaEntry]) -> [MangaEntry] {
         guard let day = selectedDay else { return entries }
         return entries.filter { $0.dayOfWeek == day }
     }
+
+    // MARK: - Body
 
     var body: some View {
         NavigationStack {
@@ -167,8 +133,8 @@ struct SearchView: View {
                 }
 
                 VStack(spacing: 0) {
-                    scopeTabBar
-                    colorFilterBar
+                    stateFilterBar
+                    secondaryFilterBar
                     content
                 }
             }
@@ -226,10 +192,76 @@ struct SearchView: View {
         }
     }
 
+    // MARK: - 行 1: 状態フィルタ（2 軸）
+
     @ViewBuilder
-    private var colorFilterBar: some View {
+    private var stateFilterBar: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 6) {
+                // 掲載状況
+                ForEach(PublicationStatus.allCases) { status in
+                    filterChip(label: status.displayName, isSelected: publicationFilter == status) {
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            contentMode = .entries
+                            publicationFilter = publicationFilter == status ? nil : status
+                        }
+                    }
+                }
+
+                Spacer().frame(width: 12)
+
+                // 読書状況
+                ForEach(ReadingState.allCases) { state in
+                    filterChip(label: state.displayName, isSelected: readingFilter == state) {
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            contentMode = .entries
+                            readingFilter = readingFilter == state ? nil : state
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+        }
+    }
+
+    // MARK: - 行 2: 種別 + メモ/コメント + カラーフィルタ
+
+    @ViewBuilder
+    private var secondaryFilterBar: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 8) {
+                // 読み切りトグル
+                filterChip(label: "読み切り", isSelected: showOneShotOnly) {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        contentMode = .entries
+                        showOneShotOnly.toggle()
+                    }
+                }
+
+                // メモ/コメントモード
+                filterChip(label: "メモ", isSelected: contentMode == .memo) {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        if contentMode == .memo {
+                            contentMode = .entries
+                        } else {
+                            contentMode = .memo
+                            clearEntryFilters()
+                        }
+                    }
+                }
+                filterChip(label: "コメント", isSelected: contentMode == .comment) {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        if contentMode == .comment {
+                            contentMode = .entries
+                        } else {
+                            contentMode = .comment
+                            clearEntryFilters()
+                        }
+                    }
+                }
+
+                // カラーフィルタ
                 ForEach(MangaColor.all) { mangaColor in
                     let isSelected = selectedColors.contains(mangaColor.name)
                     let label = colorLabelStore.label(for: mangaColor.name)
@@ -273,39 +305,32 @@ struct SearchView: View {
         }
     }
 
-    @ViewBuilder
-    private var scopeTabBar: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 8) {
-                ForEach(SearchScope.allCases) { scope in
-                    Button {
-                        withAnimation(.easeInOut(duration: 0.2)) {
-                            selectedScope = scope
-                        }
-                    } label: {
-                        Text(scope.rawValue)
-                            .font(theme.bodyFont)
-                            .padding(.horizontal, 16)
-                            .padding(.vertical, 8)
-                            .background(
-                                selectedScope == scope
-                                    ? AnyShapeStyle(theme.primary)
-                                    : AnyShapeStyle(theme.surfaceContainerHigh)
-                            )
-                            .foregroundStyle(
-                                selectedScope == scope
-                                    ? theme.onPrimary
-                                    : theme.onSurface
-                            )
-                            .clipShape(Capsule())
-                    }
-                    .buttonStyle(.plain)
-                }
-            }
-            .padding(.horizontal)
-            .padding(.vertical, 8)
+    // MARK: - Helpers
+
+    private func filterChip(label: String, isSelected: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(label)
+                .font(theme.bodyFont)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 7)
+                .background(
+                    isSelected
+                        ? AnyShapeStyle(theme.primary)
+                        : AnyShapeStyle(theme.surfaceContainerHigh)
+                )
+                .foregroundStyle(isSelected ? theme.onPrimary : theme.onSurface)
+                .clipShape(Capsule())
         }
+        .buttonStyle(.plain)
     }
+
+    private func clearEntryFilters() {
+        publicationFilter = nil
+        readingFilter = nil
+        showOneShotOnly = false
+    }
+
+    // MARK: - Content
 
     @ViewBuilder
     private var content: some View {
@@ -320,15 +345,18 @@ struct SearchView: View {
     @ViewBuilder
     private var emptyState: some View {
         let trimmed = searchText.trimmingCharacters(in: .whitespaces)
-        if trimmed.isEmpty && selectedScope == .all && selectedDay == nil && selectedColors.isEmpty {
+        let hasAnyFilter = publicationFilter != nil || readingFilter != nil
+            || showOneShotOnly || selectedDay != nil || !selectedColors.isEmpty
+
+        if trimmed.isEmpty && !hasAnyFilter && contentMode == .entries {
             ContentUnavailableView {
                 Label("検索", systemImage: "magnifyingglass")
                     .foregroundStyle(theme.onSurfaceVariant)
             } description: {
-                Text("マンガ名・掲載誌・メモ・コメントから検索できます\n下のスコープで絞り込みも可能")
+                Text("マンガ名・掲載誌・メモ・コメントから検索できます\nフィルタで絞り込みも可能")
                     .foregroundStyle(theme.onSurfaceVariant.opacity(0.7))
             }
-        } else if trimmed.isEmpty && selectedScope == .memo {
+        } else if trimmed.isEmpty && contentMode == .memo {
             ContentUnavailableView {
                 Label("メモがありません", systemImage: "note.text")
                     .foregroundStyle(theme.onSurfaceVariant)
@@ -336,7 +364,7 @@ struct SearchView: View {
                 Text("編集画面の「メモ」セクションから書けます")
                     .foregroundStyle(theme.onSurfaceVariant.opacity(0.7))
             }
-        } else if trimmed.isEmpty && selectedScope == .comment {
+        } else if trimmed.isEmpty && contentMode == .comment {
             ContentUnavailableView {
                 Label("コメントがありません", systemImage: "bubble.left.and.bubble.right")
                     .foregroundStyle(theme.onSurfaceVariant)
@@ -348,6 +376,8 @@ struct SearchView: View {
             ContentUnavailableView.search(text: trimmed)
         }
     }
+
+    // MARK: - Result List
 
     @ViewBuilder
     private func resultList(results: SearchResults) -> some View {

--- a/MangaLauncher/Views/Search/SearchView.swift
+++ b/MangaLauncher/Views/Search/SearchView.swift
@@ -3,10 +3,9 @@ import SwiftData
 import PlatformKit
 
 struct SearchView: View {
-    @Environment(\.modelContext) private var modelContext
     @Environment(\.openURL) private var openURL
 
-    @State private var viewModel: MangaViewModel?
+    var viewModel: MangaViewModel
     @State private var searchText: String = ""
     @State private var selectedScope: SearchScope = .all
     @State private var selectedDay: DayOfWeek? = nil
@@ -61,7 +60,6 @@ struct SearchView: View {
     }
 
     private var searchResults: SearchResults {
-        guard let viewModel else { return SearchResults(entries: [], memos: [], comments: []) }
         let allEntries = viewModel.allEntries()
         let scoped = applyScope(to: allEntries)
         let dayFiltered = applyDayFilter(to: scoped)
@@ -211,14 +209,10 @@ struct SearchView: View {
                 }
             }
             .sheet(item: $editingEntry) { entry in
-                if let viewModel {
-                    EditEntryView(viewModel: viewModel, entry: entry)
-                }
+                EditEntryView(viewModel: viewModel, entry: entry)
             }
             .sheet(item: $commentingEntry) { entry in
-                if let viewModel {
-                    CommentListView(entry: entry, viewModel: viewModel)
-                }
+                CommentListView(entry: entry, viewModel: viewModel)
             }
             #if canImport(UIKit)
             .sheet(item: $safariURL) { url in
@@ -227,13 +221,8 @@ struct SearchView: View {
             }
             #endif
         }
-        .onAppear {
-            if viewModel == nil {
-                viewModel = MangaViewModel(modelContext: modelContext)
-            }
-        }
         .onMangaDataChange {
-            viewModel?.refresh()
+            viewModel.refresh()
         }
     }
 
@@ -320,15 +309,11 @@ struct SearchView: View {
 
     @ViewBuilder
     private var content: some View {
-        if viewModel == nil {
-            EmptyView()
+        let results = searchResults
+        if results.isEmpty {
+            emptyState
         } else {
-            let results = searchResults
-            if results.isEmpty {
-                emptyState
-            } else {
-                resultList(results: results)
-            }
+            resultList(results: results)
         }
     }
 
@@ -373,7 +358,7 @@ struct SearchView: View {
                     ForEach(results.entries, id: \.id) { entry in
                         SearchResultRow(
                             entry: entry,
-                            viewModel: viewModel!,
+                            viewModel: viewModel,
                             editingEntry: $editingEntry,
                             commentingEntry: $commentingEntry,
                             onOpenURL: openMangaURL

--- a/MangaLauncher/Views/Search/SearchView.swift
+++ b/MangaLauncher/Views/Search/SearchView.swift
@@ -11,7 +11,7 @@ struct SearchView: View {
     // MARK: - 2 軸フィルタ（各グループ内は単一選択）
     @State private var publicationFilter: PublicationStatus? = nil
     @State private var readingFilter: ReadingState? = nil
-    @State private var showOneShotOnly = false
+    @State private var showOneShotOnly = false  // 掲載状況と排他
     @State private var contentMode: SearchContentMode = .entries
 
     @State private var selectedDay: DayOfWeek? = nil
@@ -198,12 +198,24 @@ struct SearchView: View {
     private var stateFilterBar: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 6) {
-                // 掲載状況
+                // 掲載状況 + 読み切り（排他グループ）
                 ForEach(PublicationStatus.allCases) { status in
-                    filterChip(label: status.displayName, isSelected: publicationFilter == status) {
+                    filterChip(label: status.displayName, isSelected: !showOneShotOnly && publicationFilter == status) {
                         withAnimation(.easeInOut(duration: 0.2)) {
                             contentMode = .entries
+                            showOneShotOnly = false
                             publicationFilter = publicationFilter == status ? nil : status
+                        }
+                    }
+                }
+                filterChip(label: "読み切り", isSelected: showOneShotOnly) {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        contentMode = .entries
+                        if showOneShotOnly {
+                            showOneShotOnly = false
+                        } else {
+                            showOneShotOnly = true
+                            publicationFilter = nil  // 掲載状況をクリア
                         }
                     }
                 }
@@ -231,14 +243,6 @@ struct SearchView: View {
     private var secondaryFilterBar: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 8) {
-                // 読み切りトグル
-                filterChip(label: "読み切り", isSelected: showOneShotOnly) {
-                    withAnimation(.easeInOut(duration: 0.2)) {
-                        contentMode = .entries
-                        showOneShotOnly.toggle()
-                    }
-                }
-
                 // メモ/コメントモード
                 filterChip(label: "メモ", isSelected: contentMode == .memo) {
                     withAnimation(.easeInOut(duration: 0.2)) {

--- a/MangaLauncher/Views/Search/SearchView.swift
+++ b/MangaLauncher/Views/Search/SearchView.swift
@@ -1,0 +1,440 @@
+import SwiftUI
+import SwiftData
+import PlatformKit
+
+struct SearchView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.openURL) private var openURL
+
+    @State private var viewModel: MangaViewModel?
+    @State private var searchText: String = ""
+    @State private var selectedScope: SearchScope = .all
+    @State private var selectedDay: DayOfWeek? = nil
+    @State private var selectedColors: Set<String> = []
+    @State private var safariURL: URL?
+    @State private var editingEntry: MangaEntry?
+    @State private var commentingEntry: MangaEntry?
+    @AppStorage("browserMode") private var browserMode: String = "external"
+
+    private let colorLabelStore = ColorLabelStore.shared
+
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
+    enum SearchScope: String, CaseIterable, Identifiable {
+        case all = "すべて"
+        case unread = "未読"
+        case backlog = "積読"
+        case serial = "連載中"
+        case hiatus = "休載"
+        case publicationFinished = "完結"
+        case archived = "読了"
+        case oneShot = "読み切り"
+        case memo = "メモ"
+        case comment = "コメント"
+
+        var id: String { rawValue }
+
+        var systemImage: String {
+            switch self {
+            case .all: "tray.full"
+            case .unread: "envelope.badge"
+            case .backlog: "books.vertical"
+            case .serial: "book"
+            case .hiatus: "moon.zzz"
+            case .publicationFinished: "flag.checkered"
+            case .archived: "checkmark.seal"
+            case .oneShot: "doc.text"
+            case .memo: "note.text"
+            case .comment: "bubble.left.and.bubble.right"
+            }
+        }
+    }
+
+    /// 検索結果を 3 セクション（マンガ / メモ / コメント）に分類
+    private struct SearchResults {
+        var entries: [MangaEntry]
+        var memos: [MangaEntry]
+        var comments: [(comment: MangaComment, entry: MangaEntry)]
+
+        var isEmpty: Bool { entries.isEmpty && memos.isEmpty && comments.isEmpty }
+        var totalCount: Int { entries.count + memos.count + comments.count }
+    }
+
+    private var searchResults: SearchResults {
+        guard let viewModel else { return SearchResults(entries: [], memos: [], comments: []) }
+        let allEntries = viewModel.allEntries()
+        let scoped = applyScope(to: allEntries)
+        let dayFiltered = applyDayFilter(to: scoped)
+        let candidates = applyColorFilter(to: dayFiltered)
+
+        let trimmed = searchText.trimmingCharacters(in: .whitespaces)
+        let candidateIDs = Set(candidates.map(\.id))
+        let entriesByID = Dictionary(uniqueKeysWithValues: candidates.map { ($0.id, $0) })
+
+        // メモスコープ: メモを持つエントリだけをメモセクションに表示
+        if selectedScope == .memo {
+            let memoMatched = candidates.filter {
+                !$0.memo.isEmpty
+                    && (trimmed.isEmpty || $0.memo.localizedCaseInsensitiveContains(trimmed))
+            }
+            return SearchResults(entries: [], memos: memoMatched, comments: [])
+        }
+
+        // コメントスコープ: コメントだけをコメントセクションに表示
+        if selectedScope == .comment {
+            let allComments = viewModel.allComments()
+            let commentMatched: [(MangaComment, MangaEntry)] = allComments.compactMap { comment in
+                guard candidateIDs.contains(comment.mangaEntryID),
+                      let entry = entriesByID[comment.mangaEntryID] else { return nil }
+                if !trimmed.isEmpty,
+                   !comment.content.localizedCaseInsensitiveContains(trimmed) {
+                    return nil
+                }
+                return (comment, entry)
+            }
+            return SearchResults(entries: [], memos: [], comments: commentMatched)
+        }
+
+        // クエリ未入力時はマンガセクションだけ
+        guard !trimmed.isEmpty else {
+            return SearchResults(entries: candidates, memos: [], comments: [])
+        }
+
+        // 通常スコープ: 3 セクションに分類
+        // 1. マンガ名/掲載誌マッチ
+        let nameMatched = candidates.filter {
+            $0.name.localizedCaseInsensitiveContains(trimmed)
+                || $0.publisher.localizedCaseInsensitiveContains(trimmed)
+        }
+
+        // 2. メモマッチ（マンガ名にヒットしていても独立して表示する）
+        let memoMatched = candidates.filter {
+            !$0.memo.isEmpty
+                && $0.memo.localizedCaseInsensitiveContains(trimmed)
+        }
+
+        // 3. コメントマッチ
+        let allComments = viewModel.allComments()
+        let commentMatched: [(MangaComment, MangaEntry)] = allComments.compactMap { comment in
+            guard candidateIDs.contains(comment.mangaEntryID),
+                  comment.content.localizedCaseInsensitiveContains(trimmed),
+                  let entry = entriesByID[comment.mangaEntryID] else { return nil }
+            return (comment, entry)
+        }
+
+        return SearchResults(entries: nameMatched, memos: memoMatched, comments: commentMatched)
+    }
+
+    private func applyColorFilter(to entries: [MangaEntry]) -> [MangaEntry] {
+        guard !selectedColors.isEmpty else { return entries }
+        return entries.filter { selectedColors.contains($0.iconColor) }
+    }
+
+    private func applyScope(to entries: [MangaEntry]) -> [MangaEntry] {
+        switch selectedScope {
+        case .all: return entries
+        case .unread: return entries.filter { !$0.isRead }
+        case .backlog: return entries.filter { $0.readingState == .backlog }
+        case .serial: return entries.filter {
+            !$0.isOneShot
+                && $0.publicationStatus == .active
+                && $0.readingState == .following
+        }
+        case .hiatus: return entries.filter {
+            $0.publicationStatus == .hiatus && $0.readingState != .archived
+        }
+        case .publicationFinished: return entries.filter {
+            $0.publicationStatus == .finished && $0.readingState != .archived
+        }
+        case .archived: return entries.filter { $0.readingState == .archived }
+        case .oneShot: return entries.filter {
+            $0.isOneShot && $0.readingState != .archived
+        }
+        // メモ・コメントスコープはエントリ自体は絞り込まない（曜日/カラーのみ）
+        case .memo, .comment: return entries
+        }
+    }
+
+    private func applyDayFilter(to entries: [MangaEntry]) -> [MangaEntry] {
+        guard let day = selectedDay else { return entries }
+        return entries.filter { $0.dayOfWeek == day }
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                if ThemeManager.shared.style.usesCustomSurface {
+                    ThemeManager.shared.style.surface
+                        .ignoresSafeArea()
+                }
+
+                VStack(spacing: 0) {
+                    scopeTabBar
+                    colorFilterBar
+                    content
+                }
+            }
+            .navigationTitle("検索")
+            #if os(iOS) || os(visionOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .searchable(text: $searchText, prompt: "マンガ名・掲載誌で検索")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Menu {
+                        Button {
+                            selectedDay = nil
+                        } label: {
+                            HStack {
+                                Text("すべての曜日")
+                                if selectedDay == nil {
+                                    Image(systemName: "checkmark")
+                                }
+                            }
+                        }
+                        Divider()
+                        ForEach(DayOfWeek.orderedDays) { day in
+                            Button {
+                                selectedDay = day
+                            } label: {
+                                HStack {
+                                    Text(day.displayName)
+                                    if selectedDay == day {
+                                        Image(systemName: "checkmark")
+                                    }
+                                }
+                            }
+                        }
+                    } label: {
+                        Image(systemName: selectedDay == nil ? "calendar" : "calendar.badge.checkmark")
+                    }
+                }
+            }
+            .sheet(item: $editingEntry) { entry in
+                if let viewModel {
+                    EditEntryView(viewModel: viewModel, entry: entry)
+                }
+            }
+            .sheet(item: $commentingEntry) { entry in
+                if let viewModel {
+                    CommentListView(entry: entry, viewModel: viewModel)
+                }
+            }
+            #if canImport(UIKit)
+            .sheet(item: $safariURL) { url in
+                SafariView(url: url)
+                    .ignoresSafeArea()
+            }
+            #endif
+        }
+        .onAppear {
+            if viewModel == nil {
+                viewModel = MangaViewModel(modelContext: modelContext)
+            }
+        }
+        .onMangaDataChange {
+            viewModel?.refresh()
+        }
+    }
+
+    @ViewBuilder
+    private var colorFilterBar: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(MangaColor.all) { mangaColor in
+                    let isSelected = selectedColors.contains(mangaColor.name)
+                    let label = colorLabelStore.label(for: mangaColor.name)
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            if isSelected {
+                                selectedColors.remove(mangaColor.name)
+                            } else {
+                                selectedColors.insert(mangaColor.name)
+                            }
+                        }
+                    } label: {
+                        HStack(spacing: 6) {
+                            Circle()
+                                .fill(mangaColor.color)
+                                .frame(width: 14, height: 14)
+                            if let label {
+                                Text(label)
+                                    .font(theme.captionFont)
+                            }
+                        }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 6)
+                        .background(
+                            isSelected
+                                ? AnyShapeStyle(theme.primary.opacity(0.2))
+                                : AnyShapeStyle(theme.surfaceContainerHigh)
+                        )
+                        .overlay(
+                            Capsule()
+                                .strokeBorder(isSelected ? theme.primary : Color.clear, lineWidth: 1.5)
+                        )
+                        .foregroundStyle(theme.onSurface)
+                        .clipShape(Capsule())
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal)
+            .padding(.bottom, 8)
+        }
+    }
+
+    @ViewBuilder
+    private var scopeTabBar: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(SearchScope.allCases) { scope in
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            selectedScope = scope
+                        }
+                    } label: {
+                        Text(scope.rawValue)
+                            .font(theme.bodyFont)
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 8)
+                            .background(
+                                selectedScope == scope
+                                    ? AnyShapeStyle(theme.primary)
+                                    : AnyShapeStyle(theme.surfaceContainerHigh)
+                            )
+                            .foregroundStyle(
+                                selectedScope == scope
+                                    ? theme.onPrimary
+                                    : theme.onSurface
+                            )
+                            .clipShape(Capsule())
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if viewModel == nil {
+            EmptyView()
+        } else {
+            let results = searchResults
+            if results.isEmpty {
+                emptyState
+            } else {
+                resultList(results: results)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var emptyState: some View {
+        let trimmed = searchText.trimmingCharacters(in: .whitespaces)
+        if trimmed.isEmpty && selectedScope == .all && selectedDay == nil && selectedColors.isEmpty {
+            ContentUnavailableView {
+                Label("検索", systemImage: "magnifyingglass")
+                    .foregroundStyle(theme.onSurfaceVariant)
+            } description: {
+                Text("マンガ名・掲載誌・メモ・コメントから検索できます\n下のスコープで絞り込みも可能")
+                    .foregroundStyle(theme.onSurfaceVariant.opacity(0.7))
+            }
+        } else if trimmed.isEmpty && selectedScope == .memo {
+            ContentUnavailableView {
+                Label("メモがありません", systemImage: "note.text")
+                    .foregroundStyle(theme.onSurfaceVariant)
+            } description: {
+                Text("編集画面の「メモ」セクションから書けます")
+                    .foregroundStyle(theme.onSurfaceVariant.opacity(0.7))
+            }
+        } else if trimmed.isEmpty && selectedScope == .comment {
+            ContentUnavailableView {
+                Label("コメントがありません", systemImage: "bubble.left.and.bubble.right")
+                    .foregroundStyle(theme.onSurfaceVariant)
+            } description: {
+                Text("マンガを長押し →「コメント」から投稿できます")
+                    .foregroundStyle(theme.onSurfaceVariant.opacity(0.7))
+            }
+        } else {
+            ContentUnavailableView.search(text: trimmed)
+        }
+    }
+
+    @ViewBuilder
+    private func resultList(results: SearchResults) -> some View {
+        let trimmed = searchText.trimmingCharacters(in: .whitespaces)
+        List {
+            if !results.entries.isEmpty {
+                Section {
+                    ForEach(results.entries, id: \.id) { entry in
+                        SearchResultRow(
+                            entry: entry,
+                            viewModel: viewModel!,
+                            editingEntry: $editingEntry,
+                            commentingEntry: $commentingEntry,
+                            onOpenURL: openMangaURL
+                        )
+                    }
+                } header: {
+                    sectionHeader(title: "マンガ", count: results.entries.count)
+                }
+            }
+
+            if !results.memos.isEmpty {
+                Section {
+                    ForEach(results.memos, id: \.id) { entry in
+                        MemoMatchRow(
+                            entry: entry,
+                            query: trimmed,
+                            editingEntry: $editingEntry
+                        )
+                    }
+                } header: {
+                    sectionHeader(title: "メモ", count: results.memos.count)
+                }
+            }
+
+            if !results.comments.isEmpty {
+                Section {
+                    ForEach(results.comments, id: \.comment.id) { match in
+                        CommentMatchRow(
+                            comment: match.comment,
+                            entry: match.entry,
+                            query: trimmed,
+                            commentingEntry: $commentingEntry
+                        )
+                    }
+                } header: {
+                    sectionHeader(title: "コメント", count: results.comments.count)
+                }
+            }
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+    }
+
+    private func sectionHeader(title: String, count: Int) -> some View {
+        HStack(spacing: 8) {
+            Text(title)
+                .font(theme.subheadlineFont.bold())
+                .foregroundStyle(theme.onSurface)
+            Text("\(count)")
+                .font(.system(size: 11, weight: .bold))
+                .foregroundStyle(theme.onPrimary)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 1)
+                .background(theme.primary)
+                .clipShape(Capsule())
+            Spacer()
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func openMangaURL(_ urlString: String) {
+        MangaURLOpener(browserMode: browserMode, openURL: openURL) { safariURL = $0 }.open(urlString)
+    }
+}

--- a/MangaLauncher/Views/Settings/ColorLabelSettingsView.swift
+++ b/MangaLauncher/Views/Settings/ColorLabelSettingsView.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+struct ColorLabelSettingsView: View {
+    @State private var labels: [String: String] = [:]
+    @FocusState private var focusedColor: String?
+
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
+    var body: some View {
+        Form {
+            Section {
+                ForEach(MangaColor.all) { mangaColor in
+                    HStack(spacing: 12) {
+                        Circle()
+                            .fill(mangaColor.color)
+                            .frame(width: 28, height: 28)
+                        Text(mangaColor.displayName)
+                            .frame(width: 60, alignment: .leading)
+                            .foregroundStyle(theme.onSurface)
+                        TextField("ラベル（任意）", text: Binding(
+                            get: { labels[mangaColor.name] ?? "" },
+                            set: { labels[mangaColor.name] = $0 }
+                        ))
+                        .focused($focusedColor, equals: mangaColor.name)
+                        .submitLabel(.done)
+                        .onSubmit {
+                            saveLabel(for: mangaColor.name)
+                        }
+                    }
+                }
+            } footer: {
+                Text("ラベルを設定すると、検索画面のカラーフィルターで「お気に入り」「新刊」などの名前で絞り込めるようになります。")
+            }
+        }
+        .themedNavigationStyle()
+        .navigationTitle("カラーラベル")
+        #if os(iOS) || os(visionOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .onAppear {
+            ColorLabelStore.shared.load()
+            labels = ColorLabelStore.shared.labels
+        }
+        .onDisappear {
+            // 全てのラベルを保存
+            for (color, label) in labels {
+                ColorLabelStore.shared.setLabel(label, for: color)
+            }
+            // 削除されたラベル（textが空）も反映
+            for color in MangaColor.all where labels[color.name] == nil || labels[color.name]?.isEmpty == true {
+                ColorLabelStore.shared.setLabel("", for: color.name)
+            }
+        }
+    }
+
+    private func saveLabel(for colorName: String) {
+        let label = labels[colorName] ?? ""
+        ColorLabelStore.shared.setLabel(label, for: colorName)
+        focusedColor = nil
+    }
+}

--- a/MangaLauncher/Views/Settings/SettingsView.swift
+++ b/MangaLauncher/Views/Settings/SettingsView.swift
@@ -7,6 +7,7 @@ struct SettingsView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(CloudSyncMonitor.self) private var syncMonitor
     var viewModel: MangaViewModel
+    var showsCloseButton: Bool = true
 
     @State private var showingResetConfirmation = false
     @State private var achievementResetDone = false
@@ -167,6 +168,18 @@ struct SettingsView: View {
                 }
 
                 Section {
+                    NavigationLink {
+                        ColorLabelSettingsView()
+                    } label: {
+                        Label("カラーラベル", systemImage: "tag")
+                    }
+                } header: {
+                    Text("カラーラベル")
+                } footer: {
+                    Text("カラーアイコンに任意の名前を付けると、検索フィルターで使用できます（例：赤=お気に入り）")
+                }
+
+                Section {
                     Picker("ブラウザ", selection: $browserMode) {
                         Text("アプリ内（Safari）").tag("inApp")
                         Text("デフォルトブラウザ").tag("external")
@@ -276,9 +289,11 @@ struct SettingsView: View {
             .navigationBarTitleDisplayMode(.inline)
             #endif
             .toolbar {
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("閉じる") {
-                        dismiss()
+                if showsCloseButton {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("閉じる") {
+                            dismiss()
+                        }
                     }
                 }
             }

--- a/MangaShareExtension/ShareExtensionView.swift
+++ b/MangaShareExtension/ShareExtensionView.swift
@@ -17,8 +17,47 @@ struct ShareExtensionView: View {
     @State private var selectedColor = "blue"
     @State private var imageData: Data?
     @State private var saveError: String?
-    @State private var isOnHiatus = false
+    @State private var publicationStatus: PublicationStatus = .active
+    @State private var readingState: ReadingState = .following
     @State private var isOneShot = false
+    @State private var updateIntervalWeeks: Int = 1
+    @State private var isCustomInterval = false
+    @State private var nextUpdateDate: Date = Date()
+
+    private static let presetIntervals = [1, 2, 3, 4, 8]
+
+    private var actualIntervalWeeks: Int {
+        isCustomInterval && updateIntervalWeeks == -1 ? 5 : max(updateIntervalWeeks, 1)
+    }
+
+    private var pickerValue: Binding<Int> {
+        Binding(
+            get: { isCustomInterval ? -1 : (Self.presetIntervals.contains(updateIntervalWeeks) ? updateIntervalWeeks : -1) },
+            set: { newValue in
+                if newValue == -1 {
+                    isCustomInterval = true
+                    if Self.presetIntervals.contains(updateIntervalWeeks) {
+                        updateIntervalWeeks = 5
+                    }
+                } else {
+                    isCustomInterval = false
+                    updateIntervalWeeks = newValue
+                }
+            }
+        )
+    }
+
+    private var nextUpdateCandidates: [Date] {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+        let todayWeekday = calendar.component(.weekday, from: today) - 1
+        let target = selectedDay.rawValue
+        let daysToNext = (target - todayWeekday + 7) % 7
+        let firstDate = daysToNext == 0 ? today : calendar.date(byAdding: .day, value: daysToNext, to: today)!
+        return (0..<8).map { i in
+            calendar.date(byAdding: .day, value: i * 7, to: firstDate)!
+        }
+    }
 
     private let colorOptions: [(name: String, color: Color)] = [
         ("red", .red),
@@ -131,13 +170,66 @@ struct ShareExtensionView: View {
                         }
                         .pickerStyle(.segmented)
                         .onChange(of: isOneShot) { _, newValue in
-                            if newValue { isOnHiatus = false }
+                            if newValue {
+                                publicationStatus = .active
+                                if readingState == .backlog {
+                                    readingState = .following
+                                }
+                            }
                         }
                     }
 
                     if !isOneShot {
                         Section {
-                            Toggle("休載中", isOn: $isOnHiatus)
+                            Picker("掲載状況", selection: $publicationStatus) {
+                                ForEach(PublicationStatus.allCases) { status in
+                                    Text(status.displayName).tag(status)
+                                }
+                            }
+                            .pickerStyle(.segmented)
+                        } header: {
+                            Text("掲載状況")
+                        } footer: {
+                            Text("作品自体の状態。連載中／休載中／完結。")
+                        }
+                    }
+
+                    if !isOneShot {
+                        Section {
+                            Picker("読書状況", selection: $readingState) {
+                                ForEach(ReadingState.allCases) { state in
+                                    Text(state.displayName).tag(state)
+                                }
+                            }
+                            .pickerStyle(.segmented)
+                        } header: {
+                            Text("読書状況")
+                        } footer: {
+                            Text("自分の進捗。追っかけ中／積読／読了。")
+                        }
+                    }
+
+                    if !isOneShot && publicationStatus == .active && readingState == .following {
+                        Section("更新頻度") {
+                            Picker("頻度", selection: pickerValue) {
+                                Text("毎週").tag(1)
+                                Text("隔週").tag(2)
+                                Text("3週ごと").tag(3)
+                                Text("月1回").tag(4)
+                                Text("2ヶ月ごと").tag(8)
+                                Text("カスタム").tag(-1)
+                            }
+                            if isCustomInterval {
+                                Stepper("\(updateIntervalWeeks)週ごと", value: $updateIntervalWeeks, in: 1...52)
+                            }
+                            if actualIntervalWeeks >= 1 {
+                                Picker("次の更新日", selection: $nextUpdateDate) {
+                                    ForEach(nextUpdateCandidates, id: \.self) { date in
+                                        Text(date.formatted(.dateTime.month().day().weekday()))
+                                            .tag(date)
+                                    }
+                                }
+                            }
                         }
                     }
 
@@ -188,6 +280,16 @@ struct ShareExtensionView: View {
         }
         .task {
             await processSharedContent()
+        }
+        .onChange(of: selectedDay) { _, _ in
+            if let first = nextUpdateCandidates.first {
+                nextUpdateDate = first
+            }
+        }
+        .onAppear {
+            if let first = nextUpdateCandidates.first {
+                nextUpdateDate = first
+            }
         }
     }
 
@@ -333,6 +435,7 @@ struct ShareExtensionView: View {
             let existingEntries = (try? context.fetch(descriptor)) ?? []
             let maxOrder = existingEntries.map(\.sortOrder).max() ?? -1
 
+            let interval = isOneShot ? 1 : actualIntervalWeeks
             let entry = MangaEntry(
                 name: name,
                 url: url,
@@ -340,10 +443,13 @@ struct ShareExtensionView: View {
                 sortOrder: maxOrder + 1,
                 iconColor: selectedColor,
                 publisher: publisher,
-                imageData: imageData
+                imageData: imageData,
+                updateIntervalWeeks: interval
             )
-            entry.isOnHiatus = isOnHiatus
             entry.isOneShot = isOneShot
+            entry.publicationStatus = isOneShot ? .active : publicationStatus
+            entry.readingState = readingState
+            entry.nextExpectedUpdate = isOneShot ? nil : nextUpdateDate
             context.insert(entry)
             try context.save()
 

--- a/MangaWidget/MangaWidget.swift
+++ b/MangaWidget/MangaWidget.swift
@@ -46,8 +46,13 @@ struct MangaTimelineProvider: TimelineProvider {
         let selectedDay = WidgetDayStore.shared.currentDay
         let dayRaw = selectedDay.rawValue
         let context = ModelContext(container)
+        // 連載中 × 追っかけ中のエントリのみ表示
         let descriptor = FetchDescriptor<MangaEntry>(
-            predicate: #Predicate { $0.dayOfWeekRawValue == dayRaw && !$0.isOnHiatus && !$0.isCompleted },
+            predicate: #Predicate {
+                $0.dayOfWeekRawValue == dayRaw
+                    && $0.publicationStatusRawValue == 0
+                    && $0.readingStateRawValue == 0
+            },
             sortBy: [SortDescriptor(\.sortOrder)]
         )
         let results = (try? context.fetch(descriptor)) ?? []

--- a/MangaWidget/MangaWidget.swift
+++ b/MangaWidget/MangaWidget.swift
@@ -47,11 +47,13 @@ struct MangaTimelineProvider: TimelineProvider {
         let dayRaw = selectedDay.rawValue
         let context = ModelContext(container)
         // 連載中 × 追っかけ中のエントリのみ表示
+        let activeRaw = PublicationStatus.active.rawValue
+        let followingRaw = ReadingState.following.rawValue
         let descriptor = FetchDescriptor<MangaEntry>(
             predicate: #Predicate {
                 $0.dayOfWeekRawValue == dayRaw
-                    && $0.publicationStatusRawValue == 0
-                    && $0.readingStateRawValue == 0
+                    && $0.publicationStatusRawValue == activeRaw
+                    && $0.readingStateRawValue == followingRaw
             },
             sortBy: [SortDescriptor(\.sortOrder)]
         )

--- a/Packages/CloudSyncKit/Sources/CloudSyncKit/CloudSyncKit.swift
+++ b/Packages/CloudSyncKit/Sources/CloudSyncKit/CloudSyncKit.swift
@@ -28,13 +28,21 @@ public final class CloudSyncMonitor {
     /// Notification name posted when CloudKit import completes.
     public static let dataDidChangeNotification = Notification.Name("mangaDataDidChange")
 
+    private var eventObserver: NSObjectProtocol?
+
     public init() {
         startMonitoring()
         checkAccountStatus()
     }
 
+    deinit {
+        if let eventObserver {
+            NotificationCenter.default.removeObserver(eventObserver)
+        }
+    }
+
     private func startMonitoring() {
-        NotificationCenter.default.addObserver(
+        eventObserver = NotificationCenter.default.addObserver(
             forName: NSNotification.Name("NSPersistentCloudKitContainerEventChangedNotification"),
             object: nil,
             queue: .main


### PR DESCRIPTION
## Summary

マンガの状態管理を 4状態モデルにリファクタリングし、ライブラリ・検索・コメントなどの新画面を追加。
2 コミットで構成しています:

1. **Refactor manga state into PublicationStatus + ReadingState axes**  
   状態モデルを 2 軸に分離 + ホーム画面 7 曜日化 + 編集画面 2 ピッカー化
2. **Add Library/Search/Comment screens and shared UI components**  
   ボトムタブの新画面群 + 共通 UI コンポーネント + リファクタリング

## 主な変更

### データモデル (Commit 1)
- ` + "`PublicationStatus`" + ` (連載中/休載中/完結) と ` + "`ReadingState`" + ` (追っかけ中/積読/読了) を独立した 2 軸に分離
- ` + "`migrateLegacyStateIfNeeded()`" + ` でワンタイム移行 (旧 ` + "`isOnHiatus`" + `/` + "`isCompleted`" + `/` + "`isBacklog`" + ` から)
- ` + "`MangaComment`" + ` モデル + ` + "`MangaEntry.memo`" + ` / ` + "`memoUpdatedAt`" + ` フィールド追加
- ` + "`BackupData`" + ` v8 へスキーマ拡張 (v5 以前との後方互換あり)

### ホーム画面整理 (Commit 1)
- ` + "`DayOfWeek`" + ` から ` + "`.hiatus`" + ` / ` + "`.completed`" + ` ケースを削除
- 曜日タブを 7 曜日のみに (休載・完結はライブラリで管理)
- ` + "`DayPagerView`" + ` の wraparound を 7 曜日に対応

### 新画面 (Commit 2)
- ` + "`RootTabView`" + `: ホーム / ライブラリ / 設定 / 検索 のボトムタブ
- ` + "`LibraryView`" + `: 横スクロールセクション (最近のメモ・コメント / 未読 / 積読 / カラーラベル / 連載中 / 読み切り / 休載 / 完結 / 読了 / 掲載誌別)
- ` + "`SearchView`" + `: マンガ / メモ / コメントの 3 セクションに分けた検索結果。スコープ絞り込みあり
- ` + "`CommentListView`" + `: 作品ごとのタイムスタンプ付きコメント一覧 + composer
- ` + "`ColorLabelSettingsView`" + `: カラーアイコンに任意ラベル

### 共通 UI (Commit 2)
- ` + "`MangaStatusBadgeView`" + `: 状態バッジを 1 箇所に集約 (LibraryCard / SearchResultRow で重複していたものを統合)
- ` + "`SectionHeaderView`" + `: アイコン + タイトル + 件数バッジ + 「すべて表示」リンクの定型 UI
- ` + "`ActivityRowView`" + `: メモ/コメント表示用 (色とアイコンで視覚差別化)
- ` + "`MangaDataChangeModifier`" + `: 5 箇所に散らばっていた ` + "`.onReceive(.mangaDataDidChange)`" + ` を集約

### リファクタリング (Commit 2)
- ` + "`MangaViewModel`" + ` を ` + "`@MainActor`" + ` 化 (Swift 6 / SwiftData の thread safety 対応)
- ` + "`LibraryView`" + ` の N+1 fetch を解消 (` + "`allEntries`" + ` / ` + "`allComments`" + ` を 1 度だけ fetch して ` + "`ActivityBuilder`" + ` / ` + "`LibrarySectionBuilder`" + ` / ` + "`PublisherIndex`" + ` で計算)
- ` + "`DayPageView`" + ` の 11 個のパラメータを ` + "`DayPageDisplayContext`" + ` 構造体に整理
- ` + "`BacklogView`" + ` (デッドコード) と ` + "`MangaState`" + ` enum を削除
- 大きな View ファイルをトピックごとに分割 (` + "`LibraryView`" + ` 588→199行、` + "`SearchView`" + ` 619→440行)

## Test plan

- [x] `xcodebuild` 通る (各コミット時点で確認済み)
- [x] 実機 (iPhone 15 Pro, iOS 26.4) でインストール & 動作確認
- [x] 既存データの状態マイグレーション動作確認
- [x] メモ・コメント追加 → 検索 → ライブラリ表示の通し動作確認
- [x] CloudKit sync 通知の伝播 (modifier 化後)
- [ ] バックアップ export → import の互換性 (要確認)
- [ ] 他の iPhone での回帰テスト