### PR TITLE
Improve performance and deduplicate accessibility logic

### DIFF
--- a/MangaLauncher.xcodeproj/project.pbxproj
+++ b/MangaLauncher.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		AB50020000112233AA000002 /* MangaEntryAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB50020000112233AA000001 /* MangaEntryAccessibility.swift */; };
 		C2C5E8A68C5957E075832254 /* ImageColorExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05365AD0D66B41D8C20EDF49 /* ImageColorExtractor.swift */; };
 		C2C5E8A68C5957E075832255 /* ImageColorExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05365AD0D66B41D8C20EDF49 /* ImageColorExtractor.swift */; };
 		ECCE6BE2DD70F34BA69061B3 /* DesignSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC38F4ED01AE0D411DA0C66B /* DesignSystem.swift */; };
@@ -170,6 +171,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		AB50020000112233AA000001 /* MangaEntryAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaEntryAccessibility.swift; sourceTree = "<group>"; };
 		EC38F4ED01AE0D411DA0C66B /* DesignSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystem.swift; sourceTree = "<group>"; };
 		05365AD0D66B41D8C20EDF49 /* ImageColorExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageColorExtractor.swift; sourceTree = "<group>"; };
 		0557E9481117CB9F8B903947 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -619,6 +621,7 @@
 				BC000510 /* SectionHeaderView.swift */,
 				BC000810 /* MangaDataChangeModifier.swift */,
 				AB5001FF00112233AA000002 /* NextUpdateFormatter.swift */,
+				AB50020000112233AA000001 /* MangaEntryAccessibility.swift */,
 				AB5001FF00112233AA000004 /* NextUpdateBadgeView.swift */,
 			);
 			path = Shared;
@@ -817,6 +820,7 @@
 				AB4001FF00112233AA000003 /* EditEntryStatusSection.swift in Sources */,
 				AB4001FF00112233AA000005 /* AppError.swift in Sources */,
 				AB5001FF00112233AA000001 /* NextUpdateFormatter.swift in Sources */,
+				AB50020000112233AA000002 /* MangaEntryAccessibility.swift in Sources */,
 				AB5001FF00112233AA000003 /* NextUpdateBadgeView.swift in Sources */,
 				BC000701 /* SearchResultRow.swift in Sources */,
 				BC000702 /* MemoMatchRow.swift in Sources */,

--- a/MangaLauncher/Models/MangaEntry.swift
+++ b/MangaLauncher/Models/MangaEntry.swift
@@ -278,4 +278,5 @@ final class MangaEntry {
         // 新規作成時は移行済み扱い
         self.stateMigrationVersion = 1
     }
+
 }

--- a/MangaLauncher/Shared/MangaEntryAccessibility.swift
+++ b/MangaLauncher/Shared/MangaEntryAccessibility.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+extension MangaEntry {
+    func accessibilityDescription(nextUpdateStyle: NextUpdateFormatter.Style, showsNextUpdateBadge: Bool) -> String {
+        var parts = [name]
+        if !publisher.isEmpty { parts.append(publisher) }
+        if !isRead { parts.append("未読") }
+        if showsNextUpdateBadge,
+           let next = NextUpdateFormatter.format(nextExpectedUpdate, style: nextUpdateStyle) {
+            parts.append(next.accessibilityText)
+        }
+        return parts.joined(separator: "、")
+    }
+}

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -434,13 +434,12 @@ final class MangaViewModel {
     }
 
     func findEntries(by ids: Set<UUID>) -> [UUID: MangaEntry] {
-        let descriptor = FetchDescriptor<MangaEntry>()
+        let idArray = Array(ids)
+        let descriptor = FetchDescriptor<MangaEntry>(
+            predicate: #Predicate { idArray.contains($0.id) }
+        )
         let entries = modelContext.fetchLogged(descriptor)
-        var result: [UUID: MangaEntry] = [:]
-        for entry in entries where ids.contains(entry.id) {
-            result[entry.id] = entry
-        }
-        return result
+        return Dictionary(uniqueKeysWithValues: entries.map { ($0.id, $0) })
     }
 
     func markAsRead(_ entry: MangaEntry) {

--- a/MangaLauncher/Views/MangaCell/MangaGridCell.swift
+++ b/MangaLauncher/Views/MangaCell/MangaGridCell.swift
@@ -16,14 +16,7 @@ struct MangaGridCell: View {
     private var theme: ThemeStyle { ThemeManager.shared.style }
 
     private var accessibilityLabel: String {
-        var parts = [entry.name]
-        if !entry.publisher.isEmpty { parts.append(entry.publisher) }
-        if !entry.isRead { parts.append("未読") }
-        if showsNextUpdateBadge,
-           let next = NextUpdateFormatter.format(entry.nextExpectedUpdate, style: .compact) {
-            parts.append(next.accessibilityText)
-        }
-        return parts.joined(separator: "、")
+        entry.accessibilityDescription(nextUpdateStyle: .compact, showsNextUpdateBadge: showsNextUpdateBadge)
     }
 
     var body: some View {

--- a/MangaLauncher/Views/MangaCell/MangaRowCell.swift
+++ b/MangaLauncher/Views/MangaCell/MangaRowCell.swift
@@ -18,14 +18,7 @@ struct MangaRowCell: View {
     private var theme: ThemeStyle { ThemeManager.shared.style }
 
     private var accessibilityLabel: String {
-        var parts = [entry.name]
-        if !entry.publisher.isEmpty { parts.append(entry.publisher) }
-        if !entry.isRead { parts.append("未読") }
-        if showsNextUpdateBadge,
-           let next = NextUpdateFormatter.format(entry.nextExpectedUpdate, style: .full) {
-            parts.append(next.accessibilityText)
-        }
-        return parts.joined(separator: "、")
+        entry.accessibilityDescription(nextUpdateStyle: .full, showsNextUpdateBadge: showsNextUpdateBadge)
     }
 
     var body: some View {

--- a/MangaLauncher/Views/Search/SearchView.swift
+++ b/MangaLauncher/Views/Search/SearchView.swift
@@ -21,19 +21,21 @@ struct SearchView: View {
     @State private var commentingEntry: MangaEntry?
     @AppStorage(UserDefaultsKeys.browserMode) private var browserMode: String = "external"
 
+    @State private var cachedResults = SearchResults()
+
     private var theme: ThemeStyle { ThemeManager.shared.style }
 
     // MARK: - Search Results
 
     private struct SearchResults {
-        var entries: [MangaEntry]
-        var memos: [MangaEntry]
-        var comments: [(comment: MangaComment, entry: MangaEntry)]
+        var entries: [MangaEntry] = []
+        var memos: [MangaEntry] = []
+        var comments: [(comment: MangaComment, entry: MangaEntry)] = []
 
         var isEmpty: Bool { entries.isEmpty && memos.isEmpty && comments.isEmpty }
     }
 
-    private var searchResults: SearchResults {
+    private func computeSearchResults() -> SearchResults {
         let allEntries = viewModel.allEntries()
         let dayFiltered = applyDayFilter(to: allEntries)
         let colorFiltered = applyColorFilter(to: dayFiltered)
@@ -89,6 +91,10 @@ struct SearchView: View {
         }
 
         return SearchResults(entries: nameMatched, memos: memoMatched, comments: commentMatched)
+    }
+
+    private func refreshResults() {
+        cachedResults = computeSearchResults()
     }
 
     // MARK: - Filter Logic
@@ -187,6 +193,15 @@ struct SearchView: View {
             }
             #endif
         }
+        .onAppear { refreshResults() }
+        .onChange(of: searchText) { _, _ in refreshResults() }
+        .onChange(of: contentMode) { _, _ in refreshResults() }
+        .onChange(of: publicationFilter) { _, _ in refreshResults() }
+        .onChange(of: readingFilter) { _, _ in refreshResults() }
+        .onChange(of: showOneShotOnly) { _, _ in refreshResults() }
+        .onChange(of: selectedDay) { _, _ in refreshResults() }
+        .onChange(of: selectedColors) { _, _ in refreshResults() }
+        .onChange(of: viewModel.refreshCounter) { _, _ in refreshResults() }
         .onMangaDataChange {
             viewModel.refresh()
         }
@@ -196,11 +211,10 @@ struct SearchView: View {
 
     @ViewBuilder
     private var content: some View {
-        let results = searchResults
-        if results.isEmpty {
+        if cachedResults.isEmpty {
             emptyState
         } else {
-            resultList(results: results)
+            resultList(results: cachedResults)
         }
     }
 


### PR DESCRIPTION
## Summary

- **SearchView 検索結果メモ化**: computed property → `@State` + `onChange` で入力やフィルタ変更時にのみ再計算。body の再描画ごとに全データ走査していた問題を解消
- **accessibilityLabel 重複排除**: `MangaGridCell` と `MangaRowCell` で同一だったロジックを `MangaEntry.accessibilityDescription()` に共通化
- **findEntries(by:) 最適化**: 全件 fetch → `#Predicate { idArray.contains($0.id) }` で必要な ID のみ DB から取得

## Test plan

- [ ] 検索画面でテキスト入力・フィルタ切替が即座に反映されること
- [ ] グリッド / リストの VoiceOver 読み上げが従来通り動作すること
- [ ] CatchUp でカードめくり・undo が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)