### PR TITLE
Record ReadingActivity when saving with episode number

### DIFF
--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -200,6 +200,19 @@ final class MangaViewModel {
         save()
     }
 
+    func recordEpisodeRead(_ entry: MangaEntry, episodeNumber: Int) {
+        let now = Date()
+        entry.lastReadDate = now
+        let activity = ReadingActivity(
+            date: now,
+            mangaName: entry.name,
+            mangaEntryID: entry.id,
+            episodeNumber: episodeNumber
+        )
+        modelContext.insert(activity)
+        save()
+    }
+
     func incrementEpisode(_ entry: MangaEntry) {
         let newEpisode = (entry.currentEpisode ?? 0) + 1
         entry.currentEpisode = newEpisode

--- a/MangaLauncher/Views/Entry/EditEntryView.swift
+++ b/MangaLauncher/Views/Entry/EditEntryView.swift
@@ -505,6 +505,8 @@ struct EditEntryView: View {
             if markAsReadOnSave {
                 if let labelToSave {
                     viewModel.recordSpecialEpisode(entry, label: labelToSave)
+                } else if let ep = currentEpisode {
+                    viewModel.recordEpisodeRead(entry, episodeNumber: ep)
                 } else {
                     entry.lastReadDate = Date()
                 }


### PR DESCRIPTION
## Summary

編集画面で話数 + 「保存時に既読にする」ON で保存した際に ReadingActivity が作成されず、タイムラインに記録が残らないバグを修正。

## Test plan

- [ ] 編集画面で話数設定 + 既読ON → 保存 → タイムラインに「既読 N話に更新」が表示
- [ ] ラベル + 既読ON → 保存 → タイムラインにラベルが表示（従来通り）
- [ ] 話数なし + 既読ON → 保存 → lastReadDate のみ更新（従来通り）

🤖 Generated with [Claude Code](https://claude.com/claude-code)