### PR TITLE
Add Swift Charts bar chart to timeline

### DIFF
--- a/MangaLauncher.xcodeproj/project.pbxproj
+++ b/MangaLauncher.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		AB2001FF00112233AA000005 /* TimelineRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2001FF00112233AA000006 /* TimelineRowView.swift */; };
 		AB2001FF00112233AA000008 /* WeekStripView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2001FF00112233AA000009 /* WeekStripView.swift */; };
 		AB2001FF00112233AA00000A /* ActivityCalendarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2001FF00112233AA00000B /* ActivityCalendarView.swift */; };
+		AB2001FF00112233AA00000C /* TimelineChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2001FF00112233AA00000D /* TimelineChartView.swift */; };
 		BC000401 /* MangaStatusBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000410 /* MangaStatusBadgeView.swift */; };
 		BC000501 /* SectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000510 /* SectionHeaderView.swift */; };
 		BC000801 /* MangaDataChangeModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000810 /* MangaDataChangeModifier.swift */; };
@@ -206,6 +207,7 @@
 		AB2001FF00112233AA000006 /* TimelineRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineRowView.swift; sourceTree = "<group>"; };
 		AB2001FF00112233AA000009 /* WeekStripView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeekStripView.swift; sourceTree = "<group>"; };
 		AB2001FF00112233AA00000B /* ActivityCalendarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityCalendarView.swift; sourceTree = "<group>"; };
+		AB2001FF00112233AA00000D /* TimelineChartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineChartView.swift; sourceTree = "<group>"; };
 		BC000410 /* MangaStatusBadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaStatusBadgeView.swift; sourceTree = "<group>"; };
 		BC000510 /* SectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionHeaderView.swift; sourceTree = "<group>"; };
 		BC000810 /* MangaDataChangeModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaDataChangeModifier.swift; sourceTree = "<group>"; };
@@ -451,6 +453,7 @@
 				AB2001FF00112233AA000006 /* TimelineRowView.swift */,
 				AB2001FF00112233AA000009 /* WeekStripView.swift */,
 				AB2001FF00112233AA00000B /* ActivityCalendarView.swift */,
+				AB2001FF00112233AA00000D /* TimelineChartView.swift */,
 			);
 			path = Timeline;
 			sourceTree = "<group>";
@@ -797,6 +800,7 @@
 				AB2001FF00112233AA000005 /* TimelineRowView.swift in Sources */,
 				AB2001FF00112233AA000008 /* WeekStripView.swift in Sources */,
 				AB2001FF00112233AA00000A /* ActivityCalendarView.swift in Sources */,
+				AB2001FF00112233AA00000C /* TimelineChartView.swift in Sources */,
 				BC000401 /* MangaStatusBadgeView.swift in Sources */,
 				BC000501 /* SectionHeaderView.swift in Sources */,
 				BC000801 /* MangaDataChangeModifier.swift in Sources */,

--- a/MangaLauncher/Models/MangaComment.swift
+++ b/MangaLauncher/Models/MangaComment.swift
@@ -3,7 +3,7 @@ import SwiftData
 
 /// マンガに紐付くタイムスタンプ付きコメント（投稿型）
 @Model
-final class MangaComment {
+final class MangaComment: Identifiable {
     var id: UUID = UUID()
     var mangaEntryID: UUID = UUID()
     var content: String = ""

--- a/MangaLauncher/Models/TimelineItem.swift
+++ b/MangaLauncher/Models/TimelineItem.swift
@@ -1,11 +1,35 @@
 import Foundation
 
+/// TimelineItem のタイプを表す軽量タグ。Swift Charts での集計など
+/// enum 本体の associated value 無しで扱いたい場面で使う。
+enum TimelineItemKind: String, CaseIterable, Identifiable {
+    case comment, memo, read
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .comment: "コメント"
+        case .memo: "メモ"
+        case .read: "既読"
+        }
+    }
+}
+
 /// 1 日のアクティビティタイムラインを構成する単一アイテム。
 /// コメント / メモ更新 / 読んだ記録 を統一的に並べるための sum type。
 enum TimelineItem: Identifiable {
     case comment(MangaComment, MangaEntry)
     case memo(MangaEntry)
     case read(ReadingActivity, MangaEntry?)
+
+    var kind: TimelineItemKind {
+        switch self {
+        case .comment: .comment
+        case .memo: .memo
+        case .read: .read
+        }
+    }
 
     var id: String {
         switch self {
@@ -78,16 +102,52 @@ enum TimelineFilter: String, CaseIterable, Hashable, Identifiable {
         }
     }
 
-    func apply(to items: [TimelineItem]) -> [TimelineItem] {
+    /// フィルタが単一種別を指す場合の TimelineItemKind。.all のとき nil。
+    /// チャートのフィルタ連動などで使う。
+    var kind: TimelineItemKind? {
         switch self {
-        case .all:
-            return items
-        case .comment:
-            return items.filter { if case .comment = $0 { true } else { false } }
-        case .memo:
-            return items.filter { if case .memo = $0 { true } else { false } }
-        case .read:
-            return items.filter { if case .read = $0 { true } else { false } }
+        case .all: nil
+        case .comment: .comment
+        case .memo: .memo
+        case .read: .read
+        }
+    }
+
+    func apply(to items: [TimelineItem]) -> [TimelineItem] {
+        guard let kind else { return items }
+        return items.filter { $0.kind == kind }
+    }
+}
+
+// MARK: - Chart granularity
+
+/// タイムラインチャートの期間粒度。週 (7 日) / 月 (30 日前後)。
+enum TimelineChartGranularity: String, CaseIterable, Hashable, Identifiable {
+    case week, month
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .week: "週"
+        case .month: "月"
+        }
+    }
+
+    /// 指定日を含む期間の日付配列。月曜はじまりの週 / 月の 1 日はじまりの月。
+    func days(containing date: Date) -> [Date] {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.firstWeekday = 2
+        switch self {
+        case .week:
+            let components = calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: date)
+            let start = calendar.date(from: components) ?? date
+            return (0..<7).compactMap { calendar.date(byAdding: .day, value: $0, to: start) }
+        case .month:
+            let components = calendar.dateComponents([.year, .month], from: date)
+            guard let start = calendar.date(from: components),
+                  let range = calendar.range(of: .day, in: .month, for: start) else { return [] }
+            return range.compactMap { calendar.date(byAdding: .day, value: $0 - 1, to: start) }
         }
     }
 }
@@ -159,4 +219,31 @@ enum TimelineBuilder {
         }
         return days
     }
+
+    /// 指定した日付集合の、タイプ別件数を返す。Swift Charts の棒グラフ用。
+    /// 日付 × 種別 の全組合せで 0 件もエントリを作ることで、グラフが
+    /// 日付方向に途切れないようにする。
+    static func dailyCounts(
+        days: [Date],
+        entries: [MangaEntry],
+        comments: [MangaComment],
+        activities: [ReadingActivity]
+    ) -> [TimelineDailyCount] {
+        days.flatMap { day in
+            let items = items(for: day, entries: entries, comments: comments, activities: activities)
+            let byKind = Dictionary(grouping: items, by: \.kind).mapValues(\.count)
+            return TimelineItemKind.allCases.map { kind in
+                TimelineDailyCount(date: day, kind: kind, count: byKind[kind] ?? 0)
+            }
+        }
+    }
+}
+
+/// Swift Charts に渡す集計単位。
+struct TimelineDailyCount: Identifiable, Hashable {
+    let date: Date
+    let kind: TimelineItemKind
+    let count: Int
+
+    var id: String { "\(date.timeIntervalSince1970)-\(kind.rawValue)" }
 }

--- a/MangaLauncher/Views/Library/Timeline/TimelineChartView.swift
+++ b/MangaLauncher/Views/Library/Timeline/TimelineChartView.swift
@@ -1,0 +1,258 @@
+import SwiftUI
+import Charts
+
+/// TimelineView 上部のコンパクトな棒グラフ。
+/// granularity (週 / 月) で期間を切替、種別を積み上げ、棒タップで selectedDate を更新。
+/// 長押し (Chart 標準の selection gesture) で tooltip に件数内訳を表示。
+struct TimelineChartView: View {
+    @Binding var selectedDate: Date
+    let granularity: TimelineChartGranularity
+    let counts: [TimelineDailyCount]
+
+    /// selection gesture で hover/長押しされた日付
+    @State private var hoveredDate: Date?
+
+    private let chartHeight: CGFloat = 80
+
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
+    // MARK: - Aggregates
+
+    private var totalCount: Int { counts.reduce(0) { $0 + $1.count } }
+
+    private func total(for kind: TimelineItemKind) -> Int {
+        counts.filter { $0.kind == kind }.reduce(0) { $0 + $1.count }
+    }
+
+    private var isEmpty: Bool { totalCount == 0 }
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            summaryLine
+            chartBody
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilitySummary)
+    }
+
+    // MARK: - Summary line
+
+    @ViewBuilder
+    private var summaryLine: some View {
+        HStack(spacing: 8) {
+            Text(granularity == .week ? "今週" : "今月")
+                .font(theme.captionFont)
+                .foregroundStyle(theme.onSurfaceVariant)
+            Text("\(totalCount) 件")
+                .font(theme.subheadlineFont.weight(.semibold))
+                .foregroundStyle(theme.onSurface)
+            if totalCount > 0 {
+                Text(breakdownText)
+                    .font(theme.captionFont)
+                    .foregroundStyle(theme.onSurfaceVariant)
+            }
+            Spacer()
+        }
+    }
+
+    private var breakdownText: String {
+        let parts = TimelineItemKind.allCases.compactMap { kind -> String? in
+            let count = total(for: kind)
+            guard count > 0 else { return nil }
+            return "\(kind.displayName) \(count)"
+        }
+        return "(\(parts.joined(separator: " / ")))"
+    }
+
+    // MARK: - Chart body
+
+    @ViewBuilder
+    private var chartBody: some View {
+        ZStack {
+            Chart(counts) { datum in
+                BarMark(
+                    x: .value("日", datum.date, unit: .day),
+                    y: .value("件数", datum.count)
+                )
+                .foregroundStyle(by: .value("種別", datum.kind.displayName))
+                .cornerRadius(3)
+                .opacity(isSelected(datum.date) ? 1.0 : 0.55)
+
+                if let hoveredDate, Calendar.current.isDate(datum.date, inSameDayAs: hoveredDate) {
+                    RuleMark(x: .value("選択", datum.date, unit: .day))
+                        .foregroundStyle(theme.onSurface.opacity(0.25))
+                        .offset(yStart: -6)
+                        .zIndex(-1)
+                        .annotation(position: .top, overflowResolution: .init(x: .fit, y: .disabled)) {
+                            tooltip(for: hoveredDate)
+                        }
+                }
+            }
+            .chartForegroundStyleScale([
+                TimelineItemKind.comment.displayName: Color.blue,
+                TimelineItemKind.memo.displayName: Color.orange,
+                TimelineItemKind.read.displayName: Color.green
+            ])
+            .chartXAxis { xAxis }
+            .chartYAxis(.hidden)
+            .chartLegend(.hidden)
+            .chartXSelection(value: $hoveredDate)
+            .frame(height: chartHeight)
+            .chartOverlay { proxy in
+                GeometryReader { geo in
+                    Rectangle()
+                        .fill(Color.clear)
+                        .contentShape(Rectangle())
+                        .onTapGesture { location in
+                            handleTap(at: location, proxy: proxy, geo: geo)
+                        }
+                }
+            }
+
+            if isEmpty {
+                Text("この\(granularity.displayName)はアクティビティがありません")
+                    .font(theme.captionFont)
+                    .foregroundStyle(theme.onSurfaceVariant)
+            }
+        }
+    }
+
+    private var xAxis: some AxisContent {
+        AxisMarks(values: xAxisValues) { value in
+            if let date = value.as(Date.self) {
+                AxisValueLabel {
+                    Text(axisLabel(for: date))
+                        .font(.caption2.weight(isToday(date) ? .bold : .regular))
+                        .foregroundStyle(labelColor(for: date))
+                }
+            }
+        }
+    }
+
+    /// 週: 7 日全て表示。月: 週次 (月曜) だけ表示してラベル過密を防ぐ。
+    private var xAxisValues: [Date] {
+        let uniqueDates = counts.map(\.date).unique()
+        switch granularity {
+        case .week:
+            return uniqueDates
+        case .month:
+            var cal = Calendar(identifier: .gregorian)
+            cal.firstWeekday = 2
+            return uniqueDates.filter { cal.component(.weekday, from: $0) == 2 }
+        }
+    }
+
+    private func axisLabel(for date: Date) -> String {
+        switch granularity {
+        case .week: return Self.weekdayFormatter.string(from: date)
+        case .month: return Self.dayFormatter.string(from: date)
+        }
+    }
+
+    private func labelColor(for date: Date) -> Color {
+        if isSelected(date) { return theme.primary }
+        if isToday(date) { return theme.onSurface }
+        return .secondary
+    }
+
+    // MARK: - Tooltip
+
+    @ViewBuilder
+    private func tooltip(for date: Date) -> some View {
+        let dayCounts = counts.filter { Calendar.current.isDate($0.date, inSameDayAs: date) }
+        let dayTotal = dayCounts.reduce(0) { $0 + $1.count }
+        VStack(alignment: .leading, spacing: 2) {
+            Text(Self.tooltipDateFormatter.string(from: date))
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            Text("\(dayTotal) 件")
+                .font(.caption.weight(.semibold))
+            ForEach(TimelineItemKind.allCases) { kind in
+                let c = dayCounts.first(where: { $0.kind == kind })?.count ?? 0
+                if c > 0 {
+                    HStack(spacing: 4) {
+                        Circle().fill(color(for: kind)).frame(width: 6, height: 6)
+                        Text("\(kind.displayName) \(c)")
+                            .font(.caption2)
+                    }
+                }
+            }
+        }
+        .padding(6)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(theme.surfaceContainerHighest)
+                .shadow(radius: 2)
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func isSelected(_ date: Date) -> Bool {
+        Calendar.current.isDate(date, inSameDayAs: selectedDate)
+    }
+
+    private func isToday(_ date: Date) -> Bool {
+        Calendar.current.isDateInToday(date)
+    }
+
+    private func color(for kind: TimelineItemKind) -> Color {
+        switch kind {
+        case .comment: .blue
+        case .memo: .orange
+        case .read: .green
+        }
+    }
+
+    private func handleTap(at location: CGPoint, proxy: ChartProxy, geo: GeometryProxy) {
+        guard let plot = proxy.plotFrame else { return }
+        let plotFrame = geo[plot]
+        let relativeX = location.x - plotFrame.origin.x
+        guard relativeX >= 0, relativeX <= plotFrame.width else { return }
+        guard let date: Date = proxy.value(atX: relativeX) else { return }
+        selectedDate = Calendar.current.startOfDay(for: date)
+    }
+
+    // MARK: - Accessibility
+
+    private var accessibilitySummary: String {
+        let period = granularity.displayName
+        if isEmpty {
+            return "この\(period)はアクティビティがありません"
+        }
+        let parts = TimelineItemKind.allCases.map { "\($0.displayName) \(total(for: $0)) 件" }
+        return "この\(period)のアクティビティ合計 \(totalCount) 件。" + parts.joined(separator: "、")
+    }
+
+    // MARK: - Formatters
+
+    private static let weekdayFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "ja_JP")
+        f.dateFormat = "E"
+        return f
+    }()
+
+    private static let dayFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "d"
+        return f
+    }()
+
+    private static let tooltipDateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "ja_JP")
+        f.dateFormat = "M月d日(E)"
+        return f
+    }()
+}
+
+private extension Array where Element: Hashable {
+    /// 先頭からの出現順を保って重複を取り除く。
+    func unique() -> [Element] {
+        var seen = Set<Element>()
+        return filter { seen.insert($0).inserted }
+    }
+}

--- a/MangaLauncher/Views/Library/Timeline/TimelineView.swift
+++ b/MangaLauncher/Views/Library/Timeline/TimelineView.swift
@@ -12,6 +12,7 @@ struct TimelineView: View {
     @State private var safariURL: URL?
     @State private var filter: TimelineFilter = .all
     @State private var showingMonthPicker = false
+    @State private var chartGranularity: TimelineChartGranularity = .week
     @AppStorage("browserMode") private var browserMode: String = "external"
 
     private var theme: ThemeStyle { ThemeManager.shared.style }
@@ -39,6 +40,7 @@ struct TimelineView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
                     header
+                    chartBlock(entries: allEntries, comments: allComments, activities: allActivities)
                     filterChips
                     timelineSection(entries: allEntries, comments: allComments, activities: allActivities)
                 }
@@ -219,6 +221,44 @@ struct TimelineView: View {
             guard let entry else { return }
             MangaURLOpener(browserMode: browserMode, openURL: openURL) { safariURL = $0 }.open(entry.url)
         }
+    }
+
+    // MARK: - Chart block
+
+    /// 期間トグル + 棒グラフをまとめたブロック。
+    /// フィルタが .all 以外ならその kind だけに絞った counts を渡す。
+    @ViewBuilder
+    private func chartBlock(
+        entries: [MangaEntry],
+        comments: [MangaComment],
+        activities: [ReadingActivity]
+    ) -> some View {
+        let allCounts = TimelineBuilder.dailyCounts(
+            days: chartGranularity.days(containing: selectedDate),
+            entries: entries,
+            comments: comments,
+            activities: activities
+        )
+        let counts = filter.kind.map { kind in allCounts.filter { $0.kind == kind } } ?? allCounts
+        VStack(alignment: .leading, spacing: 8) {
+            granularityPicker
+            TimelineChartView(
+                selectedDate: $selectedDate,
+                granularity: chartGranularity,
+                counts: counts
+            )
+        }
+    }
+
+    @ViewBuilder
+    private var granularityPicker: some View {
+        Picker("期間", selection: $chartGranularity) {
+            ForEach(TimelineChartGranularity.allCases) { g in
+                Text(g.displayName).tag(g)
+            }
+        }
+        .pickerStyle(.segmented)
+        .frame(maxWidth: 160)
     }
 
     // MARK: - Formatters

--- a/MangaLauncher/Views/Library/Timeline/WeekStripView.swift
+++ b/MangaLauncher/Views/Library/Timeline/WeekStripView.swift
@@ -40,6 +40,16 @@ struct WeekStripView: View {
                 withAnimation { weekOffset = target }
             }
         }
+        .onChange(of: weekOffset) { _, newOffset in
+            // ストリップをスワイプして週が変わったら、selectedDate も同じ曜日で
+            // 新しい週に引越しする。チャートと週表示のズレを防ぐ。
+            let currentOffset = computeWeekOffset(for: selectedDate)
+            guard currentOffset != newOffset else { return }
+            let delta = newOffset - currentOffset
+            if let newDate = calendar.date(byAdding: .weekOfYear, value: delta, to: selectedDate) {
+                selectedDate = calendar.startOfDay(for: newDate)
+            }
+        }
         .onAppear {
             weekOffset = computeWeekOffset(for: selectedDate)
         }


### PR DESCRIPTION
## Summary

タイムライン画面に Swift Charts の積み上げ棒グラフを追加。週/月の粒度切替、種別フィルタ連動、週ストリップとの同期、長押し tooltip、VoiceOver 対応をまとめて入れる。

## 画面

```
┌─────────────────────────┐
│ [<]  タイムライン   [📅]│
├─────────────────────────┤
│ [週ストリップ]          │ ← スワイプで selectedDate も同期
├─────────────────────────┤
│ 16日 (木)               │
│                         │
│ [週] [月]               │ ← granularity picker
│ 今週 14件 (コ5/メ3/既6) │ ← summary line
│ ┃                       │
│ ┃ ┃  ┃━━┃              │ ← 積み上げ棒 (種別で色分け)
│ ┃━┃━━┃━━┃━━━          │   選択日 1.0 / 他 0.55
│ 月 火 水 [木]金 土 日   │   今日は太字
│                         │
│ [すべて][コメ][メモ][既]│ ← フィルタ (グラフにも連動)
│                         │
│ [タイムラインリスト]    │
└─────────────────────────┘
```

長押しすると RuleMark と annotation でその日の件数内訳が tooltip 表示されます。

## 改善項目 (全 8 件)

| # | 改善 | 実装 |
|---|---|---|
| 1 | 週ストリップ swipe 時に selectedDate を同曜日で引越し | `WeekStripView.onChange(weekOffset)` |
| 2 | 空週/月のオーバーレイ | `TimelineChartView isEmpty` |
| 3 | 合計件数サマリ行 | `TimelineChartView summaryLine` |
| 4 | 今日マーカー (X 軸ラベル太字) | `TimelineChartView labelColor/axisLabel` |
| 5 | VoiceOver 件数サマリ | `accessibilityElement(children: .ignore)` + `accessibilityLabel` |
| 6 | フィルタ連動 (1 色表示) | `TimelineView chartBlock` で `filter.kind` 絞り込み |
| 7 | 週/月トグル | `TimelineChartGranularity` + `Picker(.segmented)` |
| 8 | 長押し tooltip | `chartXSelection(value:)` + `RuleMark.annotation` |

## モデル拡張

- `TimelineItemKind` (軽量タグ enum)
- `TimelineItem.kind` プロパティ
- `TimelineDailyCount` (Chart 用データ)
- `TimelineChartGranularity` (週/月)
- `TimelineFilter.kind` マッピング
- `TimelineBuilder.dailyCounts(...)` 純関数

## ビルド修正

- `MangaComment: Identifiable` を明示。新規 enum 追加の副作用で型推論が弱まり `.sheet(item: $editingComment)` の Identifiable 要求を満たせなくなった現象を解消

## 保守性

- Builder は純関数、View はバインディングで state 共有
- granularity を追加する場合は `TimelineChartGranularity` に case を増やして `days(containing:)` を実装するだけ
- `TimelineItem.kind` / `TimelineFilter.kind` / `TimelineDailyCount.kind` と kind 概念が統一

## Test plan

- [x] `xcodebuild` 通る
- [x] 実機 (iPhone 15 Pro) で動作確認
- [ ] 週/月トグルで期間切替
- [ ] 棒タップで selectedDate 同期
- [ ] 長押しで tooltip 表示 / 離すと消える
- [ ] フィルタで「コメント」選択中はグラフも青だけ
- [ ] 空週で「アクティビティがありません」オーバーレイ
- [ ] 週ストリップスワイプでチャートも追従
- [ ] VoiceOver で件数サマリ読み上げ

🤖 Generated with [Claude Code](https://claude.com/claude-code)