### PR TITLE
Fix onboarding to display above tab bar

### DIFF
--- a/MangaLauncher/Views/Home/ContentView.swift
+++ b/MangaLauncher/Views/Home/ContentView.swift
@@ -16,7 +16,6 @@ struct ContentView: View {
 
     var viewModel: MangaViewModel
     @State private var homeState = HomeState()
-    @AppStorage(UserDefaultsKeys.hasSeenOnboarding) private var hasSeenOnboarding = false
     @AppStorage(UserDefaultsKeys.displayMode) private var displayMode: DisplayMode = .grid
     @AppStorage(UserDefaultsKeys.browserMode) private var browserMode: String = "external"
 
@@ -25,17 +24,12 @@ struct ContentView: View {
     private let orderedDays = DayOfWeek.orderedDays
 
     var body: some View {
-        if !hasSeenOnboarding {
-            OnboardingView {
-                hasSeenOnboarding = true
-            }
-        } else {
-            NavigationStack {
-                mainContent(viewModel: viewModel)
-            }
-            .onAppear {
-                homeState.wallpaper.loadImage()
-            }
+        NavigationStack {
+            mainContent(viewModel: viewModel)
+        }
+        .onAppear {
+            homeState.wallpaper.loadImage()
+        }
             .onMangaDataChange {
                 viewModel.refresh()
             }
@@ -49,7 +43,6 @@ struct ContentView: View {
             .onReceive(NotificationCenter.default.publisher(for: .openCatchUp)) { _ in
                 homeState.sheets.showingCatchUp = true
             }
-        }
     }
 
     // MARK: - Main Content

--- a/MangaLauncher/Views/RootTabView.swift
+++ b/MangaLauncher/Views/RootTabView.swift
@@ -7,8 +7,14 @@ enum RootTab: Hashable {
 struct RootTabView: View {
     var viewModel: MangaViewModel
     @State private var selectedTab: RootTab = .home
+    @AppStorage(UserDefaultsKeys.hasSeenOnboarding) private var hasSeenOnboarding = false
 
     var body: some View {
+        if !hasSeenOnboarding {
+            OnboardingView {
+                hasSeenOnboarding = true
+            }
+        } else {
         TabView(selection: $selectedTab) {
             Tab("ホーム", systemImage: "house.fill", value: RootTab.home) {
                 ContentView(viewModel: viewModel)
@@ -62,6 +68,7 @@ struct RootTabView: View {
             Button("OK") { viewModel.lastError = nil }
         } message: { error in
             Text(error.message)
+        }
         }
     }
 }


### PR DESCRIPTION
## Summary

- オンボーディング画面が ContentView（ホームタブ内）に配置されていたため、タブバーの上に表示されていた
- RootTabView に移動し、全タブの上にフルスクリーンで表示されるように修正

## Test plan

- [x] アプリ削除→再インストールでオンボーディングがタブバーなしで全画面表示されること
- [x] オンボーディング完了後に通常のタブ画面が表示されること
- [x] 設定画面の「アプリについて」からオンボーディングを再表示できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)