### PR TITLE
Add manga lifetime visualization

### DIFF
--- a/MangaLauncher.xcodeproj/project.pbxproj
+++ b/MangaLauncher.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		AB50030000112233AA000003 /* MangaLifetimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB50030000112233AA000004 /* MangaLifetimeView.swift */; };
+		AB50030000112233AA000001 /* MangaLifetime.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB50030000112233AA000002 /* MangaLifetime.swift */; };
 		AB50020000112233AA000002 /* MangaEntryAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB50020000112233AA000001 /* MangaEntryAccessibility.swift */; };
 		C2C5E8A68C5957E075832254 /* ImageColorExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05365AD0D66B41D8C20EDF49 /* ImageColorExtractor.swift */; };
 		C2C5E8A68C5957E075832255 /* ImageColorExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05365AD0D66B41D8C20EDF49 /* ImageColorExtractor.swift */; };
@@ -171,6 +173,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		AB50030000112233AA000004 /* MangaLifetimeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaLifetimeView.swift; sourceTree = "<group>"; };
+		AB50030000112233AA000002 /* MangaLifetime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaLifetime.swift; sourceTree = "<group>"; };
 		AB50020000112233AA000001 /* MangaEntryAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaEntryAccessibility.swift; sourceTree = "<group>"; };
 		EC38F4ED01AE0D411DA0C66B /* DesignSystem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSystem.swift; sourceTree = "<group>"; };
 		05365AD0D66B41D8C20EDF49 /* ImageColorExtractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageColorExtractor.swift; sourceTree = "<group>"; };
@@ -402,6 +406,7 @@
 			isa = PBXGroup;
 			children = (
 				A2000002 /* MangaEntry.swift */,
+				AB50030000112233AA000002 /* MangaLifetime.swift */,
 				3AFF912AECB7C6B219DD1600 /* BackupData.swift */,
 				AA000010 /* ReadingActivity.swift */,
 				BC000010 /* MangaComment.swift */,
@@ -591,6 +596,7 @@
 			isa = PBXGroup;
 			children = (
 				AA000011 /* ReadingHeatmapView.swift */,
+				AB50030000112233AA000004 /* MangaLifetimeView.swift */,
 			);
 			path = Heatmap;
 			sourceTree = "<group>";
@@ -808,6 +814,8 @@
 				ECFEA85C2F7F7C5200CE4DC0 /* PublisherFilterView.swift in Sources */,
 				ECCD2FCE2F65596900BF3309 /* PublisherPickerView.swift in Sources */,
 				A1000002 /* MangaEntry.swift in Sources */,
+				AB50030000112233AA000001 /* MangaLifetime.swift in Sources */,
+				AB50030000112233AA000003 /* MangaLifetimeView.swift in Sources */,
 				ECFEA8482F7F6E5700CE4DC0 /* MangaURLOpener.swift in Sources */,
 				A1000003 /* MangaViewModel.swift in Sources */,
 				ECFEA8582F7F7C3500CE4DC0 /* MangaListView.swift in Sources */,

--- a/MangaLauncher/Models/MangaLifetime.swift
+++ b/MangaLauncher/Models/MangaLifetime.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+struct MangaLifetime: Identifiable {
+    let entry: MangaEntry
+    let startDate: Date
+    let endDate: Date
+    let activityCount: Int
+    var id: UUID { entry.id }
+
+    var isActive: Bool {
+        entry.readingState != .archived && entry.publicationStatus != .finished
+    }
+}
+
+enum LifetimeBuilder {
+    static func build(
+        entries: [MangaEntry],
+        activities: [ReadingActivity],
+        comments: [MangaComment]
+    ) -> [MangaLifetime] {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+
+        var activityDatesByEntry: [UUID: [Date]] = [:]
+
+        for activity in activities {
+            activityDatesByEntry[activity.mangaEntryID, default: []].append(activity.date)
+        }
+        for comment in comments {
+            activityDatesByEntry[comment.mangaEntryID, default: []].append(comment.createdAt)
+        }
+        for entry in entries {
+            if let memoDate = entry.memoUpdatedAt, !entry.memo.isEmpty {
+                activityDatesByEntry[entry.id, default: []].append(memoDate)
+            }
+        }
+
+        let entriesByID = Dictionary(uniqueKeysWithValues: entries.map { ($0.id, $0) })
+
+        return activityDatesByEntry.compactMap { entryID, dates in
+            guard let entry = entriesByID[entryID],
+                  let earliest = dates.min(),
+                  let latest = dates.max() else { return nil }
+
+            let startDate = calendar.startOfDay(for: earliest)
+            let endDate: Date
+            if entry.readingState == .archived || entry.publicationStatus == .finished {
+                endDate = calendar.startOfDay(for: latest)
+            } else {
+                endDate = today
+            }
+
+            let minEndDate = calendar.date(byAdding: .day, value: 1, to: startDate) ?? startDate
+            return MangaLifetime(
+                entry: entry,
+                startDate: startDate,
+                endDate: max(minEndDate, endDate),
+                activityCount: dates.count
+            )
+        }
+        .sorted {
+            if $0.startDate != $1.startDate { return $0.startDate < $1.startDate }
+            return $0.entry.name < $1.entry.name
+        }
+    }
+}

--- a/MangaLauncher/Views/Heatmap/MangaLifetimeView.swift
+++ b/MangaLauncher/Views/Heatmap/MangaLifetimeView.swift
@@ -250,18 +250,22 @@ struct LifetimeDetailSheet: View {
     @Environment(\.openURL) private var openURL
     @AppStorage(UserDefaultsKeys.browserMode) private var browserMode: String = "external"
     @State private var safariURL: URL?
+    @State private var filter: TimelineFilter = .all
 
     private var theme: ThemeStyle { ThemeManager.shared.style }
 
     var body: some View {
         NavigationStack {
-            let items = buildItems()
+            let allItems = buildItems()
+            let items = filter.apply(to: allItems)
             ScrollView {
                 VStack(alignment: .leading, spacing: 0) {
                     periodHeader
+                    filterChips
                     if items.isEmpty {
                         ContentUnavailableView {
-                            Label("イベントなし", systemImage: "calendar.badge.clock")
+                            Label(allItems.isEmpty ? "イベントなし" : "該当するイベントがありません",
+                                  systemImage: allItems.isEmpty ? "calendar.badge.clock" : "line.3.horizontal.decrease.circle")
                                 .foregroundStyle(theme.onSurfaceVariant)
                         }
                         .padding(.top, 40)
@@ -320,6 +324,35 @@ struct LifetimeDetailSheet: View {
         .foregroundStyle(theme.onSurfaceVariant)
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.vertical, 8)
+    }
+
+    @ViewBuilder
+    private var filterChips: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(TimelineFilter.allCases) { option in
+                    let isSelected = filter == option
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.15)) { filter = option }
+                    } label: {
+                        HStack(spacing: 4) {
+                            Image(systemName: option.iconName)
+                                .font(.caption2)
+                            Text(option.displayName)
+                                .font(theme.captionFont.weight(.medium))
+                        }
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .background(
+                            Capsule().fill(isSelected ? Color.accentColor : theme.surfaceContainerHigh)
+                        )
+                        .foregroundStyle(isSelected ? Color.white : theme.onSurface)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+        .padding(.bottom, 8)
     }
 
     @ViewBuilder

--- a/MangaLauncher/Views/Heatmap/MangaLifetimeView.swift
+++ b/MangaLauncher/Views/Heatmap/MangaLifetimeView.swift
@@ -1,0 +1,474 @@
+import SwiftUI
+import PlatformKit
+
+struct MangaLifetimeView: View {
+    @Environment(\.openURL) private var openURL
+    let lifetimes: [MangaLifetime]
+    var viewModel: MangaViewModel
+    @State private var selectedLifetime: MangaLifetime?
+    @State private var chartAreaWidth: CGFloat = 0
+    @State private var safariURL: URL?
+    @AppStorage(UserDefaultsKeys.browserMode) private var browserMode: String = "external"
+
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+    private let thumbnailSize: CGFloat = 32
+    private let rowHeight: CGFloat = 36
+    private let barHeight: CGFloat = 14
+
+    var body: some View {
+        if lifetimes.isEmpty {
+            emptyState
+        } else {
+            VStack(alignment: .leading, spacing: 8) {
+                sectionHeader
+                axisRow
+                scrollableContent
+            }
+            .sheet(item: $selectedLifetime) { lifetime in
+                LifetimeDetailSheet(lifetime: lifetime, viewModel: viewModel)
+            }
+            #if canImport(UIKit)
+            .sheet(item: $safariURL) { url in
+                SafariView(url: url).ignoresSafeArea()
+            }
+            #endif
+        }
+    }
+
+    @ViewBuilder
+    private var sectionHeader: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "chart.bar.xaxis")
+                .foregroundStyle(theme.primary)
+            Text("マンガライフタイム")
+                .font(theme.subheadlineFont.weight(.semibold))
+                .foregroundStyle(theme.onSurface)
+        }
+    }
+
+    @ViewBuilder
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            sectionHeader
+            Text("アクティビティのある作品がありません")
+                .font(theme.captionFont)
+                .foregroundStyle(theme.onSurfaceVariant)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 20)
+        }
+    }
+
+    // MARK: - Time axis & bar rows (horizontally scrollable)
+
+    private var contentWidth: CGFloat {
+        let days = Int(totalDays)
+        let minWidth = chartAreaWidth
+        let pixelsPerDay: CGFloat = 8
+        return max(CGFloat(days) * pixelsPerDay, minWidth)
+    }
+
+    @ViewBuilder
+    private var axisRow: some View {
+        HStack(spacing: 8) {
+            Color.clear.frame(width: thumbnailSize)
+            GeometryReader { geo in
+                Color.clear.onAppear { chartAreaWidth = geo.size.width }
+                    .onChange(of: geo.size.width) { _, w in chartAreaWidth = w }
+            }
+        }
+        .frame(height: 0)
+    }
+
+    @ViewBuilder
+    private var scrollableContent: some View {
+        HStack(alignment: .top, spacing: 8) {
+            // Fixed left: thumbnails
+            VStack(spacing: 0) {
+                Color.clear.frame(height: 16)
+                ForEach(lifetimes) { lifetime in
+                    thumbnail(for: lifetime.entry)
+                        .frame(height: rowHeight)
+                        .contentShape(Rectangle())
+                        .onTapGesture { openMangaURL(lifetime.entry.url) }
+                }
+            }
+            .frame(width: thumbnailSize)
+
+            // Scrollable right: axis + bars
+            ScrollView(.horizontal, showsIndicators: false) {
+                VStack(alignment: .leading, spacing: 0) {
+                    ZStack(alignment: .leading) {
+                        let labels = axisLabels()
+                        ForEach(Array(labels.enumerated()), id: \.offset) { _, label in
+                            Text(label.text)
+                                .font(.system(size: 9))
+                                .foregroundStyle(theme.onSurfaceVariant)
+                                .position(x: label.fraction * contentWidth, y: 8)
+                        }
+                    }
+                    .frame(width: contentWidth, height: 16)
+
+                    ForEach(lifetimes) { lifetime in
+                        barContent(lifetime: lifetime)
+                            .frame(height: rowHeight)
+                            .contentShape(Rectangle())
+                            .onTapGesture { selectedLifetime = lifetime }
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func barContent(lifetime: MangaLifetime) -> some View {
+        let startFrac = dayFraction(for: lifetime.startDate)
+        let endFrac = dayFraction(for: lifetime.endDate)
+        let barWidth = max((endFrac - startFrac) * contentWidth, 6)
+
+        ZStack(alignment: .leading) {
+            Color.clear.frame(width: contentWidth)
+            RoundedRectangle(cornerRadius: 3)
+                .fill(Color.fromName(lifetime.entry.iconColor).opacity(lifetime.isActive ? 0.8 : 0.5))
+                .frame(width: barWidth, height: barHeight)
+                .offset(x: startFrac * contentWidth)
+        }
+        .frame(height: barHeight)
+    }
+
+    @ViewBuilder
+    private func thumbnail(for entry: MangaEntry) -> some View {
+        Group {
+            if let data = entry.imageData, let image = data.toSwiftUIImage() {
+                image.resizable().scaledToFill()
+            } else {
+                Color.fromName(entry.iconColor)
+                    .overlay {
+                        Text(entry.name.prefix(1))
+                            .font(.system(size: 10, weight: .bold))
+                            .foregroundStyle(.white)
+                    }
+            }
+        }
+        .frame(width: thumbnailSize, height: thumbnailSize)
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    private func openMangaURL(_ urlString: String) {
+        MangaURLOpener(browserMode: browserMode, openURL: openURL) { safariURL = $0 }.open(urlString)
+    }
+
+    // MARK: - Domain
+
+    private var domainStart: Date {
+        let earliest = lifetimes.map(\.startDate).min() ?? Date()
+        return Calendar.current.date(byAdding: .day, value: -1, to: earliest) ?? earliest
+    }
+
+    private var domainEnd: Date {
+        let latest = lifetimes.map(\.endDate).max() ?? Date()
+        return Calendar.current.date(byAdding: .day, value: 2, to: latest) ?? latest
+    }
+
+    private var totalDays: CGFloat {
+        CGFloat(max(Calendar.current.dateComponents([.day], from: domainStart, to: domainEnd).day ?? 1, 1))
+    }
+
+    private func dayFraction(for date: Date) -> CGFloat {
+        let days = Calendar.current.dateComponents([.day], from: domainStart, to: date).day ?? 0
+        return CGFloat(days) / totalDays
+    }
+
+    // MARK: - Axis labels
+
+    private func axisLabels() -> [(text: String, fraction: CGFloat)] {
+        let days = Int(totalDays)
+        let calendar = Calendar.current
+
+        if days > 365 {
+            return monthBoundaries().map {
+                (Self.yearMonthFormatter.string(from: $0), dayFraction(for: $0))
+            }
+        } else if days > 60 {
+            return monthBoundaries().map {
+                (Self.monthFormatter.string(from: $0), dayFraction(for: $0))
+            }
+        } else {
+            let stride = max(days / 4, 1)
+            var result: [(String, CGFloat)] = []
+            var i = stride
+            while i < days {
+                let date = calendar.date(byAdding: .day, value: i, to: domainStart) ?? domainStart
+                result.append((Self.dayFormatter.string(from: date), dayFraction(for: date)))
+                i += stride
+            }
+            return result
+        }
+    }
+
+    private func monthBoundaries() -> [Date] {
+        let calendar = Calendar.current
+        var result: [Date] = []
+        var comps = calendar.dateComponents([.year, .month], from: domainStart)
+        comps.month! += 1
+        while let date = calendar.date(from: comps), date < domainEnd {
+            result.append(date)
+            comps.month! += 1
+        }
+        return result
+    }
+
+    // MARK: - Formatters
+
+    private static let yearMonthFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "ja_JP")
+        f.dateFormat = "yy/M"
+        return f
+    }()
+
+    private static let monthFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "ja_JP")
+        f.dateFormat = "M月"
+        return f
+    }()
+
+    private static let dayFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "ja_JP")
+        f.dateFormat = "M/d"
+        return f
+    }()
+}
+
+// MARK: - Detail sheet
+
+struct LifetimeDetailSheet: View {
+    let lifetime: MangaLifetime
+    var viewModel: MangaViewModel
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.openURL) private var openURL
+    @AppStorage(UserDefaultsKeys.browserMode) private var browserMode: String = "external"
+    @State private var safariURL: URL?
+
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
+    var body: some View {
+        NavigationStack {
+            let items = buildItems()
+            ScrollView {
+                VStack(alignment: .leading, spacing: 0) {
+                    periodHeader
+                    if items.isEmpty {
+                        ContentUnavailableView {
+                            Label("イベントなし", systemImage: "calendar.badge.clock")
+                                .foregroundStyle(theme.onSurfaceVariant)
+                        }
+                        .padding(.top, 40)
+                    } else {
+                        LazyVStack(spacing: 0) {
+                            ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
+                                let showDate = index == 0 || !Calendar.current.isDate(item.timestamp, inSameDayAs: items[index - 1].timestamp)
+                                eventRow(item: item, index: index, total: items.count, showDate: showDate)
+                            }
+                        }
+                    }
+                }
+                .padding(.horizontal)
+            }
+            .themedNavigationStyle()
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .principal) {
+                    Button {
+                        openDetailURL(lifetime.entry.url)
+                    } label: {
+                        HStack(spacing: 8) {
+                            entryThumbnail
+                            Text(lifetime.entry.name)
+                                .font(theme.subheadlineFont.weight(.semibold))
+                                .foregroundStyle(theme.onSurface)
+                                .lineLimit(1)
+                        }
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("閉じる") { dismiss() }
+                }
+            }
+            #if canImport(UIKit)
+            .sheet(item: $safariURL) { url in
+                SafariView(url: url).ignoresSafeArea()
+            }
+            #endif
+        }
+        .presentationDetents([.medium, .large])
+    }
+
+    private func openDetailURL(_ urlString: String) {
+        MangaURLOpener(browserMode: browserMode, openURL: openURL) { safariURL = $0 }.open(urlString)
+    }
+
+    @ViewBuilder
+    private var periodHeader: some View {
+        HStack(spacing: 4) {
+            Text(Self.dateFormatter.string(from: lifetime.startDate))
+            Text("〜")
+            Text(lifetime.isActive ? "現在" : Self.dateFormatter.string(from: lifetime.endDate))
+        }
+        .font(theme.captionFont)
+        .foregroundStyle(theme.onSurfaceVariant)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 8)
+    }
+
+    @ViewBuilder
+    private func eventRow(item: TimelineItem, index: Int, total: Int, showDate: Bool) -> some View {
+        let isFirst = index == 0
+        let isLast = index == total - 1
+        let lineColor = theme.onSurfaceVariant.opacity(0.25)
+
+        HStack(alignment: .top, spacing: 0) {
+            // Left: date column
+            VStack {
+                if showDate {
+                    Text(Self.sectionDateFormatter.string(from: item.timestamp))
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(theme.onSurfaceVariant)
+                }
+            }
+            .frame(width: 56, alignment: .trailing)
+            .padding(.top, 2)
+
+            // Middle: connector
+            VStack(spacing: 0) {
+                Rectangle()
+                    .fill(isFirst ? Color.clear : lineColor)
+                    .frame(width: 2, height: 8)
+                Image(systemName: iconName(for: item))
+                    .font(.system(size: 8, weight: .bold))
+                    .foregroundStyle(.white)
+                    .frame(width: 18, height: 18)
+                    .background(iconColor(for: item), in: Circle())
+                Rectangle()
+                    .fill(isLast ? Color.clear : lineColor)
+                    .frame(width: 2)
+                    .frame(maxHeight: .infinity)
+            }
+            .frame(width: 18)
+            .padding(.horizontal, 8)
+
+            // Right: content card
+            VStack(alignment: .leading, spacing: 2) {
+                Text(eventText(for: item))
+                    .font(theme.captionFont)
+                    .foregroundStyle(theme.onSurface)
+                Text(Self.timeFormatter.string(from: item.timestamp))
+                    .font(theme.caption2Font)
+                    .foregroundStyle(theme.onSurfaceVariant)
+            }
+            .padding(10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(theme.surfaceContainerHigh)
+            )
+            .padding(.vertical, 3)
+        }
+    }
+
+    private func iconName(for item: TimelineItem) -> String {
+        switch item {
+        case .comment: "bubble.left.fill"
+        case .memo: "pencil"
+        case .read(let activity, _):
+            activity.episodeNumber != nil ? "book.fill" : "checkmark"
+        }
+    }
+
+    @ViewBuilder
+    private var entryThumbnail: some View {
+        Group {
+            if let data = lifetime.entry.imageData, let image = data.toSwiftUIImage() {
+                image.resizable().scaledToFill()
+            } else {
+                Color.fromName(lifetime.entry.iconColor)
+                    .overlay {
+                        Text(lifetime.entry.name.prefix(1))
+                            .font(.system(size: 10, weight: .bold))
+                            .foregroundStyle(.white)
+                    }
+            }
+        }
+        .frame(width: 28, height: 28)
+        .clipShape(RoundedRectangle(cornerRadius: 6))
+    }
+
+    private func iconColor(for item: TimelineItem) -> Color {
+        switch item {
+        case .comment: .blue
+        case .memo: .orange
+        case .read(let activity, _):
+            activity.episodeNumber != nil ? .purple : .green
+        }
+    }
+
+    private func eventText(for item: TimelineItem) -> String {
+        switch item {
+        case .comment(let comment, _):
+            comment.content
+        case .memo(let entry):
+            entry.memo.isEmpty ? "(空)" : entry.memo
+        case .read(let activity, _):
+            if let ep = activity.episodeNumber {
+                "既読 \(ep)話に更新"
+            } else {
+                "読みました"
+            }
+        }
+    }
+
+    private func buildItems() -> [TimelineItem] {
+        let entryID = lifetime.entry.id
+        let allActivities = viewModel.allActivities().filter { $0.mangaEntryID == entryID }
+        let allComments = viewModel.allComments().filter { $0.mangaEntryID == entryID }
+
+        var items: [TimelineItem] = []
+        for activity in allActivities {
+            items.append(.read(activity, lifetime.entry))
+        }
+        for comment in allComments {
+            items.append(.comment(comment, lifetime.entry))
+        }
+        if let _ = lifetime.entry.memoUpdatedAt, !lifetime.entry.memo.isEmpty {
+            items.append(.memo(lifetime.entry))
+        }
+        return items.sorted { $0.timestamp > $1.timestamp }
+    }
+
+    private static let dateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "ja_JP")
+        f.dateFormat = "yyyy/M/d"
+        return f
+    }()
+
+    private static let sectionDateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "ja_JP")
+        f.dateFormat = "M月d日(E)"
+        return f
+    }()
+
+    private static let timeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "HH:mm"
+        return f
+    }()
+}
+
+extension MangaLifetime: @retroactive Equatable {
+    static func == (lhs: MangaLifetime, rhs: MangaLifetime) -> Bool {
+        lhs.id == rhs.id
+    }
+}

--- a/MangaLauncher/Views/Heatmap/ReadingHeatmapView.swift
+++ b/MangaLauncher/Views/Heatmap/ReadingHeatmapView.swift
@@ -21,6 +21,7 @@ struct ReadingHeatmapView: View {
                 statsSection
                 heatmapSection
                 legendSection
+                lifetimeSection
             }
             .padding()
         }
@@ -176,6 +177,17 @@ struct ReadingHeatmapView: View {
                 .font(theme.caption2Font)
                 .foregroundStyle(theme.onSurfaceVariant)
         }
+    }
+
+    // MARK: - Lifetime
+
+    private var lifetimeSection: some View {
+        let lifetimes = LifetimeBuilder.build(
+            entries: viewModel.allEntries(),
+            activities: viewModel.allActivities(),
+            comments: viewModel.allComments()
+        )
+        return MangaLifetimeView(lifetimes: lifetimes, viewModel: viewModel)
     }
 
     // MARK: - Helpers

--- a/MangaLauncher/Views/Library/AllPublishersView.swift
+++ b/MangaLauncher/Views/Library/AllPublishersView.swift
@@ -73,6 +73,7 @@ struct PublisherEntriesView: View {
     @Binding var commentingEntry: MangaEntry?
     let onOpenURL: (String) -> Void
 
+    @State private var lifetimeEntry: MangaEntry?
     private var theme: ThemeStyle { ThemeManager.shared.style }
 
     private var entries: [MangaEntry] {
@@ -105,7 +106,15 @@ struct PublisherEntriesView: View {
                     .buttonStyle(.plain)
                     .listRowBackground(Color.clear)
                     .contextMenu {
-                        MangaContextMenu(entry: entry, viewModel: viewModel, editingEntry: $editingEntry, commentingEntry: $commentingEntry)
+                        MangaContextMenu(entry: entry, viewModel: viewModel, editingEntry: $editingEntry, commentingEntry: $commentingEntry, onShowLifetime: { lifetimeEntry = entry })
+                    }
+                    .sheet(item: $lifetimeEntry) { entry in
+                        let lifetime = LifetimeBuilder.build(
+                            entries: [entry],
+                            activities: viewModel.allActivities(),
+                            comments: viewModel.allComments()
+                        ).first ?? MangaLifetime(entry: entry, startDate: Date(), endDate: Date(), activityCount: 0)
+                        LifetimeDetailSheet(lifetime: lifetime, viewModel: viewModel)
                     }
                 }
             }

--- a/MangaLauncher/Views/Library/LibraryCard.swift
+++ b/MangaLauncher/Views/Library/LibraryCard.swift
@@ -8,6 +8,7 @@ struct LibraryCard: View {
     @Binding var commentingEntry: MangaEntry?
     let onOpenURL: (String) -> Void
 
+    @State private var lifetimeEntry: MangaEntry?
     private var theme: ThemeStyle { ThemeManager.shared.style }
     private let cardWidth: CGFloat = 130
 
@@ -62,7 +63,15 @@ struct LibraryCard: View {
         }
         .buttonStyle(.plain)
         .contextMenu {
-            MangaContextMenu(entry: entry, viewModel: viewModel, editingEntry: $editingEntry, commentingEntry: $commentingEntry)
+            MangaContextMenu(entry: entry, viewModel: viewModel, editingEntry: $editingEntry, commentingEntry: $commentingEntry, onShowLifetime: { lifetimeEntry = entry })
+        }
+        .sheet(item: $lifetimeEntry) { entry in
+            let lifetime = LifetimeBuilder.build(
+                entries: [entry],
+                activities: viewModel.allActivities(),
+                comments: viewModel.allComments()
+            ).first ?? MangaLifetime(entry: entry, startDate: Date(), endDate: Date(), activityCount: 0)
+            LifetimeDetailSheet(lifetime: lifetime, viewModel: viewModel)
         }
     }
 

--- a/MangaLauncher/Views/Library/Timeline/TimelineView.swift
+++ b/MangaLauncher/Views/Library/Timeline/TimelineView.swift
@@ -15,6 +15,7 @@ struct TimelineView: View {
     @State private var showingMonthPicker = false
     @State private var chartGranularity: TimelineChartGranularity = .week
     @AppStorage(UserDefaultsKeys.browserMode) private var browserMode: String = "external"
+    @State private var lifetimeEntry: MangaEntry?
 
     @State private var pageAnchor: Date = Calendar.current.startOfDay(for: Date())
 
@@ -59,7 +60,8 @@ struct TimelineView: View {
                         allEntries: allEntries,
                         allComments: allComments,
                         allActivities: allActivities,
-                        onTap: { handleTap(on: $0) }
+                        onTap: { handleTap(on: $0) },
+                        onShowLifetime: { lifetimeEntry = $0 }
                     )
                     .tag(date)
                 }
@@ -125,6 +127,14 @@ struct TimelineView: View {
                 .ignoresSafeArea()
         }
         #endif
+        .sheet(item: $lifetimeEntry) { entry in
+            let lifetime = LifetimeBuilder.build(
+                entries: [entry],
+                activities: viewModel.allActivities(),
+                comments: viewModel.allComments()
+            ).first ?? MangaLifetime(entry: entry, startDate: Date(), endDate: Date(), activityCount: 0)
+            LifetimeDetailSheet(lifetime: lifetime, viewModel: viewModel)
+        }
         .onMangaDataChange {
             viewModel.refresh()
         }
@@ -269,6 +279,7 @@ private struct TimelineDatePage: View {
     let allComments: [MangaComment]
     let allActivities: [ReadingActivity]
     let onTap: (TimelineItem) -> Void
+    var onShowLifetime: ((MangaEntry) -> Void)?
 
     private var theme: ThemeStyle { ThemeManager.shared.style }
 
@@ -294,6 +305,15 @@ private struct TimelineDatePage: View {
                             isLast: index == items.count - 1,
                             onTap: { onTap(item) }
                         )
+                        .contextMenu {
+                            if let entry = item.entry {
+                                Button {
+                                    onShowLifetime?(entry)
+                                } label: {
+                                    Label("ライフタイムを見る", systemImage: "chart.bar.xaxis")
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/MangaLauncher/Views/MangaCell/MangaContextMenu.swift
+++ b/MangaLauncher/Views/MangaCell/MangaContextMenu.swift
@@ -5,6 +5,7 @@ struct MangaContextMenu: View {
     var viewModel: MangaViewModel
     @Binding var editingEntry: MangaEntry?
     @Binding var commentingEntry: MangaEntry?
+    var onShowLifetime: (() -> Void)? = nil
     var onReorder: (() -> Void)? = nil
 
     var body: some View {
@@ -53,6 +54,14 @@ struct MangaContextMenu: View {
             commentingEntry = entry
         } label: {
             Label("コメント", systemImage: "bubble.left.and.bubble.right")
+        }
+
+        if let onShowLifetime {
+            Button {
+                onShowLifetime()
+            } label: {
+                Label("ライフタイムを見る", systemImage: "chart.bar.xaxis")
+            }
         }
 
         if let onReorder {

--- a/MangaLauncher/Views/MangaCell/MangaGridCell.swift
+++ b/MangaLauncher/Views/MangaCell/MangaGridCell.swift
@@ -11,6 +11,7 @@ struct MangaGridCell: View {
     @Binding var commentingEntry: MangaEntry?
     let onOpenURL: (String) -> Void
 
+    @State private var lifetimeEntry: MangaEntry?
     @AppStorage(UserDefaultsKeys.showsNextUpdateBadge) private var showsNextUpdateBadge: Bool = true
 
     private var theme: ThemeStyle { ThemeManager.shared.style }
@@ -115,11 +116,19 @@ struct MangaGridCell: View {
                 }
             }
             .contextMenu {
-                MangaContextMenu(entry: entry, viewModel: viewModel, editingEntry: $editingEntry, commentingEntry: $commentingEntry) {
+                MangaContextMenu(entry: entry, viewModel: viewModel, editingEntry: $editingEntry, commentingEntry: $commentingEntry, onShowLifetime: { lifetimeEntry = entry }) {
                     withAnimation(.easeInOut(duration: 0.2)) {
                         isGridEditMode = true
                     }
                 }
+            }
+            .sheet(item: $lifetimeEntry) { entry in
+                let lifetime = LifetimeBuilder.build(
+                    entries: [entry],
+                    activities: viewModel.allActivities(),
+                    comments: viewModel.allComments()
+                ).first ?? MangaLifetime(entry: entry, startDate: Date(), endDate: Date(), activityCount: 0)
+                LifetimeDetailSheet(lifetime: lifetime, viewModel: viewModel)
             }
         }
     }

--- a/MangaLauncher/Views/MangaCell/MangaListView.swift
+++ b/MangaLauncher/Views/MangaCell/MangaListView.swift
@@ -28,12 +28,27 @@ struct MangaListView: View {
                     viewModel.queueDelete(entry)
                 }
             }
-            .onMove { source, destination in
-                viewModel.moveEntries(for: day, from: source, to: destination)
+            .if(listEditMode == .active) { view in
+                view.onMove { source, destination in
+                    viewModel.moveEntries(for: day, from: source, to: destination)
+                }
             }
             .listRowSeparator(.hidden)
             .if(theme.usesCustomSurface) { view in
                 view.listRowInsets(EdgeInsets(top: 2, leading: 12, bottom: 2, trailing: 12))
+            }
+
+            Section {
+                Color.clear
+                    .frame(height: 200)
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
+                    .contentShape(Rectangle())
+                    .onLongPressGesture(minimumDuration: 0.5) {
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            listEditMode = .active
+                        }
+                    }
             }
         }
         .listStyle(.plain)
@@ -42,14 +57,6 @@ struct MangaListView: View {
         .if(theme.usesCustomSurface && !hasWallpaper) { view in
             view.background(theme.surface)
         }
-        .simultaneousGesture(
-            LongPressGesture(minimumDuration: 0.5)
-                .onEnded { _ in
-                    withAnimation(.easeInOut(duration: 0.2)) {
-                        listEditMode = .active
-                    }
-                }
-        )
         #if os(iOS) || os(visionOS)
         .environment(\.editMode, $listEditMode)
         #endif

--- a/MangaLauncher/Views/MangaCell/MangaRowCell.swift
+++ b/MangaLauncher/Views/MangaCell/MangaRowCell.swift
@@ -13,6 +13,7 @@ struct MangaRowCell: View {
     #endif
     let onOpenURL: (String) -> Void
 
+    @State private var lifetimeEntry: MangaEntry?
     @AppStorage(UserDefaultsKeys.showsNextUpdateBadge) private var showsNextUpdateBadge: Bool = true
 
     private var theme: ThemeStyle { ThemeManager.shared.style }
@@ -163,13 +164,21 @@ struct MangaRowCell: View {
                 }
             )
             .contextMenu {
-                MangaContextMenu(entry: entry, viewModel: viewModel, editingEntry: $editingEntry, commentingEntry: $commentingEntry) {
+                MangaContextMenu(entry: entry, viewModel: viewModel, editingEntry: $editingEntry, commentingEntry: $commentingEntry, onShowLifetime: { lifetimeEntry = entry }) {
                     #if os(iOS) || os(visionOS)
                     withAnimation(.easeInOut(duration: 0.2)) {
                         listEditMode = .active
                     }
                     #endif
                 }
+            }
+            .sheet(item: $lifetimeEntry) { entry in
+                let lifetime = LifetimeBuilder.build(
+                    entries: [entry],
+                    activities: viewModel.allActivities(),
+                    comments: viewModel.allComments()
+                ).first ?? MangaLifetime(entry: entry, startDate: Date(), endDate: Date(), activityCount: 0)
+                LifetimeDetailSheet(lifetime: lifetime, viewModel: viewModel)
             }
         }
     }

--- a/MangaLauncher/Views/Search/SearchResultRow.swift
+++ b/MangaLauncher/Views/Search/SearchResultRow.swift
@@ -8,6 +8,7 @@ struct SearchResultRow: View {
     @Binding var commentingEntry: MangaEntry?
     let onOpenURL: (String) -> Void
 
+    @State private var lifetimeEntry: MangaEntry?
     private var theme: ThemeStyle { ThemeManager.shared.style }
 
     var body: some View {
@@ -55,7 +56,15 @@ struct SearchResultRow: View {
         .listRowBackground(Color.clear)
         .listRowSeparator(.hidden)
         .contextMenu {
-            MangaContextMenu(entry: entry, viewModel: viewModel, editingEntry: $editingEntry, commentingEntry: $commentingEntry)
+            MangaContextMenu(entry: entry, viewModel: viewModel, editingEntry: $editingEntry, commentingEntry: $commentingEntry, onShowLifetime: { lifetimeEntry = entry })
+        }
+        .sheet(item: $lifetimeEntry) { entry in
+            let lifetime = LifetimeBuilder.build(
+                entries: [entry],
+                activities: viewModel.allActivities(),
+                comments: viewModel.allComments()
+            ).first ?? MangaLifetime(entry: entry, startDate: Date(), endDate: Date(), activityCount: 0)
+            LifetimeDetailSheet(lifetime: lifetime, viewModel: viewModel)
         }
     }
 


### PR DESCRIPTION
## Summary

読書アクティビティ画面にマンガライフタイムチャートを追加。各作品の読書期間をガントチャート風に可視化し、タップで詳細タイムラインを表示。

## 機能

### ライフタイムチャート
- 読書アクティビティ画面の凡例下に配置
- 左固定列にサムネイル、右に横スクロール可能なバーチャート
- 時間軸ラベル: 期間に応じて M/d / M月 / yy/M を自動切替
- アクティブな作品は今日まで伸びる、読了/完結は最終アクティビティ日で終了
- 1日のみのデータでも最低1日幅のバーを表示
- サムネタップでマンガサイトを開く、バータップでタイムライン詳細

### タイムライン詳細シート
- 左列に日付、中央に連続する縦線+アイコン、右にカード形式のイベント
- イベント種別: 既読(緑) / 話数更新(紫) / コメント(青) / メモ(橙)
- ナビゲーションバーにサムネ+作品名（タップでサイト遷移）

### コンテキストメニュー「ライフタイムを見る」
- MangaContextMenu に追加 → ホーム・ライブラリ・検索の全セルで利用可能
- タイムラインのセルからも利用可能

### リスト長押し修正
- `.onMove` を編集モード時のみ有効にし、セル長押しで編集モードに入る問題を解消
- セルのない空白エリアの長押しは引き続き編集モードに入る

## Test plan

- [x] ライフタイムチャートが読書アクティビティ画面に表示
- [x] バータップでタイムライン詳細が表示
- [x] サムネタップでマンガサイトに遷移
- [x] コンテキストメニューから「ライフタイムを見る」で詳細表示
- [x] セル長押しで編集モードに入らないこと
- [x] 空白エリア長押しで編集モードに入ること
- [x] テーマ切替で表示が破綻しないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)