### PR TITLE
Fix missing fields in BackupActivity

### DIFF
--- a/MangaLauncher/Models/BackupData.swift
+++ b/MangaLauncher/Models/BackupData.swift
@@ -14,6 +14,31 @@ struct BackupData: Codable {
         let date: Date
         let mangaName: String
         let mangaEntryID: UUID
+        // v12+
+        let timestamp: Date?
+        let episodeNumber: Int?
+        let episodeLabel: String?
+
+        init(id: UUID, date: Date, mangaName: String, mangaEntryID: UUID, timestamp: Date? = nil, episodeNumber: Int? = nil, episodeLabel: String? = nil) {
+            self.id = id
+            self.date = date
+            self.mangaName = mangaName
+            self.mangaEntryID = mangaEntryID
+            self.timestamp = timestamp
+            self.episodeNumber = episodeNumber
+            self.episodeLabel = episodeLabel
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decode(UUID.self, forKey: .id)
+            date = try container.decode(Date.self, forKey: .date)
+            mangaName = try container.decode(String.self, forKey: .mangaName)
+            mangaEntryID = try container.decode(UUID.self, forKey: .mangaEntryID)
+            timestamp = try container.decodeIfPresent(Date.self, forKey: .timestamp)
+            episodeNumber = try container.decodeIfPresent(Int.self, forKey: .episodeNumber)
+            episodeLabel = try container.decodeIfPresent(String.self, forKey: .episodeLabel)
+        }
     }
 
     struct BackupComment: Codable {
@@ -109,7 +134,7 @@ struct BackupData: Codable {
 
     static func from(_ entries: [MangaEntry], activities: [ReadingActivity] = [], comments: [MangaComment] = []) -> BackupData {
         BackupData(
-            version: 11,
+            version: 12,
             exportDate: Date(),
             entries: entries.map {
                 BackupEntry(
@@ -139,7 +164,10 @@ struct BackupData: Codable {
                     id: $0.id,
                     date: $0.date,
                     mangaName: $0.mangaName,
-                    mangaEntryID: $0.mangaEntryID
+                    mangaEntryID: $0.mangaEntryID,
+                    timestamp: $0.timestamp,
+                    episodeNumber: $0.episodeNumber,
+                    episodeLabel: $0.episodeLabel
                 )
             },
             comments: comments.map {

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -512,9 +512,7 @@ final class MangaViewModel {
                     episodeLabel: backupActivity.episodeLabel
                 )
                 activity.id = backupActivity.id
-                if let timestamp = backupActivity.timestamp {
-                    activity.timestamp = timestamp
-                }
+                activity.timestamp = backupActivity.timestamp
                 modelContext.insert(activity)
                 importedCount += 1
             }

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -507,9 +507,14 @@ final class MangaViewModel {
                 let activity = ReadingActivity(
                     date: backupActivity.date,
                     mangaName: backupActivity.mangaName,
-                    mangaEntryID: backupActivity.mangaEntryID
+                    mangaEntryID: backupActivity.mangaEntryID,
+                    episodeNumber: backupActivity.episodeNumber,
+                    episodeLabel: backupActivity.episodeLabel
                 )
                 activity.id = backupActivity.id
+                if let timestamp = backupActivity.timestamp {
+                    activity.timestamp = timestamp
+                }
                 modelContext.insert(activity)
                 importedCount += 1
             }


### PR DESCRIPTION
## Summary

BackupActivity に timestamp, episodeNumber, episodeLabel が含まれていなかったバグを修正。

インポート時に:
- タイムラインの時刻が全て 00:00 になる問題を修正
- 話数更新・特別回の履歴が失われる問題を修正

## 変更
- BackupActivity に 3 フィールド追加（v12）
- `decodeIfPresent` で旧バックアップとの後方互換性維持
- エクスポート・インポート処理を更新

## 監査結果
- MangaEntry ↔ BackupEntry: 全フィールドカバー済み ✓
- MangaComment ↔ BackupComment: 全フィールドカバー済み ✓
- ReadingActivity ↔ BackupActivity: **この PR で修正** ✓

## Test plan
- [x] エクスポート → インポートでタイムラインの時刻が保持されること
- [x] 話数更新・特別回ラベルがインポート後も表示されること
- [x] 旧バックアップ（v11以前）のインポートが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)