### PR TITLE
Add activity timeline with week strip and month picker

### DIFF
--- a/MangaLauncher.xcodeproj/project.pbxproj
+++ b/MangaLauncher.xcodeproj/project.pbxproj
@@ -52,6 +52,11 @@
 		BC000003 /* MangaComment.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000010 /* MangaComment.swift */; };
 		BC000101 /* CommentListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000110 /* CommentListView.swift */; };
 		BC000301 /* ActivityItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000310 /* ActivityItem.swift */; };
+		AB2001FF00112233AA000001 /* TimelineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2001FF00112233AA000002 /* TimelineItem.swift */; };
+		AB2001FF00112233AA000003 /* TimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2001FF00112233AA000004 /* TimelineView.swift */; };
+		AB2001FF00112233AA000005 /* TimelineRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2001FF00112233AA000006 /* TimelineRowView.swift */; };
+		AB2001FF00112233AA000008 /* WeekStripView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2001FF00112233AA000009 /* WeekStripView.swift */; };
+		AB2001FF00112233AA00000A /* ActivityCalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2001FF00112233AA00000B /* ActivityCalendarView.swift */; };
 		BC000401 /* MangaStatusBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000410 /* MangaStatusBadgeView.swift */; };
 		BC000501 /* SectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000510 /* SectionHeaderView.swift */; };
 		BC000801 /* MangaDataChangeModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000810 /* MangaDataChangeModifier.swift */; };
@@ -196,6 +201,11 @@
 		BC000010 /* MangaComment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaComment.swift; sourceTree = "<group>"; };
 		BC000110 /* CommentListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentListView.swift; sourceTree = "<group>"; };
 		BC000310 /* ActivityItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityItem.swift; sourceTree = "<group>"; };
+		AB2001FF00112233AA000002 /* TimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineItem.swift; sourceTree = "<group>"; };
+		AB2001FF00112233AA000004 /* TimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineView.swift; sourceTree = "<group>"; };
+		AB2001FF00112233AA000006 /* TimelineRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineRowView.swift; sourceTree = "<group>"; };
+		AB2001FF00112233AA000009 /* WeekStripView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeekStripView.swift; sourceTree = "<group>"; };
+		AB2001FF00112233AA00000B /* ActivityCalendarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityCalendarView.swift; sourceTree = "<group>"; };
 		BC000410 /* MangaStatusBadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaStatusBadgeView.swift; sourceTree = "<group>"; };
 		BC000510 /* SectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionHeaderView.swift; sourceTree = "<group>"; };
 		BC000810 /* MangaDataChangeModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaDataChangeModifier.swift; sourceTree = "<group>"; };
@@ -376,6 +386,7 @@
 				AA000010 /* ReadingActivity.swift */,
 				BC000010 /* MangaComment.swift */,
 				BC000310 /* ActivityItem.swift */,
+				AB2001FF00112233AA000002 /* TimelineItem.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -428,8 +439,20 @@
 				BC000630 /* AllPublishersView.swift */,
 				BC000640 /* LibrarySection.swift */,
 				BC000650 /* LibrarySectionBuilder.swift */,
+				AB2001FF00112233AA000007 /* Timeline */,
 			);
 			path = Library;
+			sourceTree = "<group>";
+		};
+		AB2001FF00112233AA000007 /* Timeline */ = {
+			isa = PBXGroup;
+			children = (
+				AB2001FF00112233AA000004 /* TimelineView.swift */,
+				AB2001FF00112233AA000006 /* TimelineRowView.swift */,
+				AB2001FF00112233AA000009 /* WeekStripView.swift */,
+				AB2001FF00112233AA00000B /* ActivityCalendarView.swift */,
+			);
+			path = Timeline;
 			sourceTree = "<group>";
 		};
 		A5000005 /* ViewModels */ = {
@@ -769,6 +792,11 @@
 				BC000605 /* LibrarySectionBuilder.swift in Sources */,
 				BC000101 /* CommentListView.swift in Sources */,
 				BC000301 /* ActivityItem.swift in Sources */,
+				AB2001FF00112233AA000001 /* TimelineItem.swift in Sources */,
+				AB2001FF00112233AA000003 /* TimelineView.swift in Sources */,
+				AB2001FF00112233AA000005 /* TimelineRowView.swift in Sources */,
+				AB2001FF00112233AA000008 /* WeekStripView.swift in Sources */,
+				AB2001FF00112233AA00000A /* ActivityCalendarView.swift in Sources */,
 				BC000401 /* MangaStatusBadgeView.swift in Sources */,
 				BC000501 /* SectionHeaderView.swift in Sources */,
 				BC000801 /* MangaDataChangeModifier.swift in Sources */,

--- a/MangaLauncher/Models/ReadingActivity.swift
+++ b/MangaLauncher/Models/ReadingActivity.swift
@@ -4,13 +4,18 @@ import SwiftData
 @Model
 final class ReadingActivity {
     var id: UUID = UUID()
+    /// 日単位に正規化された日付。heatmap の集計や同日重複 insert 防止に使う。
     var date: Date = Date()
+    /// 秒単位のタイムスタンプ。タイムラインで時刻を表示するのに使う。
+    /// 旧データは nil。新規 insert では date 引数の full timestamp を保持する。
+    var timestamp: Date?
     var mangaName: String = ""
     var mangaEntryID: UUID = UUID()
 
     init(date: Date, mangaName: String, mangaEntryID: UUID) {
         self.id = UUID()
         self.date = Calendar.current.startOfDay(for: date)
+        self.timestamp = date
         self.mangaName = mangaName
         self.mangaEntryID = mangaEntryID
     }

--- a/MangaLauncher/Models/TimelineItem.swift
+++ b/MangaLauncher/Models/TimelineItem.swift
@@ -1,0 +1,162 @@
+import Foundation
+
+/// 1 日のアクティビティタイムラインを構成する単一アイテム。
+/// コメント / メモ更新 / 読んだ記録 を統一的に並べるための sum type。
+enum TimelineItem: Identifiable {
+    case comment(MangaComment, MangaEntry)
+    case memo(MangaEntry)
+    case read(ReadingActivity, MangaEntry?)
+
+    var id: String {
+        switch self {
+        case .comment(let comment, _): return "c-\(comment.id.uuidString)"
+        case .memo(let entry): return "m-\(entry.id.uuidString)"
+        case .read(let activity, _): return "r-\(activity.id.uuidString)"
+        }
+    }
+
+    /// タイムライン上の時刻。秒単位で並べるときに使う。
+    /// 旧 ReadingActivity は timestamp が nil なので startOfDay にフォールバック。
+    /// 正確な時刻かどうかは `hasPreciseTime` で判定する。
+    var timestamp: Date {
+        switch self {
+        case .comment(let comment, _): return comment.updatedAt ?? comment.createdAt
+        case .memo(let entry): return entry.memoUpdatedAt ?? .distantPast
+        case .read(let activity, _): return activity.timestamp ?? activity.date
+        }
+    }
+
+    /// timestamp が秒単位の情報を持つか。旧 ReadingActivity (timestamp == nil) は false。
+    var hasPreciseTime: Bool {
+        switch self {
+        case .comment, .memo: return true
+        case .read(let activity, _): return activity.timestamp != nil
+        }
+    }
+
+    /// 関連エントリ。読んだ記録で entry が見つからなかった場合のみ nil。
+    var entry: MangaEntry? {
+        switch self {
+        case .comment(_, let entry): return entry
+        case .memo(let entry): return entry
+        case .read(_, let entry): return entry
+        }
+    }
+
+    var mangaName: String {
+        switch self {
+        case .comment(_, let entry): return entry.name
+        case .memo(let entry): return entry.name
+        case .read(let activity, let entry): return entry?.name ?? activity.mangaName
+        }
+    }
+}
+
+// MARK: - Filter
+
+/// タイムラインの種別フィルタ。チップ UI のソース。
+enum TimelineFilter: String, CaseIterable, Hashable, Identifiable {
+    case all, comment, memo, read
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .all: "すべて"
+        case .comment: "コメント"
+        case .memo: "メモ"
+        case .read: "既読"
+        }
+    }
+
+    var iconName: String {
+        switch self {
+        case .all: "list.bullet"
+        case .comment: "bubble.left.fill"
+        case .memo: "pencil"
+        case .read: "checkmark"
+        }
+    }
+
+    func apply(to items: [TimelineItem]) -> [TimelineItem] {
+        switch self {
+        case .all:
+            return items
+        case .comment:
+            return items.filter { if case .comment = $0 { true } else { false } }
+        case .memo:
+            return items.filter { if case .memo = $0 { true } else { false } }
+        case .read:
+            return items.filter { if case .read = $0 { true } else { false } }
+        }
+    }
+}
+
+/// TimelineItem を構築する純関数群。
+/// 呼び出し側は必要なデータを一度 fetch して渡す（N+1 fetch を避ける）。
+enum TimelineBuilder {
+    /// 指定日のアクティビティを時系列降順で返す。
+    static func items(
+        for date: Date,
+        entries: [MangaEntry],
+        comments: [MangaComment],
+        activities: [ReadingActivity]
+    ) -> [TimelineItem] {
+        let calendar = Calendar.current
+        let startOfDay = calendar.startOfDay(for: date)
+        let endOfDay = calendar.date(byAdding: .day, value: 1, to: startOfDay) ?? startOfDay
+
+        let entriesByID = Dictionary(uniqueKeysWithValues: entries.map { ($0.id, $0) })
+
+        var items: [TimelineItem] = []
+
+        // Comments
+        for comment in comments {
+            guard comment.createdAt >= startOfDay, comment.createdAt < endOfDay else { continue }
+            guard let entry = entriesByID[comment.mangaEntryID] else { continue }
+            items.append(.comment(comment, entry))
+        }
+
+        // Memo updates
+        for entry in entries {
+            guard let updated = entry.memoUpdatedAt,
+                  updated >= startOfDay, updated < endOfDay,
+                  !entry.memo.isEmpty else { continue }
+            items.append(.memo(entry))
+        }
+
+        // Reading activities
+        for activity in activities {
+            guard activity.date >= startOfDay, activity.date < endOfDay else { continue }
+            items.append(.read(activity, entriesByID[activity.mangaEntryID]))
+        }
+
+        // 昇順 (朝→夜) で 1 日の流れを読めるようにする
+        return items.sorted { $0.timestamp < $1.timestamp }
+    }
+
+    /// アクティビティがあった日 (startOfDay) の集合。
+    /// WeekStripView などでドット表示に使う。
+    /// items() と同じ可視条件で判定し、孤児コメント (entry 不在) はカウントしない。
+    static func activeDays(
+        entries: [MangaEntry],
+        comments: [MangaComment],
+        activities: [ReadingActivity]
+    ) -> Set<Date> {
+        let calendar = Calendar.current
+        let entryIDs = Set(entries.map(\.id))
+        var days = Set<Date>()
+        for comment in comments where entryIDs.contains(comment.mangaEntryID) {
+            days.insert(calendar.startOfDay(for: comment.createdAt))
+        }
+        for entry in entries {
+            if let updated = entry.memoUpdatedAt, !entry.memo.isEmpty {
+                days.insert(calendar.startOfDay(for: updated))
+            }
+        }
+        for activity in activities {
+            days.insert(calendar.startOfDay(for: activity.date))
+        }
+        return days
+    }
+}

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -273,6 +273,10 @@ final class MangaViewModel {
         for activity in modelContext.fetchLogged(activityDescriptor) {
             modelContext.delete(activity)
         }
+        let commentDescriptor = FetchDescriptor<MangaComment>()
+        for comment in modelContext.fetchLogged(commentDescriptor) {
+            modelContext.delete(comment)
+        }
         UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.lastStreakShownDate)
         UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.shownMilestones)
         do {
@@ -540,6 +544,17 @@ final class MangaViewModel {
         )
         let pendingIDs = Set(pendingDeleteComments.map(\.id))
         return modelContext.fetchLogged(descriptor).filter { !pendingIDs.contains($0.id) }
+    }
+
+    /// タイムラインのアクティビティドットや日別集計に使う全 ReadingActivity。
+    /// ReadingStatsProvider.fetchActivityCounts は日付→件数のマップで情報が
+    /// 抜けるため、個々の record が欲しい用途はこちらを使う。
+    func allActivities() -> [ReadingActivity] {
+        let _ = refreshCounter
+        let descriptor = FetchDescriptor<ReadingActivity>(
+            sortBy: [SortDescriptor(\.date, order: .reverse)]
+        )
+        return modelContext.fetchLogged(descriptor)
     }
 
     func unreadCount(for day: DayOfWeek) -> Int {

--- a/MangaLauncher/Views/Library/LibrarySection.swift
+++ b/MangaLauncher/Views/Library/LibrarySection.swift
@@ -28,4 +28,5 @@ struct LibrarySection: Identifiable {
 enum LibraryDestination: Hashable {
     case allActivity
     case allPublishers
+    case timeline
 }

--- a/MangaLauncher/Views/Library/LibraryView.swift
+++ b/MangaLauncher/Views/Library/LibraryView.swift
@@ -79,6 +79,7 @@ struct LibraryView: View {
         } else {
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 24) {
+                    timelineLink
                     if !recentActivity.isEmpty {
                         recentActivitySection(items: recentActivity, totalCount: totalActivityCount)
                     }
@@ -110,7 +111,37 @@ struct LibraryView: View {
                 commentingEntry: $commentingEntry,
                 onOpenURL: { openMangaURL($0) }
             )
+        case .timeline:
+            TimelineView(viewModel: viewModel)
         }
+    }
+
+    @ViewBuilder
+    private var timelineLink: some View {
+        NavigationLink(value: LibraryDestination.timeline) {
+            HStack(spacing: 10) {
+                Image(systemName: "chart.bar.doc.horizontal.fill")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(.white)
+                    .frame(width: 28, height: 28)
+                    .background(Color.indigo, in: RoundedRectangle(cornerRadius: 6))
+                Text("タイムライン")
+                    .font(theme.subheadlineFont.weight(.semibold))
+                    .foregroundStyle(theme.onSurface)
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundStyle(theme.onSurfaceVariant)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(theme.surfaceContainerHigh)
+            )
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal)
     }
 
     @ViewBuilder

--- a/MangaLauncher/Views/Library/Timeline/ActivityCalendarView.swift
+++ b/MangaLauncher/Views/Library/Timeline/ActivityCalendarView.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+import UIKit
+
+/// アクティビティがあった日にドット装飾を出す月 grid カレンダー。
+/// SwiftUI の DatePicker(.graphical) は装飾 API が無いため、
+/// UIKit の UICalendarView を UIViewRepresentable で包んで使う。
+struct ActivityCalendarView: UIViewRepresentable {
+    @Binding var selectedDate: Date
+    /// startOfDay に正規化されたアクティビティありの日付集合。
+    let activeDays: Set<Date>
+
+    func makeUIView(context: Context) -> UICalendarView {
+        let view = UICalendarView()
+        view.locale = Locale(identifier: "ja_JP")
+        view.delegate = context.coordinator
+        view.fontDesign = .default
+
+        let selection = UICalendarSelectionSingleDate(delegate: context.coordinator)
+        selection.selectedDate = dateComponents(from: selectedDate)
+        view.selectionBehavior = selection
+
+        // 最初に表示する月を選択日に合わせる
+        view.visibleDateComponents = dateComponents(from: selectedDate)
+
+        return view
+    }
+
+    func updateUIView(_ uiView: UICalendarView, context: Context) {
+        context.coordinator.activeDays = activeDays
+
+        // 外部から selectedDate が変わったときに選択状態を同期
+        if let selection = uiView.selectionBehavior as? UICalendarSelectionSingleDate {
+            let current = dateComponents(from: selectedDate)
+            if selection.selectedDate != current {
+                selection.selectedDate = current
+            }
+        }
+
+        // ドット装飾を再評価 (activeDays 更新後や月切替時の抜けを埋める)
+        uiView.reloadDecorations(forDateComponents: [], animated: false)
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(selectedDate: $selectedDate, activeDays: activeDays)
+    }
+
+    private func dateComponents(from date: Date) -> DateComponents {
+        Calendar.current.dateComponents([.year, .month, .day], from: date)
+    }
+
+    final class Coordinator: NSObject, UICalendarViewDelegate, UICalendarSelectionSingleDateDelegate {
+        @Binding var selectedDate: Date
+        var activeDays: Set<Date>
+
+        init(selectedDate: Binding<Date>, activeDays: Set<Date>) {
+            self._selectedDate = selectedDate
+            self.activeDays = activeDays
+        }
+
+        func calendarView(
+            _ calendarView: UICalendarView,
+            decorationFor dateComponents: DateComponents
+        ) -> UICalendarView.Decoration? {
+            guard let date = Calendar.current.date(from: dateComponents) else { return nil }
+            let day = Calendar.current.startOfDay(for: date)
+            guard activeDays.contains(day) else { return nil }
+            return .default(color: .tintColor, size: .small)
+        }
+
+        func dateSelection(
+            _ selection: UICalendarSelectionSingleDate,
+            didSelectDate dateComponents: DateComponents?
+        ) {
+            guard let components = dateComponents,
+                  let date = Calendar.current.date(from: components) else { return }
+            selectedDate = Calendar.current.startOfDay(for: date)
+        }
+    }
+}

--- a/MangaLauncher/Views/Library/Timeline/TimelineRowView.swift
+++ b/MangaLauncher/Views/Library/Timeline/TimelineRowView.swift
@@ -1,0 +1,140 @@
+import SwiftUI
+
+/// TimelineView の 1 行。時刻ラベル + 縦線 + タイプアイコン + 内容カード。
+struct TimelineRowView: View {
+    let item: TimelineItem
+    let isFirst: Bool
+    let isLast: Bool
+    var onTap: () -> Void = {}
+
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
+    private static let timeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "HH:mm"
+        return f
+    }()
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            timeColumn
+            connector
+            card
+        }
+        .contentShape(Rectangle())
+        .onTapGesture { onTap() }
+    }
+
+    // MARK: - Time label (left column)
+    @ViewBuilder
+    private var timeColumn: some View {
+        Text(item.hasPreciseTime ? Self.timeFormatter.string(from: item.timestamp) : "--:--")
+            .font(theme.captionFont.monospacedDigit())
+            .foregroundStyle(item.hasPreciseTime ? theme.onSurfaceVariant : theme.onSurfaceVariant.opacity(0.5))
+            .frame(width: 42, alignment: .trailing)
+            .padding(.top, 2)
+    }
+
+    // MARK: - Vertical connector with dot/icon
+    @ViewBuilder
+    private var connector: some View {
+        VStack(spacing: 0) {
+            // top half line
+            Rectangle()
+                .fill(isFirst ? Color.clear : theme.onSurfaceVariant.opacity(0.25))
+                .frame(width: 2)
+                .frame(height: 8)
+
+            // type icon in a circle
+            Image(systemName: icon.name)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.white)
+                .frame(width: 22, height: 22)
+                .background(icon.color, in: Circle())
+
+            // bottom line (extends to next row)
+            Rectangle()
+                .fill(isLast ? Color.clear : theme.onSurfaceVariant.opacity(0.25))
+                .frame(width: 2)
+                .frame(maxHeight: .infinity)
+        }
+    }
+
+    // MARK: - Content card
+    @ViewBuilder
+    private var card: some View {
+        HStack(alignment: .top, spacing: 10) {
+            thumbnail
+            VStack(alignment: .leading, spacing: 4) {
+                Text(item.mangaName)
+                    .font(theme.subheadlineFont.weight(.semibold))
+                    .foregroundStyle(theme.onSurface)
+                    .lineLimit(1)
+                content
+                    .font(theme.captionFont)
+                    .foregroundStyle(theme.onSurfaceVariant)
+                    .lineLimit(2)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(.vertical, 10)
+        .padding(.horizontal, 12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(theme.surfaceContainerHigh)
+        )
+        .padding(.vertical, 2)
+    }
+
+    /// マンガの表紙サムネイル。画像がなければアイコンカラーの塊を返す。
+    @ViewBuilder
+    private var thumbnail: some View {
+        let size: CGFloat = 40
+        Group {
+            if let entry = item.entry,
+               let data = entry.imageData,
+               let image = data.toSwiftUIImage() {
+                image
+                    .resizable()
+                    .scaledToFill()
+            } else if let entry = item.entry {
+                Color.fromName(entry.iconColor)
+                    .overlay {
+                        Text(entry.name.prefix(1))
+                            .font(.system(size: 14, weight: .bold))
+                            .foregroundStyle(.white)
+                    }
+            } else {
+                Color.fromName("blue").opacity(0.3)
+            }
+        }
+        .frame(width: size, height: size)
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch item {
+        case .comment(let comment, _):
+            Text(comment.content)
+        case .memo(let entry):
+            if entry.memo.isEmpty {
+                Text("(空)")
+            } else {
+                Text(entry.memo)
+            }
+        case .read:
+            Text("読みました")
+        }
+    }
+
+    // MARK: - Icon / color per type
+    private var icon: (name: String, color: Color) {
+        switch item {
+        case .comment: return ("bubble.left.fill", .blue)
+        case .memo: return ("pencil", .orange)
+        case .read: return ("checkmark", .green)
+        }
+    }
+}

--- a/MangaLauncher/Views/Library/Timeline/TimelineView.swift
+++ b/MangaLauncher/Views/Library/Timeline/TimelineView.swift
@@ -1,0 +1,239 @@
+import SwiftUI
+
+/// 1 日のアクティビティ (コメント / メモ / 既読) を時系列に並べる画面。
+/// WeekStripView で日付切替、ActivityCalendarView で月 grid ピッカー、
+/// TimelineFilter で種別フィルタを提供する。
+struct TimelineView: View {
+    @Environment(\.openURL) private var openURL
+    var viewModel: MangaViewModel
+    @State private var selectedDate: Date = Date()
+    @State private var editingEntry: MangaEntry?
+    @State private var commentingEntry: MangaEntry?
+    @State private var safariURL: URL?
+    @State private var filter: TimelineFilter = .all
+    @State private var showingMonthPicker = false
+    @AppStorage("browserMode") private var browserMode: String = "external"
+
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
+    var body: some View {
+        // 1 度だけ fetch して week strip とタイムラインで共有する
+        let _ = viewModel.refreshCounter
+        let allEntries = viewModel.allEntries()
+        let allComments = viewModel.allComments()
+        let allActivities = viewModel.allActivities()
+        let activeDays = TimelineBuilder.activeDays(
+            entries: allEntries,
+            comments: allComments,
+            activities: allActivities
+        )
+
+        return VStack(alignment: .leading, spacing: 0) {
+            WeekStripView(selectedDate: $selectedDate, activeDays: activeDays)
+                .padding(.top, 8)
+                .padding(.bottom, 4)
+                .background(
+                    theme.usesCustomSurface ? AnyView(theme.surface) : AnyView(Color(uiColor: .systemBackground))
+                )
+            Divider()
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    header
+                    filterChips
+                    timelineSection(entries: allEntries, comments: allComments, activities: allActivities)
+                }
+                .padding(.horizontal)
+                .padding(.vertical, 12)
+            }
+        }
+        .background(
+            theme.usesCustomSurface ? AnyView(theme.surface.ignoresSafeArea()) : AnyView(Color.clear)
+        )
+        .navigationTitle("タイムライン")
+        #if os(iOS) || os(visionOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    showingMonthPicker = true
+                } label: {
+                    Image(systemName: "calendar")
+                }
+            }
+        }
+        .sheet(isPresented: $showingMonthPicker) {
+            NavigationStack {
+                ActivityCalendarView(selectedDate: $selectedDate, activeDays: activeDays)
+                    .padding()
+                    .navigationTitle("日付を選択")
+                    #if os(iOS) || os(visionOS)
+                    .navigationBarTitleDisplayMode(.inline)
+                    #endif
+                    .toolbar {
+                        ToolbarItem(placement: .confirmationAction) {
+                            Button("完了") { showingMonthPicker = false }
+                        }
+                    }
+            }
+            .presentationDetents([.medium, .large])
+        }
+        .sheet(item: $editingEntry) { entry in
+            EditEntryView(viewModel: viewModel, entry: entry)
+        }
+        .sheet(item: $commentingEntry) { entry in
+            CommentListView(entry: entry, viewModel: viewModel)
+        }
+        #if canImport(UIKit)
+        .sheet(item: $safariURL) { url in
+            SafariView(url: url)
+                .ignoresSafeArea()
+        }
+        #endif
+        .onMangaDataChange {
+            viewModel.refresh()
+        }
+    }
+
+    // MARK: - Filter chips
+
+    @ViewBuilder
+    private var filterChips: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(TimelineFilter.allCases) { option in
+                    filterChip(for: option)
+                }
+            }
+        }
+    }
+
+    private func filterChip(for option: TimelineFilter) -> some View {
+        let isSelected = filter == option
+        return Button {
+            withAnimation(.easeInOut(duration: 0.15)) {
+                filter = option
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: option.iconName)
+                    .font(.caption2)
+                Text(option.displayName)
+                    .font(theme.captionFont.weight(.medium))
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(
+                Capsule()
+                    .fill(isSelected ? Color.accentColor : theme.surfaceContainerHigh)
+            )
+            .foregroundStyle(isSelected ? Color.white : theme.onSurface)
+        }
+        .buttonStyle(.plain)
+    }
+
+
+    // MARK: - Header
+
+    @ViewBuilder
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(Self.dayOfMonthFormatter.string(from: selectedDate))
+                .font(.system(size: 40, weight: .bold))
+                .foregroundStyle(theme.onSurface)
+            Text(Self.monthYearFormatter.string(from: selectedDate))
+                .font(theme.subheadlineFont)
+                .foregroundStyle(theme.onSurfaceVariant)
+        }
+        .padding(.bottom, 4)
+    }
+
+    // MARK: - Timeline list
+
+    @ViewBuilder
+    private func timelineSection(
+        entries: [MangaEntry],
+        comments: [MangaComment],
+        activities: [ReadingActivity]
+    ) -> some View {
+        let allItems = TimelineBuilder.items(
+            for: selectedDate,
+            entries: entries,
+            comments: comments,
+            activities: activities
+        )
+        let items = filter.apply(to: allItems)
+
+        if items.isEmpty {
+            emptyState(hasAnyItems: !allItems.isEmpty)
+                .padding(.top, 40)
+        } else {
+            LazyVStack(spacing: 0) {
+                ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
+                    TimelineRowView(
+                        item: item,
+                        isFirst: index == 0,
+                        isLast: index == items.count - 1,
+                        onTap: { handleTap(on: item) }
+                    )
+                }
+            }
+        }
+    }
+
+    /// 空状態。フィルタ適用で 0 件になった場合と、そもそも 0 件の場合を区別する。
+    @ViewBuilder
+    private func emptyState(hasAnyItems: Bool) -> some View {
+        if hasAnyItems && filter != .all {
+            ContentUnavailableView {
+                Label("該当するアクティビティがありません", systemImage: "line.3.horizontal.decrease.circle")
+                    .foregroundStyle(theme.onSurfaceVariant)
+            } description: {
+                Text("フィルタ「\(filter.displayName)」に合うものはこの日にありません")
+                    .foregroundStyle(theme.onSurfaceVariant.opacity(0.7))
+            } actions: {
+                Button("すべて表示") { filter = .all }
+            }
+        } else {
+            ContentUnavailableView {
+                Label("この日はアクティビティがありません", systemImage: "calendar.badge.clock")
+                    .foregroundStyle(theme.onSurfaceVariant)
+            } description: {
+                Text("コメント・メモ編集・既読の記録がここに並びます")
+                    .foregroundStyle(theme.onSurfaceVariant.opacity(0.7))
+            }
+        }
+    }
+
+    // MARK: - Tap handling
+
+    private func handleTap(on item: TimelineItem) {
+        switch item {
+        case .comment(_, let entry):
+            commentingEntry = entry
+        case .memo(let entry):
+            editingEntry = entry
+        case .read(_, let entry):
+            // 「読みました」の再訪導線としてマンガサイトを開く。
+            // entry が見つからないのは削除済みエントリの場合のみ (無視)。
+            guard let entry else { return }
+            MangaURLOpener(browserMode: browserMode, openURL: openURL) { safariURL = $0 }.open(entry.url)
+        }
+    }
+
+    // MARK: - Formatters
+
+    private static let dayOfMonthFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "ja_JP")
+        f.dateFormat = "d日 (EEE)"
+        return f
+    }()
+
+    private static let monthYearFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "ja_JP")
+        f.dateFormat = "yyyy年 M月"
+        return f
+    }()
+}

--- a/MangaLauncher/Views/Library/Timeline/WeekStripView.swift
+++ b/MangaLauncher/Views/Library/Timeline/WeekStripView.swift
@@ -1,0 +1,147 @@
+import SwiftUI
+
+/// タイムライン上部の曜日ストリップ。横スワイプで週を切替、日付タップで選択。
+/// アクティビティがあった日は日付下にドットを出す。
+struct WeekStripView: View {
+    @Binding var selectedDate: Date
+    /// startOfDay 済みの日付集合。親が TimelineBuilder.activeDays で計算して渡す。
+    let activeDays: Set<Date>
+
+    /// 表示中の週オフセット (0 = 今週、-1 = 先週)
+    @State private var weekOffset: Int = 0
+
+    /// 月曜はじまりの週。firstWeekday = 2
+    private let calendar: Calendar = {
+        var cal = Calendar(identifier: .gregorian)
+        cal.firstWeekday = 2
+        return cal
+    }()
+
+    /// 過去 26 週 + 今週 + 未来 1 週 までをページング可能に。
+    private let pageRange = -26...1
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            monthHeader
+            TabView(selection: $weekOffset) {
+                ForEach(pageRange, id: \.self) { offset in
+                    weekRow(for: offset)
+                        .tag(offset)
+                }
+            }
+            .tabViewStyle(.page(indexDisplayMode: .never))
+            .frame(height: 68)
+        }
+        .onChange(of: selectedDate) { _, newDate in
+            // 月 grid などで外から selectedDate が変わったとき、
+            // その週に表示を追従させる
+            let target = computeWeekOffset(for: newDate)
+            if target != weekOffset {
+                withAnimation { weekOffset = target }
+            }
+        }
+        .onAppear {
+            weekOffset = computeWeekOffset(for: selectedDate)
+        }
+    }
+
+    // MARK: - Header (year/month of visible week)
+
+    private var monthHeader: some View {
+        let firstDay = weekStart(for: weekOffset)
+        return Text(Self.monthFormatter.string(from: firstDay))
+            .font(.subheadline.weight(.semibold))
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 16)
+    }
+
+    // MARK: - Week row
+
+    private func weekRow(for offset: Int) -> some View {
+        let start = weekStart(for: offset)
+        let days = (0..<7).compactMap { calendar.date(byAdding: .day, value: $0, to: start) }
+        return HStack(spacing: 0) {
+            ForEach(days, id: \.self) { day in
+                dayCell(day)
+                    .frame(maxWidth: .infinity)
+            }
+        }
+        .padding(.horizontal, 8)
+    }
+
+    // MARK: - Day cell
+
+    private func dayCell(_ day: Date) -> some View {
+        let isSelected = calendar.isDate(day, inSameDayAs: selectedDate)
+        let isToday = calendar.isDateInToday(day)
+        let hasActivity = activeDays.contains(calendar.startOfDay(for: day))
+
+        return VStack(spacing: 3) {
+            Text(Self.weekdayFormatter.string(from: day))
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            ZStack {
+                Circle()
+                    .fill(isSelected ? Color.accentColor : Color.clear)
+                    .frame(width: 30, height: 30)
+                if isToday && !isSelected {
+                    Circle()
+                        .stroke(Color.accentColor, lineWidth: 1.5)
+                        .frame(width: 30, height: 30)
+                }
+                Text(Self.dayFormatter.string(from: day))
+                    .font(.system(size: 15, weight: isSelected || isToday ? .bold : .medium))
+                    .foregroundStyle(isSelected ? Color.white : Color.primary)
+            }
+            Circle()
+                .fill(hasActivity ? Color.accentColor.opacity(0.7) : Color.clear)
+                .frame(width: 4, height: 4)
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            selectedDate = calendar.startOfDay(for: day)
+        }
+    }
+
+    // MARK: - Date math
+
+    private func weekStart(for offset: Int) -> Date {
+        let today = calendar.startOfDay(for: Date())
+        let components = calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: today)
+        let thisWeekStart = calendar.date(from: components) ?? today
+        return calendar.date(byAdding: .weekOfYear, value: offset, to: thisWeekStart) ?? thisWeekStart
+    }
+
+    /// 与えられた日付が属する週の、今週との差 (週単位)。
+    private func computeWeekOffset(for date: Date) -> Int {
+        let dateComponents = calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: date)
+        let todayComponents = calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: Date())
+        guard let dateWeekStart = calendar.date(from: dateComponents),
+              let todayWeekStart = calendar.date(from: todayComponents) else { return 0 }
+        let weeks = calendar.dateComponents([.weekOfYear], from: todayWeekStart, to: dateWeekStart).weekOfYear ?? 0
+        // ページング範囲にクランプ
+        return max(pageRange.lowerBound, min(pageRange.upperBound, weeks))
+    }
+
+    // MARK: - Formatters
+
+    private static let monthFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "ja_JP")
+        f.dateFormat = "yyyy年 M月"
+        return f
+    }()
+
+    private static let weekdayFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "ja_JP")
+        f.dateFormat = "E"
+        return f
+    }()
+
+    private static let dayFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "d"
+        return f
+    }()
+}

--- a/MangaLauncher/Views/Settings/SettingsView.swift
+++ b/MangaLauncher/Views/Settings/SettingsView.swift
@@ -116,6 +116,14 @@ struct SettingsView: View {
                             Text("読書アクティビティ")
                         }
                     }
+                    NavigationLink {
+                        TimelineView(viewModel: viewModel)
+                    } label: {
+                        HStack {
+                            Image(systemName: "chart.bar.doc.horizontal.fill")
+                            Text("タイムライン")
+                        }
+                    }
                 }
 
                 Section("iCloud同期") {


### PR DESCRIPTION
## Summary

1 日のアクティビティ (コメント・メモ編集・既読) を時系列に並べるタイムライン画面を追加。上部に曜日ストリップと月 grid ピッカー、チップで種別フィルタが切り替えられる。

## 画面構成

```
┌─────────────────────────┐
│ [<]  タイムライン   [📅]│
├─────────────────────────┤
│ 2026年 4月              │
│ 月火水[木]金土日        │ ← WeekStripView
│ 13 14 15 16 17 18 19    │   (横スワイプで週切替)
│  •     •  •             │   (アクティビティドット)
├─────────────────────────┤
│ 16日 (木)               │
│ 2026年 4月              │
│                         │
│ [すべて][コメ][メモ][既]│ ← TimelineFilter
│                         │
│ 09:30 ─┬─ ✓ 既読       │ ← TimelineRowView
│        │  《ワンピース》│   (時刻+縦線+アイコン+カード)
│ 14:05 ─┴─ 💬 コメント   │
│           《呪術廻戦》  │
└─────────────────────────┘
```

## 主な追加ファイル

- `Models/TimelineItem.swift` : sum type `TimelineItem` + 純関数 `TimelineBuilder` + `TimelineFilter`
- `Views/Library/Timeline/TimelineView.swift` : 画面本体
- `Views/Library/Timeline/TimelineRowView.swift` : 1 行コンポーネント
- `Views/Library/Timeline/WeekStripView.swift` : 週ストリップ (TabView paging)
- `Views/Library/Timeline/ActivityCalendarView.swift` : 月 grid ピッカー (UICalendarView の UIViewRepresentable ラッパ。ドット装飾は公式 decoration API 経由)

## データ拡張

- `ReadingActivity.timestamp: Date?` を追加。Optional なので migration 不要
- 新規 `markAsRead` で秒単位タイムスタンプを保持
- 旧レコード (timestamp == nil) は「時刻なし」表示

## 導線

- `LibraryView` 先頭に「タイムライン」 navigation link
- `SettingsView` の読書アクティビティ下に並べて追加（両方から発見可能）

## バグ修正

- `deleteAllEntries()` が `MangaComment` を削除していなかったので残存していた。コメント削除も追加
- `TimelineBuilder.activeDays` が孤児コメント (entry 不在) をカウントしていたので `items()` と同じ可視条件に統一

## UX

- アイテムタップの遷移先を種別で分岐
  - コメント → `CommentListView`
  - メモ → `EditEntryView`
  - 既読 → マンガ URL を再訪 (`MangaURLOpener` 経由、browserMode に従う)
- 昇順 (朝→夜) で 1 日の流れを読める
- 空日で「フィルタ適用中」と「完全に 0 件」を文言で区別

## 保守性

- `ActivityItem` / `ActivityBuilder` と同じ「enum + static builder」パターンで一貫
- ビルダーは純関数。親が一度だけ fetch して渡す (N+1 回避)
- 種別追加は TimelineItem に case + TimelineFilter に case を足すだけで既存箇所に波及しない

## Test plan

- [x] `xcodebuild` 通る
- [x] 実機 (iPhone 15 Pro) で動作確認
- [x] 既存のコメント/メモ/既読の日が timeline に表示される
- [x] week strip スワイプで過去週に遡れる
- [x] 月 grid でも active days にドット表示
- [x] 種別フィルタで 0 件のときは「該当なし」+「すべて表示」復帰ボタン
- [x] すべてのデータを削除後にドットが消える
- [ ] 旧 ReadingActivity (timestamp == nil) が「時刻なし」で並ぶ
- [ ] 設定とライブラリ両方からタイムラインに入れる

🤖 Generated with [Claude Code](https://claude.com/claude-code)