### PR TITLE
Add secret mode with biometric authentication

### DIFF
--- a/MangaLauncher.xcodeproj/project.pbxproj
+++ b/MangaLauncher.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		AB50040000112233AA000003 /* HiddenEntriesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB50040000112233AA000004 /* HiddenEntriesView.swift */; };
+		AB50040000112233AA000001 /* BiometricAuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB50040000112233AA000002 /* BiometricAuthService.swift */; };
 		AB50050000112233AA000001 /* SpecialEpisodeAlertModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB50050000112233AA000002 /* SpecialEpisodeAlertModifier.swift */; };
 		AB50030000112233AA000003 /* MangaLifetimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB50030000112233AA000004 /* MangaLifetimeView.swift */; };
 		AB50030000112233AA000001 /* MangaLifetime.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB50030000112233AA000002 /* MangaLifetime.swift */; };
@@ -174,6 +176,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		AB50040000112233AA000004 /* HiddenEntriesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiddenEntriesView.swift; sourceTree = "<group>"; };
+		AB50040000112233AA000002 /* BiometricAuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricAuthService.swift; sourceTree = "<group>"; };
 		AB50050000112233AA000002 /* SpecialEpisodeAlertModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecialEpisodeAlertModifier.swift; sourceTree = "<group>"; };
 		AB50030000112233AA000004 /* MangaLifetimeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaLifetimeView.swift; sourceTree = "<group>"; };
 		AB50030000112233AA000002 /* MangaLifetime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaLifetime.swift; sourceTree = "<group>"; };
@@ -462,6 +466,7 @@
 			isa = PBXGroup;
 			children = (
 				BB000104 /* LibraryView.swift */,
+				AB50040000112233AA000004 /* HiddenEntriesView.swift */,
 				BB000105 /* LibraryCard.swift */,
 				BC000610 /* ActivityRowView.swift */,
 				BC000620 /* AllActivityView.swift */,
@@ -630,6 +635,7 @@
 				BC000810 /* MangaDataChangeModifier.swift */,
 				AB5001FF00112233AA000002 /* NextUpdateFormatter.swift */,
 				AB50020000112233AA000001 /* MangaEntryAccessibility.swift */,
+				AB50040000112233AA000002 /* BiometricAuthService.swift */,
 				AB50050000112233AA000002 /* SpecialEpisodeAlertModifier.swift */,
 				AB5001FF00112233AA000004 /* NextUpdateBadgeView.swift */,
 			);
@@ -817,6 +823,8 @@
 				ECFEA85C2F7F7C5200CE4DC0 /* PublisherFilterView.swift in Sources */,
 				ECCD2FCE2F65596900BF3309 /* PublisherPickerView.swift in Sources */,
 				A1000002 /* MangaEntry.swift in Sources */,
+				AB50040000112233AA000001 /* BiometricAuthService.swift in Sources */,
+				AB50040000112233AA000003 /* HiddenEntriesView.swift in Sources */,
 				AB50050000112233AA000001 /* SpecialEpisodeAlertModifier.swift in Sources */,
 				AB50030000112233AA000001 /* MangaLifetime.swift in Sources */,
 				AB50030000112233AA000003 /* MangaLifetimeView.swift in Sources */,

--- a/MangaLauncher/Info.plist
+++ b/MangaLauncher/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSFaceIDUsageDescription</key>
+	<string>非表示のマンガを閲覧するために認証が必要です</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>remote-notification</string>

--- a/MangaLauncher/Models/BackupData.swift
+++ b/MangaLauncher/Models/BackupData.swift
@@ -48,12 +48,14 @@ struct BackupData: Codable {
         let currentEpisode: Int?
         // v10+
         let episodeLabel: String?
+        // v11+
+        let isHidden: Bool?
         // Legacy fields (kept for backward-compat with v5 backups)
         let isOnHiatus: Bool?
         let isCompleted: Bool?
         let isBacklog: Bool?
 
-        init(id: UUID, name: String, url: String, dayOfWeekRawValue: Int, sortOrder: Int, iconColor: String, publisher: String, imageData: Data?, lastReadDate: Date? = nil, updateIntervalWeeks: Int = 1, nextExpectedUpdate: Date? = nil, isOneShot: Bool = false, publicationStatusRawValue: Int = 0, readingStateRawValue: Int = 0, memo: String = "", memoUpdatedAt: Date? = nil, currentEpisode: Int? = nil, episodeLabel: String? = nil) {
+        init(id: UUID, name: String, url: String, dayOfWeekRawValue: Int, sortOrder: Int, iconColor: String, publisher: String, imageData: Data?, lastReadDate: Date? = nil, updateIntervalWeeks: Int = 1, nextExpectedUpdate: Date? = nil, isOneShot: Bool = false, publicationStatusRawValue: Int = 0, readingStateRawValue: Int = 0, memo: String = "", memoUpdatedAt: Date? = nil, currentEpisode: Int? = nil, episodeLabel: String? = nil, isHidden: Bool = false) {
             self.id = id
             self.name = name
             self.url = url
@@ -72,6 +74,7 @@ struct BackupData: Codable {
             self.memoUpdatedAt = memoUpdatedAt
             self.currentEpisode = currentEpisode
             self.episodeLabel = episodeLabel
+            self.isHidden = isHidden
             self.isOnHiatus = nil
             self.isCompleted = nil
             self.isBacklog = nil
@@ -97,6 +100,7 @@ struct BackupData: Codable {
             memoUpdatedAt = try container.decodeIfPresent(Date.self, forKey: .memoUpdatedAt)
             currentEpisode = try container.decodeIfPresent(Int.self, forKey: .currentEpisode)
             episodeLabel = try container.decodeIfPresent(String.self, forKey: .episodeLabel)
+            isHidden = try container.decodeIfPresent(Bool.self, forKey: .isHidden)
             isOnHiatus = try container.decodeIfPresent(Bool.self, forKey: .isOnHiatus)
             isCompleted = try container.decodeIfPresent(Bool.self, forKey: .isCompleted)
             isBacklog = try container.decodeIfPresent(Bool.self, forKey: .isBacklog)
@@ -105,7 +109,7 @@ struct BackupData: Codable {
 
     static func from(_ entries: [MangaEntry], activities: [ReadingActivity] = [], comments: [MangaComment] = []) -> BackupData {
         BackupData(
-            version: 10,
+            version: 11,
             exportDate: Date(),
             entries: entries.map {
                 BackupEntry(
@@ -126,7 +130,8 @@ struct BackupData: Codable {
                     memo: $0.memo,
                     memoUpdatedAt: $0.memoUpdatedAt,
                     currentEpisode: $0.currentEpisode,
-                    episodeLabel: $0.episodeLabel
+                    episodeLabel: $0.episodeLabel,
+                    isHidden: $0.isHidden
                 )
             },
             activities: activities.map {

--- a/MangaLauncher/Models/MangaEntry.swift
+++ b/MangaLauncher/Models/MangaEntry.swift
@@ -115,6 +115,8 @@ final class MangaEntry {
     var currentEpisode: Int?
     /// 表示用ラベル（「おまけ」「1.5話」等）。nil なら currentEpisode から自動生成。
     var episodeLabel: String?
+    /// 非表示フラグ（シークレットモード）
+    var isHidden: Bool = false
 
     /// 掲載状況の Int 値（PublicationStatus.rawValue）
     var publicationStatusRawValue: Int = 0

--- a/MangaLauncher/Shared/BiometricAuthService.swift
+++ b/MangaLauncher/Shared/BiometricAuthService.swift
@@ -1,0 +1,16 @@
+import LocalAuthentication
+
+enum BiometricAuthService {
+    static func authenticate(reason: String) async -> Bool {
+        let context = LAContext()
+        var error: NSError?
+        let policy: LAPolicy = context.canEvaluatePolicy(
+            .deviceOwnerAuthenticationWithBiometrics, error: &error
+        ) ? .deviceOwnerAuthenticationWithBiometrics : .deviceOwnerAuthentication
+        do {
+            return try await context.evaluatePolicy(policy, localizedReason: reason)
+        } catch {
+            return false
+        }
+    }
+}

--- a/MangaLauncher/Shared/UserDefaultsKeys.swift
+++ b/MangaLauncher/Shared/UserDefaultsKeys.swift
@@ -15,6 +15,7 @@ enum UserDefaultsKeys {
     static let displayMode = "displayMode"
     static let browserMode = "browserMode"
     static let showsNextUpdateBadge = "showsNextUpdateBadge"
+    static let showHiddenSection = "showHiddenSection"
 
     // MARK: - Pending intent signals (App Group 経由)
     static let pendingIntentData = "pendingIntentData"

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -11,6 +11,7 @@ import WidgetKit
 final class MangaViewModel {
     var selectedDay: DayOfWeek = .today
     private(set) var refreshCounter = 0
+    private var hiddenIDs: Set<UUID> = []
     var pendingDeleteEntries: [MangaEntry] = []
     private var deleteTimer: Timer?
     var pendingDeleteComments: [MangaComment] = []
@@ -32,6 +33,7 @@ final class MangaViewModel {
 
     init(modelContext: ModelContext) {
         self.modelContext = modelContext
+        reloadHiddenIDs()
         // 起動時の重い処理 (migration / backfill) は init では実行しない。
         // CloudKit 同期前のローカル DB を書き換えると、cloud で持っている値を
         // デフォルトで上書きしてしまうリスクがある (Vision Pro 初回起動などで観測)。
@@ -105,7 +107,6 @@ final class MangaViewModel {
     func fetchEntries(for day: DayOfWeek) -> [MangaEntry] {
         let _ = refreshCounter
         let dayRawValue = day.rawValue
-        // #Predicate は enum case を直接受け付けないので、ローカル let でキャプチャして意味を明示する
         let followingRaw = ReadingState.following.rawValue
         let activeRaw = PublicationStatus.active.rawValue
         let descriptor = FetchDescriptor<MangaEntry>(
@@ -118,8 +119,10 @@ final class MangaViewModel {
         )
         let results = modelContext.fetchLogged(descriptor)
         let pendingIDs = Set(pendingDeleteEntries.map(\.id))
+        let currentHiddenIDs = hiddenIDs
         var seenIDs = Set<UUID>()
         return results.filter { entry in
+            guard !currentHiddenIDs.contains(entry.id) else { return false }
             guard !pendingIDs.contains(entry.id) else { return false }
             return seenIDs.insert(entry.id).inserted
         }
@@ -135,6 +138,38 @@ final class MangaViewModel {
     func setReadingState(_ entry: MangaEntry, to state: ReadingState) {
         entry.readingState = state
         save()
+    }
+
+    /// 非表示フラグの切り替え（refresh() は呼ばない）
+    func setHidden(_ entry: MangaEntry, isHidden: Bool) {
+        entry.isHidden = isHidden
+        // entry が属するコンテキストで保存する（refresh() で modelContext が
+        // 差し替わっている場合、self.modelContext と異なる可能性がある）
+        if let ctx = entry.modelContext {
+            try? ctx.save()
+        } else {
+            try? modelContext.save()
+        }
+        refreshCounter += 1
+        #if canImport(WidgetKit)
+        WidgetCenter.shared.reloadAllTimelines()
+        #endif
+    }
+
+    func reloadHiddenIDs() {
+        let descriptor = FetchDescriptor<MangaEntry>(
+            predicate: #Predicate { $0.isHidden == true }
+        )
+        let entries = (try? modelContext.fetch(descriptor)) ?? []
+        hiddenIDs = Set(entries.map(\.id))
+    }
+
+    func hiddenEntries() -> [MangaEntry] {
+        let descriptor = FetchDescriptor<MangaEntry>(
+            predicate: #Predicate { $0.isHidden == true },
+            sortBy: [SortDescriptor(\.name)]
+        )
+        return modelContext.fetchLogged(descriptor)
     }
 
     func recordSpecialEpisode(_ entry: MangaEntry, label: String) {
@@ -250,8 +285,10 @@ final class MangaViewModel {
             sortBy: [SortDescriptor(\.lastReadDate, order: .reverse), SortDescriptor(\.name)]
         )
         let pendingIDs = Set(pendingDeleteEntries.map(\.id))
+        let currentHiddenIDs = hiddenIDs
         var seenIDs = Set<UUID>()
         let result = modelContext.fetchLogged(descriptor).filter { entry in
+            guard !currentHiddenIDs.contains(entry.id) else { return false }
             guard !pendingIDs.contains(entry.id) else { return false }
             return seenIDs.insert(entry.id).inserted
         }
@@ -262,7 +299,8 @@ final class MangaViewModel {
     func allPublishers() -> [String] {
         let descriptor = FetchDescriptor<MangaEntry>()
         let entries = modelContext.fetchLogged(descriptor)
-        let publishers = Set(entries.map(\.publisher)).filter { !$0.isEmpty }
+        let currentHiddenIDs = hiddenIDs
+        let publishers = Set(entries.filter { !currentHiddenIDs.contains($0.id) }.map(\.publisher)).filter { !$0.isEmpty }
         return publishers.sorted()
     }
 
@@ -363,8 +401,10 @@ final class MangaViewModel {
         let descriptor = FetchDescriptor<MangaEntry>()
         let results = modelContext.fetchLogged(descriptor)
         let pendingIDs = Set(pendingDeleteEntries.map(\.id))
+        let currentHiddenIDs = hiddenIDs
         var seenIDs = Set<UUID>()
         return results.filter { entry in
+            guard !currentHiddenIDs.contains(entry.id) else { return false }
             guard !pendingIDs.contains(entry.id) else { return false }
             return seenIDs.insert(entry.id).inserted
         }.count
@@ -412,6 +452,7 @@ final class MangaViewModel {
             entry.memoUpdatedAt = backupEntry.memoUpdatedAt
             entry.currentEpisode = backupEntry.currentEpisode
             entry.episodeLabel = backupEntry.episodeLabel
+            entry.isHidden = backupEntry.isHidden ?? false
             // v6+ バックアップは publicationStatusRawValue / readingStateRawValue を authoritative とする。
             // 両方 nil のときだけ v5 以前の legacy Bool から導出する。
             // 通常 export 側は両方を必ず書くので片方 nil は現実にはほぼ起こらないが、
@@ -666,6 +707,7 @@ final class MangaViewModel {
 
     func refresh() {
         modelContext = ModelContext(modelContext.container)
+        reloadHiddenIDs()
         refreshCounter += 1
     }
 

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -151,15 +151,21 @@ final class MangaViewModel {
         }
         // entry が属するコンテキストで保存する（refresh() で modelContext が
         // 差し替わっている場合、self.modelContext と異なる可能性がある）
-        if let ctx = entry.modelContext {
-            try? ctx.save()
-        } else {
-            try? modelContext.save()
+        do {
+            if let ctx = entry.modelContext {
+                try ctx.save()
+            } else {
+                try modelContext.save()
+            }
+        } catch {
+            print("[MangaViewModel] setHidden save failed: \(error)")
         }
         refreshCounter += 1
         #if canImport(WidgetKit)
         WidgetCenter.shared.reloadAllTimelines()
         #endif
+        BadgeManager.updateBadge(unreadCount: unreadCount(for: .today))
+        rescheduleNotifications()
     }
 
     func reloadHiddenIDs() {
@@ -508,7 +514,10 @@ final class MangaViewModel {
                 importedCount += 1
             }
         }
-        if importedCount > 0 { save() }
+        if importedCount > 0 {
+            save()
+            reloadHiddenIDs()
+        }
         return importedCount
     }
 

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -11,7 +11,7 @@ import WidgetKit
 final class MangaViewModel {
     var selectedDay: DayOfWeek = .today
     private(set) var refreshCounter = 0
-    private var hiddenIDs: Set<UUID> = []
+    private(set) var hiddenIDs: Set<UUID> = []
     var pendingDeleteEntries: [MangaEntry] = []
     private var deleteTimer: Timer?
     var pendingDeleteComments: [MangaComment] = []
@@ -143,6 +143,11 @@ final class MangaViewModel {
     /// 非表示フラグの切り替え（refresh() は呼ばない）
     func setHidden(_ entry: MangaEntry, isHidden: Bool) {
         entry.isHidden = isHidden
+        if isHidden {
+            hiddenIDs.insert(entry.id)
+        } else {
+            hiddenIDs.remove(entry.id)
+        }
         // entry が属するコンテキストで保存する（refresh() で modelContext が
         // 差し替わっている場合、self.modelContext と異なる可能性がある）
         if let ctx = entry.modelContext {

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -107,6 +107,7 @@ final class MangaViewModel {
     func fetchEntries(for day: DayOfWeek) -> [MangaEntry] {
         let _ = refreshCounter
         let dayRawValue = day.rawValue
+        // #Predicate は enum case を直接受け付けないので、ローカル let でキャプチャして意味を明示する
         let followingRaw = ReadingState.following.rawValue
         let activeRaw = PublicationStatus.active.rawValue
         let descriptor = FetchDescriptor<MangaEntry>(

--- a/MangaLauncher/Views/Library/HiddenEntriesView.swift
+++ b/MangaLauncher/Views/Library/HiddenEntriesView.swift
@@ -1,0 +1,150 @@
+import SwiftUI
+import PlatformKit
+
+struct HiddenEntriesView: View {
+    var viewModel: MangaViewModel
+    @State private var isAuthenticated = false
+    @State private var entries: [MangaEntry] = []
+    @State private var editingEntry: MangaEntry?
+    @State private var commentingEntry: MangaEntry?
+    @State private var lifetimeEntry: MangaEntry?
+
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
+    var body: some View {
+        Group {
+            if isAuthenticated {
+                authenticatedContent
+            } else {
+                lockedView
+            }
+        }
+        .themedNavigationStyle()
+        .navigationTitle("非表示")
+        #if os(iOS) || os(visionOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .onAppear { authenticate() }
+        .sheet(item: $editingEntry) { entry in
+            EditEntryView(viewModel: viewModel, entry: entry)
+        }
+        .sheet(item: $commentingEntry) { entry in
+            CommentListView(entry: entry, viewModel: viewModel)
+        }
+        .sheet(item: $lifetimeEntry) { entry in
+            let lifetime = LifetimeBuilder.build(
+                entries: [entry],
+                activities: viewModel.allActivities(),
+                comments: viewModel.allComments()
+            ).first ?? MangaLifetime(entry: entry, startDate: Date(), endDate: Date(), activityCount: 0)
+            LifetimeDetailSheet(lifetime: lifetime, viewModel: viewModel)
+        }
+    }
+
+    @ViewBuilder
+    private var lockedView: some View {
+        ContentUnavailableView {
+            Label("認証が必要です", systemImage: "lock.fill")
+                .foregroundStyle(theme.onSurfaceVariant)
+        } description: {
+            Text("非表示のマンガを閲覧するには認証が必要です")
+                .foregroundStyle(theme.onSurfaceVariant.opacity(0.7))
+        } actions: {
+            Button("認証する") { authenticate() }
+        }
+    }
+
+    @ViewBuilder
+    private var authenticatedContent: some View {
+        if entries.isEmpty {
+            ContentUnavailableView {
+                Label("非表示のマンガはありません", systemImage: "eye.slash")
+                    .foregroundStyle(theme.onSurfaceVariant)
+            } description: {
+                Text("マンガを長押し →「非表示にする」で追加できます")
+                    .foregroundStyle(theme.onSurfaceVariant.opacity(0.7))
+            }
+        } else {
+            List {
+                ForEach(entries, id: \.id) { entry in
+                    HStack(spacing: 12) {
+                        if let data = entry.imageData, let image = data.toSwiftUIImage() {
+                            image
+                                .resizable()
+                                .scaledToFill()
+                                .frame(width: 44, height: 44)
+                                .clipShape(RoundedRectangle(cornerRadius: 8))
+                        } else {
+                            RoundedRectangle(cornerRadius: 8)
+                                .fill(Color.fromName(entry.iconColor))
+                                .frame(width: 44, height: 44)
+                                .overlay {
+                                    Text(entry.name.prefix(1))
+                                        .font(.headline.bold())
+                                        .foregroundStyle(.white)
+                                }
+                        }
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(entry.name)
+                                .font(theme.bodyFont)
+                                .foregroundStyle(theme.onSurface)
+                            if !entry.publisher.isEmpty {
+                                Text(entry.publisher)
+                                    .font(theme.captionFont)
+                                    .foregroundStyle(theme.onSurfaceVariant)
+                            }
+                        }
+                        Spacer()
+                    }
+                    .swipeActions(edge: .trailing) {
+                        Button {
+                            unhide(entry)
+                        } label: {
+                            Label("解除", systemImage: "eye")
+                        }
+                        .tint(.blue)
+                    }
+                    .contextMenu {
+                        Button {
+                            unhide(entry)
+                        } label: {
+                            Label("非表示を解除", systemImage: "eye")
+                        }
+
+                        Divider()
+
+                        Button { editingEntry = entry } label: {
+                            Label("編集", systemImage: "pencil")
+                        }
+                        Button { commentingEntry = entry } label: {
+                            Label("コメント", systemImage: "bubble.left.and.bubble.right")
+                        }
+                        Button { lifetimeEntry = entry } label: {
+                            Label("ライフタイムを見る", systemImage: "chart.bar.xaxis")
+                        }
+                    }
+                }
+            }
+            .listStyle(.plain)
+        }
+    }
+
+    private func unhide(_ entry: MangaEntry) {
+        viewModel.setHidden(entry, isHidden: false)
+        withAnimation {
+            entries.removeAll { $0.id == entry.id }
+        }
+    }
+
+    private func authenticate() {
+        Task {
+            let success = await BiometricAuthService.authenticate(
+                reason: "非表示のマンガを表示するために認証が必要です"
+            )
+            isAuthenticated = success
+            if success {
+                entries = viewModel.hiddenEntries()
+            }
+        }
+    }
+}

--- a/MangaLauncher/Views/Library/LibrarySection.swift
+++ b/MangaLauncher/Views/Library/LibrarySection.swift
@@ -29,4 +29,5 @@ enum LibraryDestination: Hashable {
     case allActivity
     case allPublishers
     case timeline
+    case hiddenEntries
 }

--- a/MangaLauncher/Views/Library/LibraryView.swift
+++ b/MangaLauncher/Views/Library/LibraryView.swift
@@ -6,11 +6,15 @@ struct LibraryView: View {
     @Environment(\.openURL) private var openURL
 
     var viewModel: MangaViewModel
+    @Query(filter: #Predicate<MangaEntry> { $0.isHidden == false },
+           sort: \MangaEntry.lastReadDate, order: .reverse)
+    private var visibleEntries: [MangaEntry]
     @State private var editingEntry: MangaEntry?
     @State private var commentingEntry: MangaEntry?
     @State private var safariURL: URL?
     @State private var showingAddSheet = false
     @AppStorage(UserDefaultsKeys.browserMode) private var browserMode: String = "external"
+    @AppStorage(UserDefaultsKeys.showHiddenSection) private var showHiddenSection: Bool = true
 
     private var theme: ThemeStyle { ThemeManager.shared.style }
 
@@ -61,8 +65,7 @@ struct LibraryView: View {
     @ViewBuilder
     private func content(viewModel: MangaViewModel) -> some View {
         let _ = viewModel.refreshCounter
-        // 1 度だけ fetch して使い回す（N+1 fetch を避ける）
-        let allEntries = viewModel.allEntries()
+        let allEntries = Array(visibleEntries)
         let allComments = viewModel.allComments()
         let sections = LibrarySectionBuilder(allEntries: allEntries).build()
         let recentActivity = ActivityBuilder.recent(entries: allEntries, comments: allComments, limit: 8)
@@ -80,6 +83,7 @@ struct LibraryView: View {
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 24) {
                     timelineLink
+                    hiddenSectionLink
                     if !recentActivity.isEmpty {
                         recentActivitySection(items: recentActivity, totalCount: totalActivityCount)
                     }
@@ -113,6 +117,8 @@ struct LibraryView: View {
             )
         case .timeline:
             TimelineView(viewModel: viewModel)
+        case .hiddenEntries:
+            HiddenEntriesView(viewModel: viewModel)
         }
     }
 
@@ -142,6 +148,36 @@ struct LibraryView: View {
         }
         .buttonStyle(.plain)
         .padding(.horizontal)
+    }
+
+    @ViewBuilder
+    private var hiddenSectionLink: some View {
+        if showHiddenSection {
+            NavigationLink(value: LibraryDestination.hiddenEntries) {
+                HStack(spacing: 10) {
+                    Image(systemName: "eye.slash.fill")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(.white)
+                        .frame(width: 28, height: 28)
+                        .background(Color.gray, in: RoundedRectangle(cornerRadius: 6))
+                    Text("非表示")
+                        .font(theme.subheadlineFont.weight(.semibold))
+                        .foregroundStyle(theme.onSurface)
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(theme.onSurfaceVariant)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .background(
+                    RoundedRectangle(cornerRadius: 12)
+                        .fill(theme.surfaceContainerHigh)
+                )
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal)
+        }
     }
 
     @ViewBuilder

--- a/MangaLauncher/Views/Library/LibraryView.swift
+++ b/MangaLauncher/Views/Library/LibraryView.swift
@@ -1,14 +1,10 @@
 import SwiftUI
-import SwiftData
 import PlatformKit
 
 struct LibraryView: View {
     @Environment(\.openURL) private var openURL
 
     var viewModel: MangaViewModel
-    @Query(filter: #Predicate<MangaEntry> { $0.isHidden == false },
-           sort: \MangaEntry.lastReadDate, order: .reverse)
-    private var visibleEntries: [MangaEntry]
     @State private var editingEntry: MangaEntry?
     @State private var commentingEntry: MangaEntry?
     @State private var safariURL: URL?
@@ -65,7 +61,7 @@ struct LibraryView: View {
     @ViewBuilder
     private func content(viewModel: MangaViewModel) -> some View {
         let _ = viewModel.refreshCounter
-        let allEntries = Array(visibleEntries)
+        let allEntries = viewModel.allEntries()
         let allComments = viewModel.allComments()
         let sections = LibrarySectionBuilder(allEntries: allEntries).build()
         let recentActivity = ActivityBuilder.recent(entries: allEntries, comments: allComments, limit: 8)
@@ -164,6 +160,12 @@ struct LibraryView: View {
                         .font(theme.subheadlineFont.weight(.semibold))
                         .foregroundStyle(theme.onSurface)
                     Spacer()
+                    let count = viewModel.hiddenIDs.count
+                    if count > 0 {
+                        Text("\(count)")
+                            .font(theme.captionFont)
+                            .foregroundStyle(theme.onSurfaceVariant)
+                    }
                     Image(systemName: "chevron.right")
                         .font(.caption)
                         .foregroundStyle(theme.onSurfaceVariant)

--- a/MangaLauncher/Views/MangaCell/MangaContextMenu.swift
+++ b/MangaLauncher/Views/MangaCell/MangaContextMenu.swift
@@ -141,6 +141,17 @@ struct MangaContextMenu: View {
 
         Divider()
 
+        Button {
+            if entry.isHidden {
+                viewModel.setHidden(entry, isHidden: false)
+            } else {
+                viewModel.setHidden(entry, isHidden: true)
+            }
+        } label: {
+            Label(entry.isHidden ? "非表示を解除" : "非表示にする",
+                  systemImage: entry.isHidden ? "eye" : "eye.slash")
+        }
+
         Button(role: .destructive) {
             viewModel.queueDelete(entry)
         } label: {

--- a/MangaLauncher/Views/Settings/SettingsView.swift
+++ b/MangaLauncher/Views/Settings/SettingsView.swift
@@ -15,7 +15,7 @@ struct SettingsView: View {
     @State private var importResult: ImportResult?
     @AppStorage(UserDefaultsKeys.browserMode) private var browserMode: String = "external"
     @AppStorage(UserDefaultsKeys.showsNextUpdateBadge) private var showsNextUpdateBadge: Bool = true
-    @AppStorage(UserDefaultsKeys.showHiddenSection) private var showHiddenSection: Bool = false
+    @AppStorage(UserDefaultsKeys.showHiddenSection) private var showHiddenSection: Bool = true
     @State private var updateStatus: UpdateStatus = .idle
     @State private var showingOnboarding = false
     @State private var showingSyncError = false

--- a/MangaLauncher/Views/Settings/SettingsView.swift
+++ b/MangaLauncher/Views/Settings/SettingsView.swift
@@ -15,6 +15,7 @@ struct SettingsView: View {
     @State private var importResult: ImportResult?
     @AppStorage(UserDefaultsKeys.browserMode) private var browserMode: String = "external"
     @AppStorage(UserDefaultsKeys.showsNextUpdateBadge) private var showsNextUpdateBadge: Bool = true
+    @AppStorage(UserDefaultsKeys.showHiddenSection) private var showHiddenSection: Bool = false
     @State private var updateStatus: UpdateStatus = .idle
     @State private var showingOnboarding = false
     @State private var showingSyncError = false
@@ -181,10 +182,11 @@ struct SettingsView: View {
 
                 Section {
                     Toggle("次回更新日を表示", isOn: $showsNextUpdateBadge)
+                    Toggle("非表示セクションを表示", isOn: $showHiddenSection)
                 } header: {
                     Text("表示")
                 } footer: {
-                    Text("ホーム画面のセルに次回更新までの日数を表示します。")
+                    Text("ホーム画面のセルに次回更新までの日数を表示します。非表示セクションをオンにすると、ライブラリに非表示マンガの管理画面が追加されます。")
                 }
 
                 Section {

--- a/MangaWidget/MangaWidget.swift
+++ b/MangaWidget/MangaWidget.swift
@@ -54,6 +54,7 @@ struct MangaTimelineProvider: TimelineProvider {
                 $0.dayOfWeekRawValue == dayRaw
                     && $0.publicationStatusRawValue == activeRaw
                     && $0.readingStateRawValue == followingRaw
+                    && $0.isHidden == false
             },
             sortBy: [SortDescriptor(\.sortOrder)]
         )


### PR DESCRIPTION
## Summary

iOS 写真アプリの「非表示」機能をモデルにした、マンガの非表示機能。Face ID / パスコードで認証後に閲覧可能。

## 機能

- コンテキストメニューから「非表示にする」で一覧から非表示
- ライブラリに「非表示」セクション追加（件数表示付き）
- Face ID / Touch ID / パスコードで認証後にリスト表示
- スワイプまたはコンテキストメニューで「非表示を解除」
- 設定で「ライブラリに非表示を表示」トグル

## フィルタリング

非表示マンガは以下すべてから除外:
- ホーム画面（曜日タブ）
- ライブラリ（セクション・出版社一覧）
- 検索・キャッチアップ・ウィジェット・通知・バッジ・登録数

## 実装

- `MangaEntry.isHidden: Bool` (SwiftData lightweight migration)
- `hiddenIDs: Set<UUID>` でインメモリ管理（即時反映）
- `setHidden()` で `entry.modelContext` を使用して保存（refresh() による ModelContext 差し替え時にも正しいコンテキストで永続化）
- `BiometricAuthService` で LocalAuthentication を async/await で利用
- BackupData v11

## 根本原因と解決

`refresh()` が `self.modelContext` を新しいインスタンスに差し替えるが、HiddenEntriesView の `@State entries` に保持されたエントリオブジェクトは古い ModelContext に属したまま。`self.modelContext.save()` では変更が永続化されなかった。`entry.modelContext` で保存することで解決。

Closes #181

## Test plan

- [x] 非表示にする → 一覧から消える + 件数更新
- [x] 非表示セクション → 認証 → リスト表示
- [x] スワイプで解除 → リストから即座に消える
- [x] 戻る → ライブラリに即座に反映
- [x] 設定トグルで非表示セクションを隠せる
- [ ] テーマ切替で表示が破綻しないこと
- [ ] バックアップ・インポートで isHidden が保持されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)