### PR TITLE
Add Control Center widgets and widget CatchUp button

### DIFF
--- a/MangaLauncher.xcodeproj/project.pbxproj
+++ b/MangaLauncher.xcodeproj/project.pbxproj
@@ -15,6 +15,11 @@
 		1299E093C31E1C940DD2CAC4 /* ImageCropView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC07D90615785B81C2E71C8 /* ImageCropView.swift */; };
 		2AA2BDFC2D4CFE5BF3F85D4A /* DataMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CF568E5CBBFA07B55373C73 /* DataMigration.swift */; };
 		3650352634B47DCA879C45C1 /* ChangeDayIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4117777580B33705902FA67A /* ChangeDayIntent.swift */; };
+		AB1001FF00112233AA000001 /* OpenAddEntryIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1001FF00112233AA000002 /* OpenAddEntryIntent.swift */; };
+		AB1001FF00112233AA000003 /* MangaControlWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1001FF00112233AA000004 /* MangaControlWidget.swift */; };
+		AB1001FF00112233AA000005 /* OpenAddEntryIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1001FF00112233AA000002 /* OpenAddEntryIntent.swift */; };
+		AB1001FF00112233AA000011 /* ControlIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1001FF00112233AA000012 /* ControlIntents.swift */; };
+		AB1001FF00112233AA000013 /* ControlIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1001FF00112233AA000012 /* ControlIntents.swift */; };
 		39725E0E00E8E4FE9F2A7FF2 /* UniformTypeIdentifiers.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BB770326E8D34706AF8B81EC /* UniformTypeIdentifiers.framework */; };
 		3E27882FDDEB43FF0F253020 /* BackupData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AFF912AECB7C6B219DD1600 /* BackupData.swift */; };
 		4064491CAC92BFC4CAEA647C /* MangaWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EFDC883F33BA3C119960C0B /* MangaWidget.swift */; };
@@ -162,6 +167,9 @@
 		3AFF912AECB7C6B219DD1600 /* BackupData.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BackupData.swift; sourceTree = "<group>"; };
 		40221490621705DE4B77F085 /* MangaShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = MangaShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		4117777580B33705902FA67A /* ChangeDayIntent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ChangeDayIntent.swift; sourceTree = "<group>"; };
+		AB1001FF00112233AA000002 /* OpenAddEntryIntent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OpenAddEntryIntent.swift; sourceTree = "<group>"; };
+		AB1001FF00112233AA000004 /* MangaControlWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MangaControlWidget.swift; sourceTree = "<group>"; };
+		AB1001FF00112233AA000012 /* ControlIntents.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ControlIntents.swift; sourceTree = "<group>"; };
 		501DFBA332C24E2F563C81D7 /* MangaWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = MangaWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		68E247987CED890FF8E2D6A1 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		7EFDC883F33BA3C119960C0B /* MangaWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MangaWidget.swift; sourceTree = "<group>"; };
@@ -325,6 +333,7 @@
 			isa = PBXGroup;
 			children = (
 				A55D3FF44BE586A52AAF2B43 /* AddMangaIntent.swift */,
+				AB1001FF00112233AA000012 /* ControlIntents.swift */,
 			);
 			path = Intents;
 			sourceTree = "<group>";
@@ -452,6 +461,8 @@
 				EC04B7E62F78E50F00AEE45F /* MangaWidgetAdhoc.entitlements */,
 				BC0276ADB2A6EFEC185148CA /* Info.plist */,
 				4117777580B33705902FA67A /* ChangeDayIntent.swift */,
+				AB1001FF00112233AA000002 /* OpenAddEntryIntent.swift */,
+				AB1001FF00112233AA000004 /* MangaControlWidget.swift */,
 			);
 			path = MangaWidget;
 			sourceTree = "<group>";
@@ -692,6 +703,9 @@
 				431F2DADE5A1315BB2611590 /* MangaEntry.swift in Sources */,
 				E79C1EBA2299356887386C0C /* SharedModelContainer.swift in Sources */,
 				3650352634B47DCA879C45C1 /* ChangeDayIntent.swift in Sources */,
+				AB1001FF00112233AA000001 /* OpenAddEntryIntent.swift in Sources */,
+				AB1001FF00112233AA000003 /* MangaControlWidget.swift in Sources */,
+				AB1001FF00112233AA000013 /* ControlIntents.swift in Sources */,
 				ECFEA8222F7E8B9D00CE4DC0 /* UserDefaultsKeys.swift in Sources */,
 				EC79B98AEA2FF142AA989EF0 /* AnimationTiming.swift in Sources */,
 				ECCE6BE2DD70F34BA69061B3 /* DesignSystem.swift in Sources */,
@@ -779,6 +793,8 @@
 				ECFEA8502F7F755F00CE4DC0 /* GridHelpers.swift in Sources */,
 				A1A8B2ACB18D6E541985F304 /* MasonryLayout.swift in Sources */,
 				B31B9EA2FE243CD2D6209258 /* AddMangaIntent.swift in Sources */,
+				AB1001FF00112233AA000005 /* OpenAddEntryIntent.swift in Sources */,
+				AB1001FF00112233AA000011 /* ControlIntents.swift in Sources */,
 				ECFEA8542F7F78B400CE4DC0 /* DayPagerView.swift in Sources */,
 				ECFEA8282F7E919A00CE4DC0 /* MangaContextMenu.swift in Sources */,
 				1299E093C31E1C940DD2CAC4 /* ImageCropView.swift in Sources */,

--- a/MangaLauncher/Intents/AddMangaIntent.swift
+++ b/MangaLauncher/Intents/AddMangaIntent.swift
@@ -2,38 +2,6 @@ import AppIntents
 import SwiftData
 import PlatformKit
 
-enum DayOfWeekAppEnum: String, AppEnum {
-    case sunday, monday, tuesday, wednesday, thursday, friday, saturday
-
-    static var typeDisplayRepresentation: TypeDisplayRepresentation {
-        "曜日"
-    }
-
-    static var caseDisplayRepresentations: [DayOfWeekAppEnum: DisplayRepresentation] {
-        [
-            .sunday: "日曜日",
-            .monday: "月曜日",
-            .tuesday: "火曜日",
-            .wednesday: "水曜日",
-            .thursday: "木曜日",
-            .friday: "金曜日",
-            .saturday: "土曜日",
-        ]
-    }
-
-    var toDayOfWeek: DayOfWeek {
-        switch self {
-        case .sunday: .sunday
-        case .monday: .monday
-        case .tuesday: .tuesday
-        case .wednesday: .wednesday
-        case .thursday: .thursday
-        case .friday: .friday
-        case .saturday: .saturday
-        }
-    }
-}
-
 enum IconColorAppEnum: String, AppEnum {
     case red, orange, yellow, green, blue, purple, pink, teal
 
@@ -104,29 +72,6 @@ struct AddMangaIntent: AppIntent {
             }
         }
 
-        return .result()
-    }
-}
-
-// MARK: - Open Day Intent
-
-struct OpenDayIntent: AppIntent {
-    static var title: LocalizedStringResource = "曜日を開く"
-    static var description: IntentDescription = "マンガ曜日で指定した曜日のタブを開きます"
-    static var openAppWhenRun = true
-
-    @Parameter(title: "曜日")
-    var dayOfWeek: DayOfWeekAppEnum
-
-    func perform() async throws -> some IntentResult {
-        let rawValue = dayOfWeek.toDayOfWeek.rawValue
-        // For when app needs to launch
-        let defaults = UserDefaults(suiteName: SharedModelContainer.appGroupIdentifier)
-        defaults?.set(rawValue, forKey: "pendingOpenDay")
-        // For when app is already running
-        await MainActor.run {
-            NotificationCenter.default.post(name: .switchToDay, object: rawValue)
-        }
         return .result()
     }
 }

--- a/MangaLauncher/Intents/ControlIntents.swift
+++ b/MangaLauncher/Intents/ControlIntents.swift
@@ -1,0 +1,173 @@
+import AppIntents
+import Foundation
+
+extension Notification.Name {
+    /// 曜日タブの切替リクエスト。object に DayOfWeek.rawValue (Int) を渡す。
+    /// 共有定義: app と widget extension の両方から参照される。
+    static let switchToDay = Notification.Name("switchToDay")
+    /// キャッチアップ画面の起動リクエスト。
+    static let openCatchUp = Notification.Name("openCatchUp")
+}
+
+// MARK: - Shared App Enums
+
+enum DayOfWeekAppEnum: String, AppEnum {
+    case sunday, monday, tuesday, wednesday, thursday, friday, saturday
+
+    static var typeDisplayRepresentation: TypeDisplayRepresentation {
+        "曜日"
+    }
+
+    static var caseDisplayRepresentations: [DayOfWeekAppEnum: DisplayRepresentation] {
+        [
+            .sunday: "日曜日",
+            .monday: "月曜日",
+            .tuesday: "火曜日",
+            .wednesday: "水曜日",
+            .thursday: "木曜日",
+            .friday: "金曜日",
+            .saturday: "土曜日",
+        ]
+    }
+
+    var toDayOfWeek: DayOfWeek {
+        switch self {
+        case .sunday: .sunday
+        case .monday: .monday
+        case .tuesday: .tuesday
+        case .wednesday: .wednesday
+        case .thursday: .thursday
+        case .friday: .friday
+        case .saturday: .saturday
+        }
+    }
+}
+
+// MARK: - Shared Intents
+
+/// Siri / Shortcuts から曜日タブを開く intent。MangaShortcuts provider で登録される。
+/// ControlWidget (ContextCenter) からも同じ型を利用する。
+struct OpenDayIntent: AppIntent {
+    static var title: LocalizedStringResource = "曜日を開く"
+    static var description: IntentDescription = "マンガ曜日で指定した曜日のタブを開きます"
+    static var openAppWhenRun = true
+
+    @Parameter(title: "曜日")
+    var dayOfWeek: DayOfWeekAppEnum
+
+    init() {
+        self.dayOfWeek = .monday
+    }
+
+    init(dayOfWeek: DayOfWeekAppEnum) {
+        self.dayOfWeek = dayOfWeek
+    }
+
+    func perform() async throws -> some IntentResult {
+        let rawValue = dayOfWeek.toDayOfWeek.rawValue
+        let defaults = UserDefaults(suiteName: SharedModelContainer.appGroupIdentifier)
+        defaults?.set(rawValue, forKey: "pendingOpenDay")
+        await MainActor.run {
+            NotificationCenter.default.post(name: .switchToDay, object: rawValue)
+        }
+        return .result()
+    }
+}
+
+/// コントロールセンター: 今日のマンガを開く。
+/// 実行時に DayOfWeek.today を解決するので、コントロール追加日時点で固定化されない。
+struct OpenTodayIntent: AppIntent {
+    static var title: LocalizedStringResource = "今日のマンガを開く"
+    static var description: IntentDescription = "マンガ曜日で今日の曜日のタブを開きます"
+    static var openAppWhenRun = true
+
+    func perform() async throws -> some IntentResult {
+        let raw = DayOfWeek.today.rawValue
+        let defaults = UserDefaults(suiteName: SharedModelContainer.appGroupIdentifier)
+        defaults?.set(raw, forKey: "pendingOpenDay")
+        await MainActor.run {
+            NotificationCenter.default.post(name: .switchToDay, object: raw)
+        }
+        return .result()
+    }
+}
+
+/// コントロールセンター: 今日のキャッチアップを開始。
+/// 現在の曜日タブに依存せず、常に「今日」のキャッチアップを起動する。
+struct OpenCatchUpIntent: AppIntent {
+    static var title: LocalizedStringResource = "今日のキャッチアップを開始"
+    static var description: IntentDescription = "今日の未読マンガをキャッチアップ画面で開きます"
+    static var openAppWhenRun = true
+
+    func perform() async throws -> some IntentResult {
+        let todayRaw = DayOfWeek.today.rawValue
+        let defaults = UserDefaults(suiteName: SharedModelContainer.appGroupIdentifier)
+        defaults?.set(todayRaw, forKey: "pendingOpenDay")
+        defaults?.set(true, forKey: "pendingOpenCatchUp")
+        await MainActor.run {
+            // 曜日を今日に切り替えてからキャッチアップを立ち上げる（順序重要）
+            NotificationCenter.default.post(name: .switchToDay, object: todayRaw)
+            NotificationCenter.default.post(name: .openCatchUp, object: nil)
+        }
+        return .result()
+    }
+}
+
+extension DayOfWeek {
+    /// AppIntents 層で使う DayOfWeekAppEnum への変換
+    var appEnum: DayOfWeekAppEnum {
+        switch self {
+        case .sunday: .sunday
+        case .monday: .monday
+        case .tuesday: .tuesday
+        case .wednesday: .wednesday
+        case .thursday: .thursday
+        case .friday: .friday
+        case .saturday: .saturday
+        }
+    }
+}
+
+/// ホームウィジェットから「指定曜日のキャッチアップ」を起動する intent。
+/// 曜日切替 + キャッチアップ起動をまとめて行う。
+struct OpenCatchUpForDayIntent: AppIntent {
+    static var title: LocalizedStringResource = "指定曜日のキャッチアップを開く"
+    static var isDiscoverable = false
+    static var openAppWhenRun = true
+
+    @Parameter(title: "曜日")
+    var dayOfWeek: DayOfWeekAppEnum
+
+    init() {
+        self.dayOfWeek = .monday
+    }
+
+    init(dayOfWeek: DayOfWeekAppEnum) {
+        self.dayOfWeek = dayOfWeek
+    }
+
+    func perform() async throws -> some IntentResult {
+        let raw = dayOfWeek.toDayOfWeek.rawValue
+        let defaults = UserDefaults(suiteName: SharedModelContainer.appGroupIdentifier)
+        defaults?.set(raw, forKey: "pendingOpenDay")
+        defaults?.set(true, forKey: "pendingOpenCatchUp")
+        await MainActor.run {
+            // 先に曜日を切り替えてから CatchUp を立ち上げる（順序重要）
+            NotificationCenter.default.post(name: .switchToDay, object: raw)
+            NotificationCenter.default.post(name: .openCatchUp, object: nil)
+        }
+        return .result()
+    }
+}
+
+/// コントロール追加時の曜日選択用。選択した曜日を ControlWidget 側で保持する。
+struct DayConfigurationIntent: ControlConfigurationIntent {
+    static var title: LocalizedStringResource = "曜日を選択"
+
+    /// ControlConfigurationIntent はパラメータの Optional を要求する。
+    /// 未設定時は MangaDayControl 側で .monday などにフォールバックする。
+    @Parameter(title: "曜日")
+    var dayOfWeek: DayOfWeekAppEnum?
+
+    init() {}
+}

--- a/MangaLauncher/MangaLauncherApp.swift
+++ b/MangaLauncher/MangaLauncherApp.swift
@@ -14,7 +14,7 @@ var systemColorScheme: ColorScheme {
 
 extension Notification.Name {
     static let mangaDataDidChange = CloudSyncMonitor.dataDidChangeNotification
-    static let switchToDay = Notification.Name("switchToDay")
+    // .switchToDay / .openCatchUp は ControlIntents.swift (widget extension とも共有) で定義
 }
 
 class NotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
@@ -97,11 +97,13 @@ struct MangaLauncherApp: App {
                 .onAppear {
                     checkPendingIntent()
                     checkPendingOpenDay()
+                    checkPendingOpenCatchUp()
                 }
                 .onChange(of: scenePhase) { _, newPhase in
                     if newPhase == .active {
                         checkPendingIntent()
                         checkPendingOpenDay()
+                        checkPendingOpenCatchUp()
                         NotificationCenter.default.post(name: .mangaDataDidChange, object: nil)
                         updateBadge()
                     }
@@ -140,6 +142,13 @@ struct MangaLauncherApp: App {
         guard let rawValue = defaults?.object(forKey: "pendingOpenDay") as? Int else { return }
         defaults?.removeObject(forKey: "pendingOpenDay")
         NotificationCenter.default.post(name: .switchToDay, object: rawValue)
+    }
+
+    private func checkPendingOpenCatchUp() {
+        let defaults = UserDefaults(suiteName: SharedModelContainer.appGroupIdentifier)
+        guard defaults?.bool(forKey: "pendingOpenCatchUp") == true else { return }
+        defaults?.removeObject(forKey: "pendingOpenCatchUp")
+        NotificationCenter.default.post(name: .openCatchUp, object: nil)
     }
 
     private func updateBadge() {

--- a/MangaLauncher/Views/Home/ContentView.swift
+++ b/MangaLauncher/Views/Home/ContentView.swift
@@ -46,6 +46,9 @@ struct ContentView: View {
                     homeState.paging.pageIndex = homeState.paging.pageIndexForDay(day)
                 }
             }
+            .onReceive(NotificationCenter.default.publisher(for: .openCatchUp)) { _ in
+                homeState.sheets.showingCatchUp = true
+            }
         }
     }
 

--- a/MangaLauncher/Views/RootTabView.swift
+++ b/MangaLauncher/Views/RootTabView.swift
@@ -1,25 +1,37 @@
 import SwiftUI
 
+enum RootTab: Hashable {
+    case home, library, settings, search
+}
+
 struct RootTabView: View {
     var viewModel: MangaViewModel
+    @State private var selectedTab: RootTab = .home
 
     var body: some View {
-        TabView {
-            Tab("ホーム", systemImage: "house.fill") {
+        TabView(selection: $selectedTab) {
+            Tab("ホーム", systemImage: "house.fill", value: RootTab.home) {
                 ContentView(viewModel: viewModel)
             }
 
-            Tab("ライブラリ", systemImage: "books.vertical.fill") {
+            Tab("ライブラリ", systemImage: "books.vertical.fill", value: RootTab.library) {
                 LibraryView(viewModel: viewModel)
             }
 
-            Tab("設定", systemImage: "gearshape.fill") {
+            Tab("設定", systemImage: "gearshape.fill", value: RootTab.settings) {
                 SettingsView(viewModel: viewModel, showsCloseButton: false)
             }
 
-            Tab(role: .search) {
+            Tab(value: RootTab.search, role: .search) {
                 SearchView(viewModel: viewModel)
             }
+        }
+        // コントロールセンターからの曜日切替・キャッチアップは Home タブに切り替えてから反映する
+        .onReceive(NotificationCenter.default.publisher(for: .switchToDay)) { _ in
+            selectedTab = .home
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .openCatchUp)) { _ in
+            selectedTab = .home
         }
         // どのタブから削除してもトーストが表示されるように全体 overlay で保持
         .overlay(alignment: .bottom) {

--- a/MangaWidget/MangaControlWidget.swift
+++ b/MangaWidget/MangaControlWidget.swift
@@ -1,0 +1,94 @@
+import AppIntents
+import SwiftUI
+import WidgetKit
+
+/// コントロールセンター: 「マンガを登録」ボタン
+struct MangaAddControl: ControlWidget {
+    var body: some ControlWidgetConfiguration {
+        StaticControlConfiguration(kind: "MangaAddControl") {
+            ControlWidgetButton(action: OpenAddEntryIntent()) {
+                Label("マンガを登録", systemImage: "plus.circle.fill")
+            }
+        }
+        .displayName("マンガを登録")
+        .description("新しいマンガをすばやく登録")
+    }
+}
+
+/// コントロールセンター: 「今日のマンガを開く」ボタン
+struct MangaTodayControl: ControlWidget {
+    var body: some ControlWidgetConfiguration {
+        StaticControlConfiguration(kind: "MangaTodayControl") {
+            ControlWidgetButton(action: OpenTodayIntent()) {
+                Label("今日のマンガ", systemImage: "calendar")
+            }
+        }
+        .displayName("今日のマンガを開く")
+        .description("マンガ曜日で今日のタブを開く")
+    }
+}
+
+/// コントロールセンター: 「今日のキャッチアップを開始」ボタン
+struct MangaCatchUpControl: ControlWidget {
+    var body: some ControlWidgetConfiguration {
+        StaticControlConfiguration(kind: "MangaCatchUpControl") {
+            ControlWidgetButton(action: OpenCatchUpIntent()) {
+                Label("今日のキャッチアップ", systemImage: "rectangle.stack.fill")
+            }
+        }
+        .displayName("今日のキャッチアップを開始")
+        .description("今日の未読マンガをスワイプでさばく")
+    }
+}
+
+/// コントロールセンター: 「曜日を選んでタブを開く」設定式ボタン。
+/// コントロール追加時に曜日を選び、タップでその曜日のタブを開く。
+struct MangaDayControl: ControlWidget {
+    var body: some ControlWidgetConfiguration {
+        AppIntentControlConfiguration(
+            kind: "MangaDayControl",
+            intent: DayConfigurationIntent.self
+        ) { configuration in
+            let day = configuration.dayOfWeek ?? .monday
+            ControlWidgetButton(action: openDayIntent(for: day)) {
+                Label(day.label, systemImage: day.iconName)
+            }
+        }
+        .displayName("曜日のタブを開く")
+        .description("選んだ曜日のタブを開く")
+    }
+
+    private func openDayIntent(for day: DayOfWeekAppEnum) -> OpenDayIntent {
+        var intent = OpenDayIntent()
+        intent.dayOfWeek = day
+        return intent
+    }
+}
+
+private extension DayOfWeekAppEnum {
+    var label: String {
+        switch self {
+        case .sunday: "日曜日"
+        case .monday: "月曜日"
+        case .tuesday: "火曜日"
+        case .wednesday: "水曜日"
+        case .thursday: "木曜日"
+        case .friday: "金曜日"
+        case .saturday: "土曜日"
+        }
+    }
+
+    /// 曜日の漢字の由来 (陰陽五行 + 太陽 + 月) に対応した SF Symbol。
+    /// 日=太陽, 月=月, 火=炎, 水=水滴, 木=木, 金=金属(レンチ), 土=大地(山)
+    var iconName: String {
+        switch self {
+        case .sunday: "sun.max.fill"
+        case .monday: "moon.fill"
+        case .tuesday: "flame.fill"
+        case .wednesday: "drop.fill"
+        case .thursday: "tree.fill"
+        case .friday: "wrench.fill"
+        case .saturday: "mountain.2.fill"
+        }
+    }
+}

--- a/MangaWidget/MangaWidget.swift
+++ b/MangaWidget/MangaWidget.swift
@@ -141,7 +141,25 @@ struct MangaWidgetEntryView: View {
             Text("\(entry.items.count)件")
                 .font(.system(size: 9))
                 .foregroundStyle(.secondary)
+
+            // 表示中の曜日に未読があれば右端にキャッチアップボタンを出す
+            if unreadCount > 0 {
+                Button(intent: OpenCatchUpForDayIntent(dayOfWeek: entry.dayOfWeek.appEnum)) {
+                    Image(systemName: "rectangle.stack.fill")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundStyle(.white)
+                        .frame(width: 20, height: 20)
+                        .background(Color.accentColor, in: Circle())
+                        .padding(.leading, 6)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+            }
         }
+    }
+
+    private var unreadCount: Int {
+        entry.items.filter { !$0.isRead }.count
     }
 
     // MARK: - Small Widget (2x2)
@@ -350,9 +368,21 @@ struct MangaWidgetEntryView: View {
 
 }
 
-// MARK: - Widget Declaration
+// MARK: - Widget Bundle
 
 @main
+struct MangaLauncherWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        MangaLauncherWidget()
+        MangaAddControl()
+        MangaTodayControl()
+        MangaCatchUpControl()
+        MangaDayControl()
+    }
+}
+
+// MARK: - Widget Declaration
+
 struct MangaLauncherWidget: Widget {
     let kind = "MangaWidget"
 

--- a/MangaWidget/OpenAddEntryIntent.swift
+++ b/MangaWidget/OpenAddEntryIntent.swift
@@ -1,0 +1,18 @@
+import AppIntents
+
+/// コントロールセンターから「マンガを登録」を起動するための intent。
+/// アプリを開いて EditEntryView を立ち上げるだけのシグナルを出す。
+/// AddMangaIntent と違いパラメータを取らない。
+struct OpenAddEntryIntent: AppIntent {
+    static var title: LocalizedStringResource = "マンガを登録"
+    static var description: IntentDescription = "マンガ曜日の新規登録画面を開きます"
+    static var openAppWhenRun = true
+
+    func perform() async throws -> some IntentResult {
+        // App 側 checkPendingIntent が空 dict を受け取るとデフォルト値で
+        // EditEntryView を開くので、空 dict を設定するだけで十分。
+        let defaults = UserDefaults(suiteName: SharedModelContainer.appGroupIdentifier)
+        defaults?.set([String: String](), forKey: "pendingIntentData")
+        return .result()
+    }
+}


### PR DESCRIPTION
## Summary

iOS 18 のコントロールセンターにマンガ曜日のクイックアクションを追加し、ホーム画面ウィジェットにもキャッチアップ起動ボタンを載せる。

## コントロールセンターウィジェット

| コントロール | 種類 | 動作 |
|---|---|---|
| マンガを登録 | static | 新規登録画面 (EditEntryView) を開く |
| 今日のマンガを開く | static | 今日の曜日タブを Home に開く |
| 今日のキャッチアップを開始 | static | 今日の未読をキャッチアップ画面で開く |
| 曜日のタブを開く | configurable | 追加時に曜日を選び、その曜日のタブを開く |

configurable の曜日選択は `DayConfigurationIntent` で実現。曜日ごとに SF Symbol を変えることで、コントロールセンターに並べたときに何曜日か一目で分かるようにした。

| 曜日 | Symbol |
|---|---|
| 日 | \`sun.max.fill\` |
| 月 | \`moon.fill\` |
| 火 | \`flame.fill\` |
| 水 | \`drop.fill\` |
| 木 | \`tree.fill\` |
| 金 | \`wrench.fill\` |
| 土 | \`mountain.2.fill\` |

## ホーム画面ウィジェット

既存の \`MangaLauncherWidget\` ヘッダー右端に丸型キャッチアップボタンを追加。アクセントカラー背景 + 白アイコンで FAB 風の押しやすい見た目にした。未読が 0 件のときは非表示。表示中の曜日のキャッチアップを起動する (\`OpenCatchUpForDayIntent\`)。

## アプリ側の対応

### タブ切替
\`RootTabView\` に \`@State selectedTab: RootTab\` を追加。\`.switchToDay\` / \`.openCatchUp\` 通知を受けたら Home タブへ強制切替し、どのタブにいてもコントロールの挙動が見えるようにした。

### キャッチアップの起動
- \`MangaLauncherApp.checkPendingOpenCatchUp()\`: 起動時・前面復帰時に \`pendingOpenCatchUp\` を読んで通知を投げる
- \`ContentView.onReceive(.openCatchUp)\`: fullScreenCover で CatchUpView を立ち上げ

## Intent リファクタ

\`DayOfWeekAppEnum\` / \`OpenDayIntent\` を \`AddMangaIntent.swift\` (app target 専用) から \`ControlIntents.swift\` (app + widget 共有) に移動。\`MangaShortcuts: AppShortcutsProvider\` は app target に残し、widget にも AppShortcutsProvider が自動登録されて Shortcuts App で曜日インテントが二重表示される問題を回避した。

\`.switchToDay\` / \`.openCatchUp\` の Notification.Name も共有ファイルで定義し直した。

## Test plan

- [x] \`xcodebuild\` 通る
- [x] 実機 (iPhone 15 Pro) で動作確認
- [x] コントロール 4 種それぞれが期待通りに動く (登録/今日/キャッチアップ/曜日configurable)
- [x] 曜日 configurable で 7 曜日分追加しても動く
- [x] ホーム画面ウィジェットのキャッチアップボタンが、表示中の曜日で CatchUp を開く
- [x] 他のタブから control 起動しても Home に切り替わって反映
- [x] Shortcuts App で曜日インテントが重複していない
- [x] 既存の Siri 発話 (「マンガ曜日に\${曜日}を開く」等) が引き続き動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)