### PR TITLE
Show next update date in home cells

### DIFF
--- a/MangaLauncher.xcodeproj/project.pbxproj
+++ b/MangaLauncher.xcodeproj/project.pbxproj
@@ -64,6 +64,8 @@
 		AB4001FF00112233AA000001 /* SearchFilterBars.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB4001FF00112233AA000002 /* SearchFilterBars.swift */; };
 		AB4001FF00112233AA000003 /* EditEntryStatusSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB4001FF00112233AA000004 /* EditEntryStatusSection.swift */; };
 		AB4001FF00112233AA000005 /* AppError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB4001FF00112233AA000006 /* AppError.swift */; };
+		AB5001FF00112233AA000001 /* NextUpdateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5001FF00112233AA000002 /* NextUpdateFormatter.swift */; };
+		AB5001FF00112233AA000003 /* NextUpdateBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB5001FF00112233AA000004 /* NextUpdateBadgeView.swift */; };
 		BC000401 /* MangaStatusBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000410 /* MangaStatusBadgeView.swift */; };
 		BC000501 /* SectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000510 /* SectionHeaderView.swift */; };
 		BC000801 /* MangaDataChangeModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000810 /* MangaDataChangeModifier.swift */; };
@@ -220,6 +222,8 @@
 		AB4001FF00112233AA000002 /* SearchFilterBars.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchFilterBars.swift; sourceTree = "<group>"; };
 		AB4001FF00112233AA000004 /* EditEntryStatusSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditEntryStatusSection.swift; sourceTree = "<group>"; };
 		AB4001FF00112233AA000006 /* AppError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppError.swift; sourceTree = "<group>"; };
+		AB5001FF00112233AA000002 /* NextUpdateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextUpdateFormatter.swift; sourceTree = "<group>"; };
+		AB5001FF00112233AA000004 /* NextUpdateBadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NextUpdateBadgeView.swift; sourceTree = "<group>"; };
 		BC000410 /* MangaStatusBadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaStatusBadgeView.swift; sourceTree = "<group>"; };
 		BC000510 /* SectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionHeaderView.swift; sourceTree = "<group>"; };
 		BC000810 /* MangaDataChangeModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaDataChangeModifier.swift; sourceTree = "<group>"; };
@@ -614,6 +618,8 @@
 				BC000410 /* MangaStatusBadgeView.swift */,
 				BC000510 /* SectionHeaderView.swift */,
 				BC000810 /* MangaDataChangeModifier.swift */,
+				AB5001FF00112233AA000002 /* NextUpdateFormatter.swift */,
+				AB5001FF00112233AA000004 /* NextUpdateBadgeView.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -810,6 +816,8 @@
 				AB4001FF00112233AA000001 /* SearchFilterBars.swift in Sources */,
 				AB4001FF00112233AA000003 /* EditEntryStatusSection.swift in Sources */,
 				AB4001FF00112233AA000005 /* AppError.swift in Sources */,
+				AB5001FF00112233AA000001 /* NextUpdateFormatter.swift in Sources */,
+				AB5001FF00112233AA000003 /* NextUpdateBadgeView.swift in Sources */,
 				BC000701 /* SearchResultRow.swift in Sources */,
 				BC000702 /* MemoMatchRow.swift in Sources */,
 				BC000703 /* CommentMatchRow.swift in Sources */,

--- a/MangaLauncher/Shared/NextUpdateBadgeView.swift
+++ b/MangaLauncher/Shared/NextUpdateBadgeView.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+/// `NextUpdateFormatter.Result` を表示するスタイル付きラベル。
+/// MangaRowCell / MangaGridCell の両方から使う。
+struct NextUpdateBadgeView: View {
+    let result: NextUpdateFormatter.Result
+
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
+    var body: some View {
+        switch result {
+        case .upcoming(let text, let isImminent):
+            Text(text)
+                .font(.caption2.weight(isImminent ? .bold : .regular))
+                .foregroundStyle(isImminent ? theme.primary : theme.onSurfaceVariant)
+        case .overdue(let text):
+            Text(text)
+                .font(.caption2.weight(.semibold))
+                // 期日超過は注意喚起。ハードコードの .orange ではなくテーマに沿った
+                // error 色を使うことで Classic / Ink / Retro 各テーマに馴染ませる。
+                .foregroundStyle(theme.error)
+        }
+    }
+}

--- a/MangaLauncher/Shared/NextUpdateFormatter.swift
+++ b/MangaLauncher/Shared/NextUpdateFormatter.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// `MangaEntry.nextExpectedUpdate` を View 表示用の文字列に整形するヘルパー。
+/// 近日 (今日 / 明日 / N 日後) は相対表現、それ以遠は絶対日付、
+/// 過去日は「期日超過」とそれぞれ用途別の labeling を返す。
+enum NextUpdateFormatter {
+
+    enum Style: Equatable {
+        /// 通常: 直近のみ表示する。グリッドのバッジ用途。
+        ///   - 今日 / 明日 / N 日後 のみ。それ以遠 (>= 8 日 or 過去) は nil
+        case compact
+
+        /// 詳細: 常に何かを返す。リストの行末用途。
+        ///   - 今日 / 明日 / N 日後 / 絶対日付 / 期日超過
+        case full
+    }
+
+    enum Result: Equatable {
+        case upcoming(text: String, isImminent: Bool) // isImminent: 今日 or 明日
+        case overdue(text: String) // nextExpectedUpdate < 今日
+
+        /// VoiceOver の追加読み上げに使う文字列。
+        var accessibilityText: String {
+            switch self {
+            case .upcoming(let text, _): return "次回更新 \(text)"
+            case .overdue(let text): return text
+            }
+        }
+    }
+
+    /// 表示テキストと「強調すべきか」のフラグを返す。nil の場合は表示しない。
+    static func format(_ date: Date?, style: Style, now: Date = Date()) -> Result? {
+        guard let date else { return nil }
+        let calendar = Calendar.current
+        let target = calendar.startOfDay(for: date)
+        let today = calendar.startOfDay(for: now)
+        let days = calendar.dateComponents([.day], from: today, to: target).day ?? 0
+
+        if days < 0 {
+            switch style {
+            case .compact:
+                return nil // グリッドでは過去は出さない
+            case .full:
+                return .overdue(text: "期日超過")
+            }
+        }
+
+        if days == 0 { return .upcoming(text: "今日", isImminent: true) }
+        if days == 1 { return .upcoming(text: "明日", isImminent: true) }
+        if days <= 7 { return .upcoming(text: "あと\(days)日", isImminent: false) }
+
+        switch style {
+        case .compact:
+            return nil // 1 週間より先はグリッドでは出さない
+        case .full:
+            return .upcoming(text: Self.absoluteFormatter.string(from: date), isImminent: false)
+        }
+    }
+
+    private static let absoluteFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "ja_JP")
+        f.dateFormat = "M/d(E)"
+        return f
+    }()
+}

--- a/MangaLauncher/Shared/UserDefaultsKeys.swift
+++ b/MangaLauncher/Shared/UserDefaultsKeys.swift
@@ -14,6 +14,7 @@ enum UserDefaultsKeys {
     // MARK: - Display
     static let displayMode = "displayMode"
     static let browserMode = "browserMode"
+    static let showsNextUpdateBadge = "showsNextUpdateBadge"
 
     // MARK: - Pending intent signals (App Group 経由)
     static let pendingIntentData = "pendingIntentData"

--- a/MangaLauncher/Views/MangaCell/MangaGridCell.swift
+++ b/MangaLauncher/Views/MangaCell/MangaGridCell.swift
@@ -13,27 +13,51 @@ struct MangaGridCell: View {
 
     private var theme: ThemeStyle { ThemeManager.shared.style }
 
+    private var accessibilityLabel: String {
+        var parts = [entry.name]
+        if !entry.publisher.isEmpty { parts.append(entry.publisher) }
+        if !entry.isRead { parts.append("未読") }
+        if let next = NextUpdateFormatter.format(entry.nextExpectedUpdate, style: .compact) {
+            parts.append(next.accessibilityText)
+        }
+        return parts.joined(separator: "、")
+    }
+
     var body: some View {
         if entry.isDeleted || entry.modelContext == nil {
             EmptyView()
         } else {
             VStack(alignment: .leading, spacing: 6) {
-                if let imageData = entry.imageData, let image = imageData.toSwiftUIImage() {
-                    image
-                        .resizable()
-                        .scaledToFit()
-                        .clipShape(RoundedRectangle(cornerRadius: 8))
-                } else {
-                    RoundedRectangle(cornerRadius: 8)
-                        .fill(Color.fromName(entry.iconColor))
-                        .aspectRatio(3/4, contentMode: .fit)
-                        .overlay {
-                            Text(entry.name)
-                                .font(.title2.bold())
-                                .foregroundStyle(.white)
-                                .multilineTextAlignment(.center)
-                                .padding(8)
-                        }
+                ZStack(alignment: .topTrailing) {
+                    if let imageData = entry.imageData, let image = imageData.toSwiftUIImage() {
+                        image
+                            .resizable()
+                            .scaledToFit()
+                            .clipShape(RoundedRectangle(cornerRadius: 8))
+                    } else {
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(Color.fromName(entry.iconColor))
+                            .aspectRatio(3/4, contentMode: .fit)
+                            .overlay {
+                                Text(entry.name)
+                                    .font(.title2.bold())
+                                    .foregroundStyle(.white)
+                                    .multilineTextAlignment(.center)
+                                    .padding(8)
+                            }
+                    }
+
+                    if let result = NextUpdateFormatter.format(entry.nextExpectedUpdate, style: .compact) {
+                        NextUpdateBadgeView(result: result)
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 2)
+                            // テーマに沿った塗り。`.ultraThinMaterial` だと
+                            // Ink / Retro の独自背景と整合せず浮いて見える。
+                            .background(
+                                Capsule().fill(theme.surfaceContainerHighest.opacity(0.85))
+                            )
+                            .padding(4)
+                    }
                 }
 
                 HStack(alignment: .top, spacing: 4) {
@@ -71,7 +95,7 @@ struct MangaGridCell: View {
             }
             .contentShape(Rectangle())
             .accessibilityElement(children: .combine)
-            .accessibilityLabel("\(entry.name)\(entry.publisher.isEmpty ? "" : "、\(entry.publisher)")\(entry.isRead ? "" : "、未読")")
+            .accessibilityLabel(accessibilityLabel)
             .accessibilityHint("タップでサイトを開く")
             .onTapGesture {
                 if isGridEditMode {

--- a/MangaLauncher/Views/MangaCell/MangaGridCell.swift
+++ b/MangaLauncher/Views/MangaCell/MangaGridCell.swift
@@ -11,13 +11,16 @@ struct MangaGridCell: View {
     @Binding var commentingEntry: MangaEntry?
     let onOpenURL: (String) -> Void
 
+    @AppStorage(UserDefaultsKeys.showsNextUpdateBadge) private var showsNextUpdateBadge: Bool = true
+
     private var theme: ThemeStyle { ThemeManager.shared.style }
 
     private var accessibilityLabel: String {
         var parts = [entry.name]
         if !entry.publisher.isEmpty { parts.append(entry.publisher) }
         if !entry.isRead { parts.append("未読") }
-        if let next = NextUpdateFormatter.format(entry.nextExpectedUpdate, style: .compact) {
+        if showsNextUpdateBadge,
+           let next = NextUpdateFormatter.format(entry.nextExpectedUpdate, style: .compact) {
             parts.append(next.accessibilityText)
         }
         return parts.joined(separator: "、")
@@ -47,7 +50,8 @@ struct MangaGridCell: View {
                             }
                     }
 
-                    if let result = NextUpdateFormatter.format(entry.nextExpectedUpdate, style: .compact) {
+                    if showsNextUpdateBadge,
+                       let result = NextUpdateFormatter.format(entry.nextExpectedUpdate, style: .compact) {
                         NextUpdateBadgeView(result: result)
                             .padding(.horizontal, 5)
                             .padding(.vertical, 2)

--- a/MangaLauncher/Views/MangaCell/MangaRowCell.swift
+++ b/MangaLauncher/Views/MangaCell/MangaRowCell.swift
@@ -13,13 +13,16 @@ struct MangaRowCell: View {
     #endif
     let onOpenURL: (String) -> Void
 
+    @AppStorage(UserDefaultsKeys.showsNextUpdateBadge) private var showsNextUpdateBadge: Bool = true
+
     private var theme: ThemeStyle { ThemeManager.shared.style }
 
     private var accessibilityLabel: String {
         var parts = [entry.name]
         if !entry.publisher.isEmpty { parts.append(entry.publisher) }
         if !entry.isRead { parts.append("未読") }
-        if let next = NextUpdateFormatter.format(entry.nextExpectedUpdate, style: .full) {
+        if showsNextUpdateBadge,
+           let next = NextUpdateFormatter.format(entry.nextExpectedUpdate, style: .full) {
             parts.append(next.accessibilityText)
         }
         return parts.joined(separator: "、")
@@ -79,7 +82,8 @@ struct MangaRowCell: View {
 
                 Spacer()
 
-                if let result = NextUpdateFormatter.format(entry.nextExpectedUpdate, style: .full) {
+                if showsNextUpdateBadge,
+                   let result = NextUpdateFormatter.format(entry.nextExpectedUpdate, style: .full) {
                     NextUpdateBadgeView(result: result)
                         .padding(.trailing, 4)
                 }

--- a/MangaLauncher/Views/MangaCell/MangaRowCell.swift
+++ b/MangaLauncher/Views/MangaCell/MangaRowCell.swift
@@ -15,6 +15,16 @@ struct MangaRowCell: View {
 
     private var theme: ThemeStyle { ThemeManager.shared.style }
 
+    private var accessibilityLabel: String {
+        var parts = [entry.name]
+        if !entry.publisher.isEmpty { parts.append(entry.publisher) }
+        if !entry.isRead { parts.append("未読") }
+        if let next = NextUpdateFormatter.format(entry.nextExpectedUpdate, style: .full) {
+            parts.append(next.accessibilityText)
+        }
+        return parts.joined(separator: "、")
+    }
+
     var body: some View {
         if entry.isDeleted || entry.modelContext == nil {
             EmptyView()
@@ -69,6 +79,11 @@ struct MangaRowCell: View {
 
                 Spacer()
 
+                if let result = NextUpdateFormatter.format(entry.nextExpectedUpdate, style: .full) {
+                    NextUpdateBadgeView(result: result)
+                        .padding(.trailing, 4)
+                }
+
                 switch ThemeManager.shared.mode {
                 case .ink:
                     Image(systemName: "chevron.right")
@@ -88,7 +103,7 @@ struct MangaRowCell: View {
             .padding(.horizontal, theme.usesCustomSurface ? 4 : 0)
             .contentShape(Rectangle())
             .accessibilityElement(children: .combine)
-            .accessibilityLabel("\(entry.name)\(entry.publisher.isEmpty ? "" : "、\(entry.publisher)")\(entry.isRead ? "" : "、未読")")
+            .accessibilityLabel(accessibilityLabel)
             .accessibilityHint("タップでサイトを開く")
             .onTapGesture {
                 onOpenURL(entry.url)

--- a/MangaLauncher/Views/Settings/SettingsView.swift
+++ b/MangaLauncher/Views/Settings/SettingsView.swift
@@ -14,6 +14,7 @@ struct SettingsView: View {
     @State private var showingImporter = false
     @State private var importResult: ImportResult?
     @AppStorage(UserDefaultsKeys.browserMode) private var browserMode: String = "external"
+    @AppStorage(UserDefaultsKeys.showsNextUpdateBadge) private var showsNextUpdateBadge: Bool = true
     @State private var updateStatus: UpdateStatus = .idle
     @State private var showingOnboarding = false
     @State private var showingSyncError = false
@@ -176,6 +177,14 @@ struct SettingsView: View {
                     Text("カラーラベル")
                 } footer: {
                     Text("カラーアイコンに任意の名前を付けると、検索フィルターで使用できます（例：赤=お気に入り）")
+                }
+
+                Section {
+                    Toggle("次回更新日を表示", isOn: $showsNextUpdateBadge)
+                } header: {
+                    Text("表示")
+                } footer: {
+                    Text("ホーム画面のセルに次回更新までの日数を表示します。")
                 }
 
                 Section {

--- a/MangaLauncherTests/NextUpdateFormatterTests.swift
+++ b/MangaLauncherTests/NextUpdateFormatterTests.swift
@@ -1,0 +1,90 @@
+//
+//  NextUpdateFormatterTests.swift
+//  MangaLauncherTests
+//
+//  日付→表示文字列変換の境界値テスト。
+//  now パラメータで決定論的に検証。
+//
+
+import Testing
+import Foundation
+@testable import MangaLauncher
+
+@Suite("NextUpdateFormatter")
+struct NextUpdateFormatterTests {
+
+    private let now = Calendar.current.startOfDay(for: Date(timeIntervalSince1970: 1_900_000_000))
+
+    private func days(_ delta: Int) -> Date {
+        Calendar.current.date(byAdding: .day, value: delta, to: now)!
+    }
+
+    // MARK: - 共通ロジック
+
+    @Test("nil は常に nil を返す")
+    func nilReturnsNil() {
+        #expect(NextUpdateFormatter.format(nil, style: .compact, now: now) == nil)
+        #expect(NextUpdateFormatter.format(nil, style: .full, now: now) == nil)
+    }
+
+    @Test("0 日 (今日) は imminent 「今日」")
+    func today() {
+        let r = NextUpdateFormatter.format(now, style: .full, now: now)
+        #expect(r == .upcoming(text: "今日", isImminent: true))
+    }
+
+    @Test("1 日 (明日) は imminent 「明日」")
+    func tomorrow() {
+        let r = NextUpdateFormatter.format(days(1), style: .full, now: now)
+        #expect(r == .upcoming(text: "明日", isImminent: true))
+    }
+
+    @Test("2-7 日は通常 「あと N 日」")
+    func upcomingDays() {
+        let r3 = NextUpdateFormatter.format(days(3), style: .full, now: now)
+        #expect(r3 == .upcoming(text: "あと3日", isImminent: false))
+
+        let r7 = NextUpdateFormatter.format(days(7), style: .full, now: now)
+        #expect(r7 == .upcoming(text: "あと7日", isImminent: false))
+    }
+
+    // MARK: - スタイル別
+
+    @Test("compact: 8 日以上先は nil")
+    func compactHidesFar() {
+        #expect(NextUpdateFormatter.format(days(8), style: .compact, now: now) == nil)
+        #expect(NextUpdateFormatter.format(days(30), style: .compact, now: now) == nil)
+    }
+
+    @Test("full: 8 日以上先は絶対日付を返す")
+    func fullShowsAbsolute() {
+        let r = NextUpdateFormatter.format(days(8), style: .full, now: now)
+        if case .upcoming(let text, let isImminent) = r {
+            #expect(!text.isEmpty)
+            #expect(isImminent == false)
+        } else {
+            Issue.record("expected .upcoming with absolute text")
+        }
+    }
+
+    @Test("compact: 過去日は nil")
+    func compactHidesOverdue() {
+        #expect(NextUpdateFormatter.format(days(-1), style: .compact, now: now) == nil)
+        #expect(NextUpdateFormatter.format(days(-100), style: .compact, now: now) == nil)
+    }
+
+    @Test("full: 過去日は overdue 「期日超過」")
+    func fullShowsOverdue() {
+        let r = NextUpdateFormatter.format(days(-1), style: .full, now: now)
+        #expect(r == .overdue(text: "期日超過"))
+    }
+
+    // MARK: - accessibilityText
+
+    @Test("accessibilityText が VoiceOver 用文字列を返す")
+    func accessibilityText() {
+        #expect(NextUpdateFormatter.Result.upcoming(text: "今日", isImminent: true).accessibilityText == "次回更新 今日")
+        #expect(NextUpdateFormatter.Result.upcoming(text: "あと3日", isImminent: false).accessibilityText == "次回更新 あと3日")
+        #expect(NextUpdateFormatter.Result.overdue(text: "期日超過").accessibilityText == "期日超過")
+    }
+}


### PR DESCRIPTION
## Summary

ホーム画面のマンガセル (グリッド・リスト) に **次回更新日 (`nextExpectedUpdate`)** を表示する。データはすでに保存済みのため View 側だけで完結。

設定からON/OFF可能 (デフォルトON)。

## 表示仕様

| 状況 | リスト | グリッド |
|---|---|---|
| 今日 | 「今日」太字・`theme.primary` | サムネ右上にバッジ |
| 明日 | 「明日」太字・`theme.primary` | サムネ右上にバッジ |
| 2-7 日後 | 「あと N 日」通常 | サムネ右上にバッジ |
| 8 日以上先 | 「M/d(E)」絶対日付 | 表示なし (情報過多防止) |
| 過去 (期日超過) | 「期日超過」`theme.error` | 表示なし |
| nil (未設定) | 表示なし | 表示なし |

## 実装

### モデル / フォーマッタ
- **`Shared/NextUpdateFormatter.swift`** (純関数): `Date?` → `Result` enum
  - `.upcoming(text:, isImminent:)` / `.overdue(text:)`
  - `compact` / `full` の 2 スタイルでグリッドとリストで粒度切替
  - `now` パラメータで決定論的にテスト可能

### View
- **`Shared/NextUpdateBadgeView.swift`**: テーマ対応の小さなラベル
  - imminent: `theme.primary`
  - overdue: `theme.error` (各テーマで色が違う)
- **`MangaRowCell`**: 行末 chevron の前にバッジ追加
- **`MangaGridCell`**: サムネ画像を ZStack で覆い、バッジを右上にオーバーレイ。Capsule 背景は `theme.surfaceContainerHighest.opacity(0.85)` で 3 テーマに整合

### 設定トグル
- `UserDefaultsKeys.showsNextUpdateBadge` (デフォルト `true`)
- `SettingsView` に「表示」セクションを追加。「次回更新日を表示」トグル1つ
- `MangaRowCell` / `MangaGridCell` で `@AppStorage` 監視。OFF時はバッジとVoiceOver読み上げ両方を抑制

## アクセシビリティ

`accessibilityLabel` を helper に整理し VoiceOver で「次回更新 今日」「期日超過」などを読み上げ:
```swift
private var accessibilityLabel: String {
    var parts = [entry.name]
    if !entry.publisher.isEmpty { parts.append(entry.publisher) }
    if !entry.isRead { parts.append("未読") }
    if showsNextUpdateBadge,
       let next = NextUpdateFormatter.format(entry.nextExpectedUpdate, style: .full) {
        parts.append(next.accessibilityText)
    }
    return parts.joined(separator: "、")
}
```

## テスト

`MangaLauncherTests/NextUpdateFormatterTests.swift` を追加:
- 境界値 (0/1/2-7/8+/負数)
- compact vs full のスタイル差
- accessibilityText の出力

## Test plan

- [x] `xcodebuild` 通る
- [x] 実機で表示確認 (今日 / 明日 / N 日後 のバッジ表示)
- [x] 設定トグルでON/OFFが切替わること
- [ ] テーマ切替 (Classic / Ink / Retro) で配色が破綻しないこと
- [ ] グリッド・リスト両方で適切な表示
- [ ] 過去日のエントリで「期日超過」が出ること
- [ ] VoiceOver で次回更新が読み上げられること

🤖 Generated with [Claude Code](https://claude.com/claude-code)