### PR TITLE
Update lastReadDate on episode increment

### DIFF
--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -140,6 +140,7 @@ final class MangaViewModel {
     func incrementEpisode(_ entry: MangaEntry) {
         let newEpisode = (entry.currentEpisode ?? 0) + 1
         entry.currentEpisode = newEpisode
+        entry.lastReadDate = Date()
         let activity = ReadingActivity(
             date: Date(),
             mangaName: entry.name,


### PR DESCRIPTION
## Summary

- 話数更新時に `lastReadDate` を更新し、ライブラリの「最近読んだ」セクションに反映されるように修正
- 積読マンガの場合、話数更新日は「今日読んだ」状態にもなる（実際に読んでいるので自然な動作）

## Test plan

- [ ] 話数を更新した作品が「最近読んだ」セクションに表示されること
- [ ] 積読マンガの話数更新後、その日は「今日読んだ」状態になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)