### PR TITLE
Add episode tracker for reading progress

### DIFF
--- a/MangaLauncher/Models/BackupData.swift
+++ b/MangaLauncher/Models/BackupData.swift
@@ -44,12 +44,14 @@ struct BackupData: Codable {
         let memo: String?
         // v8+
         let memoUpdatedAt: Date?
+        // v9+
+        let currentEpisode: Int?
         // Legacy fields (kept for backward-compat with v5 backups)
         let isOnHiatus: Bool?
         let isCompleted: Bool?
         let isBacklog: Bool?
 
-        init(id: UUID, name: String, url: String, dayOfWeekRawValue: Int, sortOrder: Int, iconColor: String, publisher: String, imageData: Data?, lastReadDate: Date? = nil, updateIntervalWeeks: Int = 1, nextExpectedUpdate: Date? = nil, isOneShot: Bool = false, publicationStatusRawValue: Int = 0, readingStateRawValue: Int = 0, memo: String = "", memoUpdatedAt: Date? = nil) {
+        init(id: UUID, name: String, url: String, dayOfWeekRawValue: Int, sortOrder: Int, iconColor: String, publisher: String, imageData: Data?, lastReadDate: Date? = nil, updateIntervalWeeks: Int = 1, nextExpectedUpdate: Date? = nil, isOneShot: Bool = false, publicationStatusRawValue: Int = 0, readingStateRawValue: Int = 0, memo: String = "", memoUpdatedAt: Date? = nil, currentEpisode: Int? = nil) {
             self.id = id
             self.name = name
             self.url = url
@@ -66,6 +68,7 @@ struct BackupData: Codable {
             self.readingStateRawValue = readingStateRawValue
             self.memo = memo
             self.memoUpdatedAt = memoUpdatedAt
+            self.currentEpisode = currentEpisode
             self.isOnHiatus = nil
             self.isCompleted = nil
             self.isBacklog = nil
@@ -89,6 +92,7 @@ struct BackupData: Codable {
             readingStateRawValue = try container.decodeIfPresent(Int.self, forKey: .readingStateRawValue)
             memo = try container.decodeIfPresent(String.self, forKey: .memo)
             memoUpdatedAt = try container.decodeIfPresent(Date.self, forKey: .memoUpdatedAt)
+            currentEpisode = try container.decodeIfPresent(Int.self, forKey: .currentEpisode)
             isOnHiatus = try container.decodeIfPresent(Bool.self, forKey: .isOnHiatus)
             isCompleted = try container.decodeIfPresent(Bool.self, forKey: .isCompleted)
             isBacklog = try container.decodeIfPresent(Bool.self, forKey: .isBacklog)
@@ -97,7 +101,7 @@ struct BackupData: Codable {
 
     static func from(_ entries: [MangaEntry], activities: [ReadingActivity] = [], comments: [MangaComment] = []) -> BackupData {
         BackupData(
-            version: 8,
+            version: 9,
             exportDate: Date(),
             entries: entries.map {
                 BackupEntry(
@@ -116,7 +120,8 @@ struct BackupData: Codable {
                     publicationStatusRawValue: $0.publicationStatusRawValue,
                     readingStateRawValue: $0.readingStateRawValue,
                     memo: $0.memo,
-                    memoUpdatedAt: $0.memoUpdatedAt
+                    memoUpdatedAt: $0.memoUpdatedAt,
+                    currentEpisode: $0.currentEpisode
                 )
             },
             activities: activities.map {

--- a/MangaLauncher/Models/MangaEntry.swift
+++ b/MangaLauncher/Models/MangaEntry.swift
@@ -111,6 +111,8 @@ final class MangaEntry {
     var memo: String = ""
     /// メモの最終更新日時。並び替え用。
     var memoUpdatedAt: Date?
+    /// 現在の話数。nil は未設定。
+    var currentEpisode: Int?
 
     /// 掲載状況の Int 値（PublicationStatus.rawValue）
     var publicationStatusRawValue: Int = 0

--- a/MangaLauncher/Models/ReadingActivity.swift
+++ b/MangaLauncher/Models/ReadingActivity.swift
@@ -11,12 +11,14 @@ final class ReadingActivity {
     var timestamp: Date?
     var mangaName: String = ""
     var mangaEntryID: UUID = UUID()
+    var episodeNumber: Int?
 
-    init(date: Date, mangaName: String, mangaEntryID: UUID) {
+    init(date: Date, mangaName: String, mangaEntryID: UUID, episodeNumber: Int? = nil) {
         self.id = UUID()
         self.date = Calendar.current.startOfDay(for: date)
         self.timestamp = date
         self.mangaName = mangaName
         self.mangaEntryID = mangaEntryID
+        self.episodeNumber = episodeNumber
     }
 }

--- a/MangaLauncher/Shared/MangaEntryAccessibility.swift
+++ b/MangaLauncher/Shared/MangaEntryAccessibility.swift
@@ -4,6 +4,7 @@ extension MangaEntry {
     func accessibilityDescription(nextUpdateStyle: NextUpdateFormatter.Style, showsNextUpdateBadge: Bool) -> String {
         var parts = [name]
         if !publisher.isEmpty { parts.append(publisher) }
+        if let ep = currentEpisode { parts.append("既読 \(ep)話") }
         if !isRead { parts.append("未読") }
         if showsNextUpdateBadge,
            let next = NextUpdateFormatter.format(nextExpectedUpdate, style: nextUpdateStyle) {

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -137,7 +137,20 @@ final class MangaViewModel {
         save()
     }
 
-    func addEntry(name: String, url: String, days: Set<DayOfWeek>, iconColor: String, publisher: String = "", imageData: Data? = nil, updateIntervalWeeks: Int = 1, nextExpectedUpdate: Date? = nil, publicationStatus: PublicationStatus = .active, readingState: ReadingState = .following, isOneShot: Bool = false, memo: String = "") {
+    func incrementEpisode(_ entry: MangaEntry) {
+        let newEpisode = (entry.currentEpisode ?? 0) + 1
+        entry.currentEpisode = newEpisode
+        let activity = ReadingActivity(
+            date: Date(),
+            mangaName: entry.name,
+            mangaEntryID: entry.id,
+            episodeNumber: newEpisode
+        )
+        modelContext.insert(activity)
+        save()
+    }
+
+    func addEntry(name: String, url: String, days: Set<DayOfWeek>, iconColor: String, publisher: String = "", imageData: Data? = nil, updateIntervalWeeks: Int = 1, nextExpectedUpdate: Date? = nil, publicationStatus: PublicationStatus = .active, readingState: ReadingState = .following, isOneShot: Bool = false, memo: String = "", currentEpisode: Int? = nil) {
         for day in days {
             let existingEntries = fetchEntries(for: day)
             let maxOrder = existingEntries.map(\.sortOrder).max() ?? -1
@@ -160,6 +173,7 @@ final class MangaViewModel {
             if !memo.isEmpty {
                 entry.memoUpdatedAt = Date()
             }
+            entry.currentEpisode = currentEpisode
             modelContext.insert(entry)
         }
         save()
@@ -178,7 +192,8 @@ final class MangaViewModel {
         isOneShot: Bool,
         publicationStatus: PublicationStatus,
         readingState: ReadingState,
-        memo: String
+        memo: String,
+        currentEpisode: Int? = nil
     ) {
         let memoChanged = entry.memo != memo
         entry.name = name
@@ -198,6 +213,7 @@ final class MangaViewModel {
         if memoChanged {
             entry.memoUpdatedAt = memo.isEmpty ? nil : Date()
         }
+        entry.currentEpisode = currentEpisode
         save()
     }
 
@@ -373,6 +389,7 @@ final class MangaViewModel {
             entry.isOneShot = backupEntry.isOneShot ?? false
             entry.memo = backupEntry.memo ?? ""
             entry.memoUpdatedAt = backupEntry.memoUpdatedAt
+            entry.currentEpisode = backupEntry.currentEpisode
             // v6+ バックアップは publicationStatusRawValue / readingStateRawValue を authoritative とする。
             // 両方 nil のときだけ v5 以前の legacy Bool から導出する。
             // 通常 export 側は両方を必ず書くので片方 nil は現実にはほぼ起こらないが、

--- a/MangaLauncher/Views/Entry/EditEntryStatusSection.swift
+++ b/MangaLauncher/Views/Entry/EditEntryStatusSection.swift
@@ -36,7 +36,7 @@ struct EditEntryStatusSection: View {
                 } header: {
                     Text("掲載状況")
                 } footer: {
-                    Text("作品自体の状態。連載中／休載中／完結。")
+                    Text("連載中はホーム画面に表示されます。休載中・完結はライブラリのみに表示されます。")
                 }
 
                 Section {
@@ -49,7 +49,7 @@ struct EditEntryStatusSection: View {
                 } header: {
                     Text("読書状況")
                 } footer: {
-                    Text("自分の進捗。追っかけ中／積読／読了。読了にすると常に既読扱いになります。")
+                    Text("追っかけ中はホーム画面に表示されます。積読・読了はライブラリのみに表示されます。読了にすると常に既読扱いになります。")
                 }
             }
         }

--- a/MangaLauncher/Views/Entry/EditEntryView.swift
+++ b/MangaLauncher/Views/Entry/EditEntryView.swift
@@ -32,6 +32,8 @@ struct EditEntryView: View {
     @State private var readingState: ReadingState = .following
     @State private var isOneShot = false
     @State private var memo: String = ""
+    @State private var currentEpisode: Int?
+    @State private var episodeText: String = ""
 
     private var theme: ThemeStyle { ThemeManager.shared.style }
 
@@ -282,6 +284,36 @@ struct EditEntryView: View {
                 }
 
                 Section {
+                    HStack {
+                        TextField("未設定", text: $episodeText)
+                            #if os(iOS) || os(visionOS)
+                            .keyboardType(.numberPad)
+                            #endif
+                            .onChange(of: episodeText) { _, newValue in
+                                if newValue.isEmpty {
+                                    currentEpisode = nil
+                                } else if let val = Int(newValue), val > 0 {
+                                    currentEpisode = val
+                                }
+                            }
+                        if currentEpisode != nil {
+                            Button {
+                                currentEpisode = nil
+                                episodeText = ""
+                            } label: {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundStyle(.secondary)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                } header: {
+                    Text("話数")
+                } footer: {
+                    Text("読んだ話数を記録します。長押しメニューからも更新できます。")
+                }
+
+                Section {
                     TextField("メモ（あらすじ・キャラ相関図など）", text: $memo, axis: .vertical)
                         .lineLimit(3...10)
                         #if os(iOS) || os(visionOS)
@@ -387,6 +419,8 @@ struct EditEntryView: View {
                     readingState = entry.readingState
                     isOneShot = entry.isOneShot
                     memo = entry.memo
+                    currentEpisode = entry.currentEpisode
+                    episodeText = entry.currentEpisode.map { String($0) } ?? ""
                     didLoadEntry = true
                 } else if entry == nil, !didLoadEntry {
                     nextUpdateDate = nextUpdateCandidates.first ?? nextOccurrence(of: selectedDay)
@@ -444,7 +478,8 @@ struct EditEntryView: View {
                 isOneShot: isOneShot,
                 publicationStatus: publicationStatus,
                 readingState: readingState,
-                memo: memo
+                memo: memo,
+                currentEpisode: currentEpisode
             )
         } else {
             viewModel.addEntry(
@@ -459,7 +494,8 @@ struct EditEntryView: View {
                 publicationStatus: isOneShot ? .active : publicationStatus,
                 readingState: readingState,
                 isOneShot: isOneShot,
-                memo: memo
+                memo: memo,
+                currentEpisode: currentEpisode
             )
         }
     }

--- a/MangaLauncher/Views/Library/LibraryCard.swift
+++ b/MangaLauncher/Views/Library/LibraryCard.swift
@@ -31,6 +31,19 @@ struct LibraryCard: View {
                         MangaStatusBadgeView(entry: entry, fontSize: 10)
                             .padding(4)
                     }
+                    .overlay(alignment: .bottomLeading) {
+                        if let ep = entry.currentEpisode {
+                            Text("既読 \(ep)話")
+                                .font(.caption2.weight(.medium))
+                                .foregroundStyle(theme.onPrimary)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(
+                                    Capsule().fill(theme.primary.opacity(0.85))
+                                )
+                                .padding(4)
+                        }
+                    }
 
                 Text(entry.name)
                     .font(theme.captionFont)

--- a/MangaLauncher/Views/Library/Timeline/TimelineRowView.swift
+++ b/MangaLauncher/Views/Library/Timeline/TimelineRowView.swift
@@ -124,8 +124,12 @@ struct TimelineRowView: View {
             } else {
                 Text(entry.memo)
             }
-        case .read:
-            Text("読みました")
+        case .read(let activity, _):
+            if let ep = activity.episodeNumber {
+                Text("既読 \(ep)話に更新")
+            } else {
+                Text("読みました")
+            }
         }
     }
 
@@ -134,7 +138,11 @@ struct TimelineRowView: View {
         switch item {
         case .comment: return ("bubble.left.fill", .blue)
         case .memo: return ("pencil", .orange)
-        case .read: return ("checkmark", .green)
+        case .read(let activity, _):
+            if activity.episodeNumber != nil {
+                return ("book.fill", .purple)
+            }
+            return ("checkmark", .green)
         }
     }
 }

--- a/MangaLauncher/Views/MangaCell/MangaContextMenu.swift
+++ b/MangaLauncher/Views/MangaCell/MangaContextMenu.swift
@@ -31,6 +31,15 @@ struct MangaContextMenu: View {
             }
         }
 
+        Button {
+            viewModel.incrementEpisode(entry)
+        } label: {
+            Label(
+                entry.currentEpisode == nil ? "話数を記録（1話）" : "\((entry.currentEpisode ?? 0) + 1)話まで読んだ",
+                systemImage: "plus.circle"
+            )
+        }
+
         Divider()
 
         // MARK: 日常操作

--- a/MangaLauncher/Views/MangaCell/MangaGridCell.swift
+++ b/MangaLauncher/Views/MangaCell/MangaGridCell.swift
@@ -48,10 +48,21 @@ struct MangaGridCell: View {
                         NextUpdateBadgeView(result: result)
                             .padding(.horizontal, 5)
                             .padding(.vertical, 2)
-                            // テーマに沿った塗り。`.ultraThinMaterial` だと
-                            // Ink / Retro の独自背景と整合せず浮いて見える。
                             .background(
                                 Capsule().fill(theme.surfaceContainerHighest.opacity(0.85))
+                            )
+                            .padding(4)
+                    }
+                }
+                .overlay(alignment: .bottomLeading) {
+                    if let ep = entry.currentEpisode {
+                        Text("既読 \(ep)話")
+                            .font(.caption2.weight(.medium))
+                            .foregroundStyle(theme.onPrimary)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(
+                                Capsule().fill(theme.primary.opacity(0.85))
                             )
                             .padding(4)
                     }

--- a/MangaLauncher/Views/MangaCell/MangaRowCell.swift
+++ b/MangaLauncher/Views/MangaCell/MangaRowCell.swift
@@ -66,10 +66,22 @@ struct MangaRowCell: View {
                     Text(entry.name)
                         .font(theme.bodyFont)
                         .foregroundStyle(theme.onSurface)
-                    if !entry.publisher.isEmpty {
-                        Text(entry.publisher)
-                            .font(theme.captionFont)
-                            .foregroundStyle(theme.onSurfaceVariant)
+                    HStack(spacing: 4) {
+                        if !entry.publisher.isEmpty {
+                            Text(entry.publisher)
+                                .font(theme.captionFont)
+                                .foregroundStyle(theme.onSurfaceVariant)
+                        }
+                        if let ep = entry.currentEpisode {
+                            if !entry.publisher.isEmpty {
+                                Text("·")
+                                    .font(theme.captionFont)
+                                    .foregroundStyle(theme.onSurfaceVariant)
+                            }
+                            Text("既読 \(ep)話")
+                                .font(theme.captionFont)
+                                .foregroundStyle(theme.primary)
+                        }
                     }
                 }
 

--- a/MangaShareExtension/ShareExtensionView.swift
+++ b/MangaShareExtension/ShareExtensionView.swift
@@ -190,7 +190,7 @@ struct ShareExtensionView: View {
                         } header: {
                             Text("掲載状況")
                         } footer: {
-                            Text("作品自体の状態。連載中／休載中／完結。")
+                            Text("連載中はホーム画面に表示されます。休載中・完結はライブラリのみに表示されます。")
                         }
                     }
 
@@ -205,7 +205,7 @@ struct ShareExtensionView: View {
                         } header: {
                             Text("読書状況")
                         } footer: {
-                            Text("自分の進捗。追っかけ中／積読／読了。")
+                            Text("追っかけ中はホーム画面に表示されます。積読・読了はライブラリのみに表示されます。")
                         }
                     }
 


### PR DESCRIPTION
## Summary

マンガの読んだ話数をワンタップで記録できる話数トラッカー機能を追加。コメントで「N話まで読んだ」と手入力する手間を解消。

## 機能

### 話数の記録
- コンテキストメニューに「N話まで読んだ」ボタン追加（ワンタップで +1）
- 編集画面に「話数」セクション追加（直接入力・クリア可能）

### 表示
- **グリッドセル**: サムネイル左下に `既読 N話` カプセルバッジ（primary カラー）
- **リストセル**: 出版社と同じ行に `出版社 · 既読 N話` と統合表示
- **ライブラリカード**: サムネイル左下にバッジ表示
- 話数未設定時は非表示

### タイムライン連携
- 話数更新時に `ReadingActivity` を自動記録
- タイムラインに「既読 N話に更新」として表示（紫の本アイコンで区別）

### その他
- バックアップ形式を v9 に更新（`currentEpisode` フィールド追加）
- VoiceOver で「既読 N話」を読み上げ
- 掲載状況・読書状況の footer にホーム/ライブラリの表示先を説明追加

## 実装

- `MangaEntry.currentEpisode: Int?` — SwiftData Lightweight Migration（Optional追加）
- `ReadingActivity.episodeNumber: Int?` — 話数変更の記録用
- `MangaViewModel.incrementEpisode()` — +1 & ReadingActivity 挿入
- `BackupData` v9 — `decodeIfPresent` で後方互換

## Test plan

- [x] コンテキストメニューから話数を +1 できること
- [x] 編集画面で話数を直接入力・クリアできること
- [x] グリッド / リスト / ライブラリに「既読 N話」が表示されること
- [x] タイムラインに話数更新が記録・表示されること
- [x] バックアップ・インポートで話数が保持されること
- [x] テーマ切替で表示が破綻しないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)