### PR TITLE
Use undo toast for comment delete

### DIFF
--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -506,7 +506,6 @@ final class MangaViewModel {
     func commitPendingCommentDeletes() {
         commentDeleteTimer?.invalidate()
         commentDeleteTimer = nil
-        guard !pendingDeleteComments.isEmpty else { return }
         for comment in pendingDeleteComments {
             modelContext.delete(comment)
         }

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -13,6 +13,8 @@ final class MangaViewModel {
     private(set) var refreshCounter = 0
     var pendingDeleteEntries: [MangaEntry] = []
     private var deleteTimer: Timer?
+    var pendingDeleteComments: [MangaComment] = []
+    private var commentDeleteTimer: Timer?
 
     private(set) var modelContext: ModelContext
 
@@ -485,6 +487,42 @@ final class MangaViewModel {
         save()
     }
 
+    // MARK: - Comment Undo Delete
+
+    /// コメントを削除キューに入れる。entry の queueDelete と同じ「5 秒後に commit / 間に undo 可」仕様。
+    func queueDeleteComment(_ comment: MangaComment) {
+        pendingDeleteComments.append(comment)
+        refreshCounter += 1
+        restartCommentDeleteTimer()
+    }
+
+    func undoPendingCommentDeletes() {
+        commentDeleteTimer?.invalidate()
+        commentDeleteTimer = nil
+        pendingDeleteComments.removeAll()
+        refreshCounter += 1
+    }
+
+    func commitPendingCommentDeletes() {
+        commentDeleteTimer?.invalidate()
+        commentDeleteTimer = nil
+        guard !pendingDeleteComments.isEmpty else { return }
+        for comment in pendingDeleteComments {
+            modelContext.delete(comment)
+        }
+        pendingDeleteComments.removeAll()
+        save()
+    }
+
+    private func restartCommentDeleteTimer() {
+        commentDeleteTimer?.invalidate()
+        commentDeleteTimer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: false) { [weak self] _ in
+            Task { @MainActor in
+                self?.commitPendingCommentDeletes()
+            }
+        }
+    }
+
     func fetchComments(for entry: MangaEntry) -> [MangaComment] {
         let _ = refreshCounter
         let entryID = entry.id
@@ -492,7 +530,8 @@ final class MangaViewModel {
             predicate: #Predicate { $0.mangaEntryID == entryID },
             sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
         )
-        return modelContext.fetchLogged(descriptor)
+        let pendingIDs = Set(pendingDeleteComments.map(\.id))
+        return modelContext.fetchLogged(descriptor).filter { !pendingIDs.contains($0.id) }
     }
 
     func allComments() -> [MangaComment] {
@@ -500,7 +539,8 @@ final class MangaViewModel {
         let descriptor = FetchDescriptor<MangaComment>(
             sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
         )
-        return modelContext.fetchLogged(descriptor)
+        let pendingIDs = Set(pendingDeleteComments.map(\.id))
+        return modelContext.fetchLogged(descriptor).filter { !pendingIDs.contains($0.id) }
     }
 
     func unreadCount(for day: DayOfWeek) -> Int {

--- a/MangaLauncher/Views/Comment/CommentListView.swift
+++ b/MangaLauncher/Views/Comment/CommentListView.swift
@@ -8,7 +8,6 @@ struct CommentListView: View {
     @State private var draft: String = ""
     @State private var editingComment: MangaComment?
     @State private var editingContent: String = ""
-    @State private var pendingDeleteComment: MangaComment?
     @FocusState private var composerFocused: Bool
 
     private var theme: ThemeStyle { ThemeManager.shared.style }
@@ -59,25 +58,17 @@ struct CommentListView: View {
             .sheet(item: $editingComment) { comment in
                 editSheet(for: comment)
             }
-            .confirmationDialog(
-                "このコメントを削除しますか？",
-                isPresented: Binding(
-                    get: { pendingDeleteComment != nil },
-                    set: { if !$0 { pendingDeleteComment = nil } }
-                ),
-                titleVisibility: .visible,
-                presenting: pendingDeleteComment
-            ) { comment in
-                Button("削除", role: .destructive) {
-                    viewModel.deleteComment(comment)
-                    pendingDeleteComment = nil
+            .overlay(alignment: .bottom) {
+                if !viewModel.pendingDeleteComments.isEmpty {
+                    DeleteToastView(
+                        count: viewModel.pendingDeleteComments.count,
+                        onUndo: { viewModel.undoPendingCommentDeletes() }
+                    )
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                    .padding(.bottom, 80) // composer を避ける
                 }
-                Button("キャンセル", role: .cancel) {
-                    pendingDeleteComment = nil
-                }
-            } message: { _ in
-                Text("この操作は取り消せません。")
             }
+            .animation(.easeInOut(duration: 0.3), value: viewModel.pendingDeleteComments.isEmpty)
         }
     }
 
@@ -100,7 +91,7 @@ struct CommentListView: View {
         .padding(.vertical, 4)
         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
             Button(role: .destructive) {
-                pendingDeleteComment = comment
+                viewModel.queueDeleteComment(comment)
             } label: {
                 Label("削除", systemImage: "trash")
             }

--- a/MangaLauncher/Views/Comment/CommentListView.swift
+++ b/MangaLauncher/Views/Comment/CommentListView.swift
@@ -69,6 +69,11 @@ struct CommentListView: View {
                 }
             }
             .animation(.easeInOut(duration: 0.3), value: viewModel.pendingDeleteComments.isEmpty)
+            .onDisappear {
+                // シートを閉じた時点で pending を確定させる。
+                // 閉じる前に undo していなければユーザーは削除を確定したものとみなす。
+                viewModel.commitPendingCommentDeletes()
+            }
         }
     }
 

--- a/MangaLauncher/Views/Common/DeleteToastView.swift
+++ b/MangaLauncher/Views/Common/DeleteToastView.swift
@@ -1,19 +1,19 @@
 import SwiftUI
 
 struct DeleteToastView: View {
-    var viewModel: MangaViewModel
+    let count: Int
+    let onUndo: () -> Void
 
     private var theme: ThemeStyle { ThemeManager.shared.style }
 
     var body: some View {
-        let count = viewModel.pendingDeleteEntries.count
         HStack {
             Text("\(count)件削除しました")
                 .font(theme.subheadlineFont)
                 .foregroundStyle(theme.onSurface)
             Spacer()
             Button {
-                viewModel.undoPendingDeletes()
+                onUndo()
             } label: {
                 Text("元に戻す")
                     .font(theme.subheadlineFont.bold())

--- a/MangaLauncher/Views/RootTabView.swift
+++ b/MangaLauncher/Views/RootTabView.swift
@@ -24,9 +24,12 @@ struct RootTabView: View {
         // どのタブから削除してもトーストが表示されるように全体 overlay で保持
         .overlay(alignment: .bottom) {
             if !viewModel.pendingDeleteEntries.isEmpty {
-                DeleteToastView(viewModel: viewModel)
-                    .transition(.move(edge: .bottom).combined(with: .opacity))
-                    .padding(.bottom, 80) // ボトムタブを避ける
+                DeleteToastView(
+                    count: viewModel.pendingDeleteEntries.count,
+                    onUndo: { viewModel.undoPendingDeletes() }
+                )
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+                .padding(.bottom, 80) // ボトムタブを避ける
             }
         }
         .animation(.easeInOut(duration: 0.3), value: viewModel.pendingDeleteEntries.isEmpty)


### PR DESCRIPTION
## Summary

コメント削除の確認 UI を `.confirmationDialog` / `.alert` から、entry 側と同じ
「queueDelete + 5 秒 undo トースト」パターンに統一する。

### 背景

- iPad で `.confirmationDialog` を source anchor なしに出すと popover の矢印
  位置が不定になっていた
- entry 側は既に undo 形式を採用しており、comment だけ確認ダイアログという
  のは一貫性を欠いていた

## 主な変更

### MangaViewModel
- `pendingDeleteComments` / `commentDeleteTimer` を追加
- `queueDeleteComment` / `undoPendingCommentDeletes` / `commitPendingCommentDeletes`
  / `restartCommentDeleteTimer` を追加（entry 側の queueDelete パターンを 1:1 ミラー）
- `fetchComments` / `allComments` が pending ID をフィルタ
- entry の timer と独立しているので両方が同時にキューに入っても干渉しない

### DeleteToastView
- `viewModel` 引数依存から `count` + `onUndo` クロージャに汎用化
- RootTabView（entry 用グローバル overlay）と CommentListView（sheet 内 overlay）
  から共通で利用

### CommentListView
- `.confirmationDialog` を廃止
- 右スワイプ削除で `queueDeleteComment` を呼び、overlay で undo トーストを表示
- `.onDisappear` で `commitPendingCommentDeletes` を呼び、シートを閉じた時点で
  pending を確定

## Test plan

- [x] `xcodebuild` 通る
- [x] 実機 (iPhone 15 Pro) で動作確認
- [ ] スワイプ削除 → 5 秒放置 → 自動 commit
- [ ] スワイプ削除 → undo で取り消し
- [ ] スワイプ削除 → 「閉じる」で dismiss → その場で commit
- [ ] entry 削除と同時にキューに入れたとき互いに干渉しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)