### PR TITLE
Follow-up fixes from PR #159 review

### DIFF
--- a/MangaLauncher/Models/MangaEntry.swift
+++ b/MangaLauncher/Models/MangaEntry.swift
@@ -88,6 +88,11 @@ enum ReadingState: Int, Codable, CaseIterable, Identifiable {
     }
 }
 
+/// 状態の invariants:
+/// - `isOneShot == true` のとき `publicationStatus == .active` かつ `readingState != .backlog`
+///   （読み切りは掲載状況の概念がなく、積読とも不整合。`.following` か `.archived` のみ）
+/// - `readingState == .archived` のとき `isRead` は常に true
+/// これらは `MangaViewModel.addEntry` / `updateEntry` / `MangaEntry.normalizeOneShotInvariants()` で強制される。
 @Model
 final class MangaEntry {
     var id: UUID = UUID()
@@ -124,13 +129,19 @@ final class MangaEntry {
         get { isOneShot ? .oneShot : .serial }
         set {
             isOneShot = newValue == .oneShot
-            if isOneShot {
-                publicationStatusRawValue = PublicationStatus.active.rawValue
-                // 読み切りは追っかけ概念がないので following or archived
-                if readingState == .backlog {
-                    readingStateRawValue = ReadingState.following.rawValue
-                }
-            }
+            normalizeOneShotInvariants()
+        }
+    }
+
+    /// 読み切りのときに不整合な状態 (hiatus/finished、backlog) を矯正する。
+    /// ViewModel / mangaType setter から共通に呼ばれる。
+    func normalizeOneShotInvariants() {
+        guard isOneShot else { return }
+        if publicationStatusRawValue != PublicationStatus.active.rawValue {
+            publicationStatusRawValue = PublicationStatus.active.rawValue
+        }
+        if readingStateRawValue == ReadingState.backlog.rawValue {
+            readingStateRawValue = ReadingState.following.rawValue
         }
     }
 
@@ -221,6 +232,8 @@ final class MangaEntry {
             readingStateRawValue = ReadingState.following.rawValue
             publicationStatusRawValue = PublicationStatus.active.rawValue
         }
+        // 旧データで one-shot + backlog/hiatus/finished の矛盾があった場合の最終矯正
+        normalizeOneShotInvariants()
         stateMigrationVersion = 1
     }
 

--- a/MangaLauncher/Shared/MangaColor.swift
+++ b/MangaLauncher/Shared/MangaColor.swift
@@ -52,9 +52,4 @@ final class ColorLabelStore {
     func label(for colorName: String) -> String? {
         labels[colorName]
     }
-
-    /// ラベルがあればラベル、なければカラー名（赤、青等）を返す
-    func displayLabel(for colorName: String) -> String {
-        labels[colorName] ?? MangaColor.displayName(for: colorName)
-    }
 }

--- a/MangaLauncher/Shared/MangaStatusBadgeView.swift
+++ b/MangaLauncher/Shared/MangaStatusBadgeView.swift
@@ -7,7 +7,7 @@ struct MangaStatusBadgeView: View {
     enum Style {
         /// "読" "完" "休" "積" "切" などの 1 文字
         case short
-        /// "読了" "完結" "休載" "積読" "読切" などの全名
+        /// "読了" "完結" "休載" "積読" "読み切り" などの全名
         case full
     }
 
@@ -41,7 +41,7 @@ struct MangaStatusBadgeView: View {
             return (style == .short ? "積" : "積読", ThemeManager.shared.style.primary)
         }
         if entry.isOneShot {
-            return (style == .short ? "切" : "読切", .purple)
+            return (style == .short ? "切" : "読み切り", .purple)
         }
         return nil
     }

--- a/MangaLauncher/ViewModels/HomeState.swift
+++ b/MangaLauncher/ViewModels/HomeState.swift
@@ -115,7 +115,6 @@ final class WallpaperState {
 @Observable
 final class SheetState {
     var showingAddSheet = false
-    var showingSettings = false
     var showingCatchUp = false
     var showingWallpaperPicker = false
 }

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -457,21 +457,9 @@ final class MangaViewModel {
         fetchEntries(for: day).filter { !$0.isRead }
     }
 
-    // MARK: - Memo
-
-    func updateMemo(_ entry: MangaEntry, memo: String) {
-        let changed = entry.memo != memo
-        entry.memo = memo
-        if changed && !memo.isEmpty {
-            entry.memoUpdatedAt = Date()
-        } else if memo.isEmpty {
-            entry.memoUpdatedAt = nil
-        }
-        save()
-    }
-
     // 注意: アクティビティ・メモ集約は ActivityBuilder に移譲。
     // ここに recentActivity / allActivity / memoEntryCount などを置かないこと（N+1 fetch の温床になる）。
+    // メモの更新は updateEntry() に統合済み。
 
     // MARK: - Comments
 
@@ -503,15 +491,6 @@ final class MangaViewModel {
             predicate: #Predicate { $0.mangaEntryID == entryID },
             sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
         )
-        return modelContext.fetchLogged(descriptor)
-    }
-
-    func recentComments(limit: Int = 10) -> [MangaComment] {
-        let _ = refreshCounter
-        var descriptor = FetchDescriptor<MangaComment>(
-            sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
-        )
-        descriptor.fetchLimit = limit
         return modelContext.fetchLogged(descriptor)
     }
 

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -339,8 +339,9 @@ final class MangaViewModel {
             entry.memo = backupEntry.memo ?? ""
             entry.memoUpdatedAt = backupEntry.memoUpdatedAt
             // v6+ バックアップは publicationStatusRawValue / readingStateRawValue を authoritative とする。
-            // どちらか片方しかない場合も新スキーマ側を尊重し、欠けている方だけデフォルトで埋める。
             // 両方 nil のときだけ v5 以前の legacy Bool から導出する。
+            // 通常 export 側は両方を必ず書くので片方 nil は現実にはほぼ起こらないが、
+            // 手動編集や他実装からの破損対策として欠けた側はデフォルトで補っておく。
             if backupEntry.publicationStatusRawValue != nil || backupEntry.readingStateRawValue != nil {
                 entry.publicationStatusRawValue = backupEntry.publicationStatusRawValue
                     ?? PublicationStatus.active.rawValue

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -127,6 +127,7 @@ final class MangaViewModel {
             entry.publicationStatus = publicationStatus
             entry.readingState = readingState
             entry.isOneShot = isOneShot
+            entry.normalizeOneShotInvariants()
             entry.memo = memo
             if !memo.isEmpty {
                 entry.memoUpdatedAt = Date()
@@ -161,9 +162,10 @@ final class MangaViewModel {
         entry.updateIntervalWeeks = updateIntervalWeeks
         entry.nextExpectedUpdate = nextExpectedUpdate
         entry.isOneShot = isOneShot
-        // 読み切りは掲載状況の概念がないので強制的に active へ
-        entry.publicationStatus = isOneShot ? .active : publicationStatus
+        entry.publicationStatus = publicationStatus
         entry.readingState = readingState
+        // 読み切りの invariants (publicationStatus=.active, readingState != .backlog) を強制
+        entry.normalizeOneShotInvariants()
         entry.memo = memo
         if memoChanged {
             entry.memoUpdatedAt = memo.isEmpty ? nil : Date()
@@ -336,11 +338,15 @@ final class MangaViewModel {
             entry.isOneShot = backupEntry.isOneShot ?? false
             entry.memo = backupEntry.memo ?? ""
             entry.memoUpdatedAt = backupEntry.memoUpdatedAt
-            // 新フィールドが backup に含まれていればそれを使う、無ければ legacy から導出
-            if let pubRaw = backupEntry.publicationStatusRawValue,
-               let readRaw = backupEntry.readingStateRawValue {
-                entry.publicationStatusRawValue = pubRaw
-                entry.readingStateRawValue = readRaw
+            // v6+ バックアップは publicationStatusRawValue / readingStateRawValue を authoritative とする。
+            // どちらか片方しかない場合も新スキーマ側を尊重し、欠けている方だけデフォルトで埋める。
+            // 両方 nil のときだけ v5 以前の legacy Bool から導出する。
+            if backupEntry.publicationStatusRawValue != nil || backupEntry.readingStateRawValue != nil {
+                entry.publicationStatusRawValue = backupEntry.publicationStatusRawValue
+                    ?? PublicationStatus.active.rawValue
+                entry.readingStateRawValue = backupEntry.readingStateRawValue
+                    ?? ReadingState.following.rawValue
+                entry.stateMigrationVersion = 1
             } else {
                 entry.isOnHiatus = backupEntry.isOnHiatus ?? false
                 entry.isCompleted = backupEntry.isCompleted ?? false
@@ -406,7 +412,9 @@ final class MangaViewModel {
         if !entry.isOneShot {
             entry.advanceToNextUpdate()
         }
-        // 同日・同エントリのアクティビティが既に存在する場合は再 insert しない
+        // 同日・同エントリのアクティビティが既に存在する場合は再 insert しない。
+        // ReadingActivity.init は date を startOfDay に正規化するので、
+        // predicate の比較は秒単位の揺らぎなく成立する。
         let today = Calendar.current.startOfDay(for: Date())
         let entryID = entry.id
         let existingDescriptor = FetchDescriptor<ReadingActivity>(

--- a/MangaLauncher/Views/Comment/CommentListView.swift
+++ b/MangaLauncher/Views/Comment/CommentListView.swift
@@ -8,6 +8,7 @@ struct CommentListView: View {
     @State private var draft: String = ""
     @State private var editingComment: MangaComment?
     @State private var editingContent: String = ""
+    @State private var pendingDeleteComment: MangaComment?
     @FocusState private var composerFocused: Bool
 
     private var theme: ThemeStyle { ThemeManager.shared.style }
@@ -58,6 +59,25 @@ struct CommentListView: View {
             .sheet(item: $editingComment) { comment in
                 editSheet(for: comment)
             }
+            .confirmationDialog(
+                "このコメントを削除しますか？",
+                isPresented: Binding(
+                    get: { pendingDeleteComment != nil },
+                    set: { if !$0 { pendingDeleteComment = nil } }
+                ),
+                titleVisibility: .visible,
+                presenting: pendingDeleteComment
+            ) { comment in
+                Button("削除", role: .destructive) {
+                    viewModel.deleteComment(comment)
+                    pendingDeleteComment = nil
+                }
+                Button("キャンセル", role: .cancel) {
+                    pendingDeleteComment = nil
+                }
+            } message: { _ in
+                Text("この操作は取り消せません。")
+            }
         }
     }
 
@@ -80,7 +100,7 @@ struct CommentListView: View {
         .padding(.vertical, 4)
         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
             Button(role: .destructive) {
-                viewModel.deleteComment(comment)
+                pendingDeleteComment = comment
             } label: {
                 Label("削除", systemImage: "trash")
             }

--- a/MangaLauncher/Views/MangaCell/MangaContextMenu.swift
+++ b/MangaLauncher/Views/MangaCell/MangaContextMenu.swift
@@ -8,7 +8,7 @@ struct MangaContextMenu: View {
     var onReorder: (() -> Void)? = nil
 
     var body: some View {
-        // 既読/未読トグルの表示条件:
+        // MARK: 既読/未読トグル
         //  - 休載中: isRead が常に true 扱いなので未読トグル不要
         //  - 読了 (archived): 常に既読扱い、専用の「読了を取り消す」ボタンから戻す
         //  - 積読 (backlog): 表示する（ラベルを「今日読んだ」に変更して文脈を明示）
@@ -31,6 +31,9 @@ struct MangaContextMenu: View {
             }
         }
 
+        Divider()
+
+        // MARK: 日常操作
         Button {
             editingEntry = entry
         } label: {
@@ -51,48 +54,66 @@ struct MangaContextMenu: View {
             }
         }
 
-        // 積読 → 追っかけ中（追いついた）
-        if entry.readingState == .backlog {
+        Divider()
+
+        // MARK: 状態変更（サブメニュー）
+        // 頻度の低い操作をまとめてトップメニューをすっきりさせる
+        Menu {
+            // 読書状況 (追っかけ ↔ 積読)。読み切り・読了は invariant 上対象外
+            if !entry.isOneShot && entry.readingState != .archived {
+                if entry.readingState == .backlog {
+                    Button {
+                        viewModel.setReadingState(entry, to: .following)
+                    } label: {
+                        Label("追いついた", systemImage: "checkmark.circle")
+                    }
+                } else if entry.readingState == .following {
+                    Button {
+                        viewModel.setReadingState(entry, to: .backlog)
+                    } label: {
+                        Label("積読にする", systemImage: "books.vertical")
+                    }
+                }
+            }
+
+            // 掲載状況の変更（読み切り・読了は対象外）
+            if !entry.isOneShot && entry.readingState != .archived {
+                if entry.publicationStatus != .active {
+                    Button {
+                        viewModel.setPublicationStatus(entry, to: .active)
+                    } label: {
+                        Label("連載に戻す", systemImage: "arrow.uturn.left")
+                    }
+                }
+                if entry.publicationStatus != .hiatus {
+                    Button {
+                        viewModel.setPublicationStatus(entry, to: .hiatus)
+                    } label: {
+                        Label("休載中にする", systemImage: "moon.zzz")
+                    }
+                }
+                if entry.publicationStatus != .finished {
+                    Button {
+                        viewModel.setPublicationStatus(entry, to: .finished)
+                    } label: {
+                        Label("完結にする", systemImage: "flag.checkered")
+                    }
+                }
+            }
+
+            // 読了 ↔ 戻す
             Button {
-                viewModel.setReadingState(entry, to: .following)
+                let newState: ReadingState = entry.readingState == .archived ? .following : .archived
+                viewModel.setReadingState(entry, to: newState)
             } label: {
-                Label("追いついた", systemImage: "checkmark.circle")
+                Label(entry.readingState == .archived ? "読了を取り消す" : "読了にする",
+                      systemImage: entry.readingState == .archived ? "arrow.uturn.left" : "checkmark.seal")
             }
-        }
-
-        // 掲載状況の変更（読み切り・読了は対象外）
-        if !entry.isOneShot && entry.readingState != .archived {
-            if entry.publicationStatus != .active {
-                Button {
-                    viewModel.setPublicationStatus(entry, to: .active)
-                } label: {
-                    Label("連載に戻す", systemImage: "arrow.uturn.left")
-                }
-            }
-            if entry.publicationStatus != .hiatus {
-                Button {
-                    viewModel.setPublicationStatus(entry, to: .hiatus)
-                } label: {
-                    Label("休載中にする", systemImage: "moon.zzz")
-                }
-            }
-            if entry.publicationStatus != .finished {
-                Button {
-                    viewModel.setPublicationStatus(entry, to: .finished)
-                } label: {
-                    Label("完結にする", systemImage: "flag.checkered")
-                }
-            }
-        }
-
-        // 読了 ↔ 戻す
-        Button {
-            let newState: ReadingState = entry.readingState == .archived ? .following : .archived
-            viewModel.setReadingState(entry, to: newState)
         } label: {
-            Label(entry.readingState == .archived ? "読了を取り消す" : "読了にする",
-                  systemImage: entry.readingState == .archived ? "arrow.uturn.left" : "checkmark.seal")
+            Label("状態を変更", systemImage: "slider.horizontal.3")
         }
+
+        Divider()
 
         Button(role: .destructive) {
             viewModel.queueDelete(entry)

--- a/MangaLauncher/Views/MangaCell/MangaContextMenu.swift
+++ b/MangaLauncher/Views/MangaCell/MangaContextMenu.swift
@@ -8,7 +8,11 @@ struct MangaContextMenu: View {
     var onReorder: (() -> Void)? = nil
 
     var body: some View {
-        // 既読/未読トグル（休載・読了は対象外）
+        // 既読/未読トグルの表示条件:
+        //  - 休載中: isRead が常に true 扱いなので未読トグル不要
+        //  - 読了 (archived): 常に既読扱い、専用の「読了を取り消す」ボタンから戻す
+        //  - 積読 (backlog): 表示する（ラベルを「今日読んだ」に変更して文脈を明示）
+        //  - 完結: 表示する（一度読んだら既読据え置きだが、最初の一読は必要）
         if entry.publicationStatus != .hiatus && entry.readingState != .archived {
             Button {
                 if entry.isRead {

--- a/MangaLauncher/Views/MangaCell/MangaContextMenu.swift
+++ b/MangaLauncher/Views/MangaCell/MangaContextMenu.swift
@@ -57,32 +57,40 @@ struct MangaContextMenu: View {
         Divider()
 
         // MARK: 状態変更（サブメニュー）
-        // 頻度の低い操作をまとめてトップメニューをすっきりさせる
+        // 現在の状態から遷移可能な選択肢のみを表示する。
+        // 「取り消す」のような曖昧なトグルを持たず、ユーザーが行き先を明示する。
         Menu {
-            // 読書状況 (追っかけ ↔ 積読)。読み切り・読了は invariant 上対象外
-            if !entry.isOneShot && entry.readingState != .archived {
-                if entry.readingState == .backlog {
-                    Button {
-                        viewModel.setReadingState(entry, to: .following)
-                    } label: {
-                        Label("追いついた", systemImage: "checkmark.circle")
-                    }
-                } else if entry.readingState == .following {
-                    Button {
-                        viewModel.setReadingState(entry, to: .backlog)
-                    } label: {
-                        Label("積読にする", systemImage: "books.vertical")
-                    }
+            // 読書状況の遷移
+            if entry.readingState != .following {
+                Button {
+                    viewModel.setReadingState(entry, to: .following)
+                } label: {
+                    Label("追っかけ中にする", systemImage: "eyes")
+                }
+            }
+            // 読み切りは invariant 上 backlog 不可
+            if !entry.isOneShot && entry.readingState != .backlog {
+                Button {
+                    viewModel.setReadingState(entry, to: .backlog)
+                } label: {
+                    Label("積読にする", systemImage: "books.vertical")
+                }
+            }
+            if entry.readingState != .archived {
+                Button {
+                    viewModel.setReadingState(entry, to: .archived)
+                } label: {
+                    Label("読了にする", systemImage: "checkmark.seal")
                 }
             }
 
-            // 掲載状況の変更（読み切り・読了は対象外）
+            // 掲載状況の遷移（読み切り・読了は対象外）
             if !entry.isOneShot && entry.readingState != .archived {
                 if entry.publicationStatus != .active {
                     Button {
                         viewModel.setPublicationStatus(entry, to: .active)
                     } label: {
-                        Label("連載に戻す", systemImage: "arrow.uturn.left")
+                        Label("連載中にする", systemImage: "book")
                     }
                 }
                 if entry.publicationStatus != .hiatus {
@@ -99,15 +107,6 @@ struct MangaContextMenu: View {
                         Label("完結にする", systemImage: "flag.checkered")
                     }
                 }
-            }
-
-            // 読了 ↔ 戻す
-            Button {
-                let newState: ReadingState = entry.readingState == .archived ? .following : .archived
-                viewModel.setReadingState(entry, to: newState)
-            } label: {
-                Label(entry.readingState == .archived ? "読了を取り消す" : "読了にする",
-                      systemImage: entry.readingState == .archived ? "arrow.uturn.left" : "checkmark.seal")
             }
         } label: {
             Label("状態を変更", systemImage: "slider.horizontal.3")

--- a/MangaLauncher/Views/MangaCell/MangaContextMenu.swift
+++ b/MangaLauncher/Views/MangaCell/MangaContextMenu.swift
@@ -10,7 +10,7 @@ struct MangaContextMenu: View {
     var body: some View {
         // MARK: 既読/未読トグル
         //  - 休載中: isRead が常に true 扱いなので未読トグル不要
-        //  - 読了 (archived): 常に既読扱い、専用の「読了を取り消す」ボタンから戻す
+        //  - 読了 (archived): 常に既読扱い。戻すには「状態を変更」から「追っかけ中にする」
         //  - 積読 (backlog): 表示する（ラベルを「今日読んだ」に変更して文脈を明示）
         //  - 完結: 表示する（一度読んだら既読据え置きだが、最初の一読は必要）
         if entry.publicationStatus != .hiatus && entry.readingState != .archived {

--- a/scripts/ota-distribute.sh
+++ b/scripts/ota-distribute.sh
@@ -152,8 +152,9 @@ MANIFEST
     done
 
     # Generate index.html with all builds
+    # sort -V でバージョン順 (1.9 < 1.10)、-r で新しい順
     local BUILD_ROWS=""
-    for BUILD_DIR in $(ls -1dr "$BUILDS_DIR"/*/); do
+    for BUILD_DIR in $(ls -1d "$BUILDS_DIR"/*/ | sort -Vr); do
         [ -d "$BUILD_DIR" ] || continue
         local BUILD_KEY=$(basename "$BUILD_DIR")
         local INFO_FILE="${BUILD_DIR}info.json"


### PR DESCRIPTION
## Summary

PR #159 (feature/backlog-mode) マージ後のレビュー指摘対応と、
コンテキストメニューの曖昧な UI 修正。本来 PR #159 に含める予定だった 6 コミットを
切り出して出し直すもの。

## 含まれる修正

### データ整合性
- **`MangaEntry.normalizeOneShotInvariants()`** を追加し、読み切り時の状態 invariant
  (`publicationStatus=.active` かつ `readingState != .backlog`) を中央で強制。
  `addEntry` / `updateEntry` / `migrateLegacyStateIfNeeded` から共通に呼び出し。
- **BackupData 復元ロジック** を分割。v6+ バックアップは新フィールドを authoritative
  とし、両方 nil のときだけ v5 以前の legacy Bool から導出。
- `markAsRead` の ReadingActivity 重複防止について、`ReadingActivity.init` が
  date を startOfDay に正規化していることをコメントで明示。

### UI / UX
- **コンテキストメニューの構造化**: 状態変更系を `Menu ▸` サブメニューに畳んでトップ
  レベルを 7 項目から 5 項目へ削減。
- **「読了を取り消す」廃止** → 明示的な状態遷移ボタンへ。archived から undo すると
  `.following` に固定されて積読情報が失われるバグを根治。読書状況も掲載状況と
  同じ「現在の状態から遷移可能な選択肢だけ表示」方式に統一。
- **「追っかけ中 → 積読にする」** を新規追加（従来は編集画面からしか設定できなかった）。
- **「連載に戻す」→「連載中にする」** に表記統一。
- **「読切」→「読み切り」** に表記統一 (`MangaStatusBadgeView` の full スタイル)。
- **CommentListView の delete swipe** に確認ダイアログを追加。

### クリーンアップ
- `MangaViewModel.updateMemo(_:memo:)` 削除 — メモ更新は `updateEntry()` に統合済
- `MangaViewModel.recentComments(limit:)` 削除 — `LibraryView` は `allComments()` を使用
- `SheetState.showingSettings` 削除 — Settings は RootTabView のタブに移行済
- `ColorLabelStore.displayLabel(for:)` 削除 — `label(for:)` のみ参照

### ツール
- `scripts/ota-distribute.sh`: builds 一覧の並び順を `ls -dr` から `sort -Vr` に
  変更し、v1.10 が v1.9 の上に来るよう修正。

## Test plan

- [x] `xcodebuild` 通る
- [x] 実機 (iPhone 15 Pro) にインストール & 起動
- [ ] 読書状況 3 ボタンの表示/遷移確認（特に archived → following → backlog）
- [ ] 読み切りで backlog ボタンが出ないこと
- [ ] BackupData export → import で状態が維持されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)