### PR TITLE
Add collapsible activity section in Library

### DIFF
--- a/MangaLauncher/Shared/SectionHeaderView.swift
+++ b/MangaLauncher/Shared/SectionHeaderView.swift
@@ -19,31 +19,43 @@ struct SectionHeaderView<Destination: Hashable>: View {
                     .font(theme.headlineFont)
                     .foregroundStyle(iconColor ?? theme.primary)
             }
-            Text(title)
-                .font(theme.title3Font)
-                .foregroundStyle(theme.onSurface)
-            if let count {
-                Text("\(count)")
-                    .font(.system(size: 13, weight: .bold))
-                    .foregroundStyle(theme.onPrimary)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 2)
-                    .background(badgeColor ?? theme.primary)
-                    .clipShape(Capsule())
-            }
-            Spacer()
             if let seeAll {
                 NavigationLink(value: seeAll) {
-                    HStack(spacing: 2) {
-                        Text("すべて表示")
-                            .font(theme.captionFont)
+                    HStack(spacing: 8) {
+                        Text(title)
+                            .font(theme.title3Font)
+                            .foregroundStyle(theme.onSurface)
+                        if let count {
+                            countBadge
+                        }
                         Image(systemName: "chevron.right")
-                            .font(.caption2)
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(theme.onSurfaceVariant)
                     }
-                    .foregroundStyle(theme.primary)
                 }
                 .buttonStyle(.plain)
+            } else {
+                Text(title)
+                    .font(theme.title3Font)
+                    .foregroundStyle(theme.onSurface)
+                if let count {
+                    countBadge
+                }
             }
+            Spacer()
+        }
+    }
+
+    @ViewBuilder
+    private var countBadge: some View {
+        if let count {
+            Text("\(count)")
+                .font(.system(size: 13, weight: .bold))
+                .foregroundStyle(theme.onPrimary)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 2)
+                .background(badgeColor ?? theme.primary)
+                .clipShape(Capsule())
         }
     }
 }

--- a/MangaLauncher/Shared/UserDefaultsKeys.swift
+++ b/MangaLauncher/Shared/UserDefaultsKeys.swift
@@ -17,6 +17,7 @@ enum UserDefaultsKeys {
     static let showsNextUpdateBadge = "showsNextUpdateBadge"
     static let showHiddenSection = "showHiddenSection"
     static let appIconMode = "appIconMode"
+    static let recentActivityExpanded = "recentActivityExpanded"
 
     // MARK: - Pending intent signals (App Group 経由)
     static let pendingIntentData = "pendingIntentData"

--- a/MangaLauncher/Views/Library/LibraryView.swift
+++ b/MangaLauncher/Views/Library/LibraryView.swift
@@ -11,6 +11,8 @@ struct LibraryView: View {
     @State private var showingAddSheet = false
     @AppStorage(UserDefaultsKeys.browserMode) private var browserMode: String = "external"
     @AppStorage(UserDefaultsKeys.showHiddenSection) private var showHiddenSection: Bool = true
+    @AppStorage(UserDefaultsKeys.recentActivityExpanded) private var recentActivityExpandedStorage: Bool = false
+    @State private var recentActivityExpanded: Bool = false
 
     private var theme: ThemeStyle { ThemeManager.shared.style }
 
@@ -52,6 +54,12 @@ struct LibraryView: View {
                     .ignoresSafeArea()
             }
             #endif
+            .onAppear {
+                recentActivityExpanded = recentActivityExpandedStorage
+            }
+            .onChange(of: recentActivityExpanded) { _, newValue in
+                recentActivityExpandedStorage = newValue
+            }
         }
         .onMangaDataChange {
             viewModel.refresh()
@@ -185,22 +193,55 @@ struct LibraryView: View {
     @ViewBuilder
     private func recentActivitySection(items: [ActivityItem], totalCount: Int) -> some View {
         VStack(alignment: .leading, spacing: 8) {
-            SectionHeaderView(
-                title: "最近のメモ・コメント",
-                icon: "square.and.pencil",
-                iconColor: .purple,
-                count: totalCount,
-                badgeColor: .purple,
-                seeAll: totalCount > items.count ? LibraryDestination.allActivity : nil
-            )
-            .padding(.horizontal)
-
-            VStack(alignment: .leading, spacing: 8) {
-                ForEach(items) { item in
-                    activityRow(item)
+            HStack(spacing: 8) {
+                Image(systemName: "square.and.pencil")
+                    .font(theme.headlineFont)
+                    .foregroundStyle(.purple)
+                NavigationLink(value: LibraryDestination.allActivity) {
+                    HStack(spacing: 8) {
+                        Text("メモ・コメント")
+                            .font(theme.title3Font)
+                            .foregroundStyle(theme.onSurface)
+                        Text("\(totalCount)")
+                            .font(.system(size: 13, weight: .bold))
+                            .foregroundStyle(theme.onPrimary)
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 2)
+                            .background(.purple)
+                            .clipShape(Capsule())
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(theme.onSurfaceVariant)
+                    }
                 }
+                .buttonStyle(.plain)
+                Spacer()
+                Button {
+                    withAnimation(.easeInOut(duration: 0.25)) {
+                        recentActivityExpanded.toggle()
+                    }
+                } label: {
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 13, weight: .bold))
+                        .foregroundStyle(theme.primary)
+                        .rotationEffect(.degrees(recentActivityExpanded ? 0 : -90))
+                        .frame(width: 30, height: 30)
+                        .background(theme.onSurfaceVariant.opacity(0.2))
+                        .clipShape(Circle())
+                }
+                .buttonStyle(.plain)
             }
             .padding(.horizontal)
+
+            if recentActivityExpanded {
+                VStack(alignment: .leading, spacing: 8) {
+                    ForEach(items) { item in
+                        activityRow(item)
+                    }
+                }
+                .padding(.horizontal)
+                .transition(.opacity)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- ライブラリの「メモ・コメント」セクションを折りたたみ式に変更（デフォルト閉、状態は永続化）
- 「すべて表示」テキストリンクをシェブロンアイコンに統一し、タイトル+バッジ全体をリンク化
- 開閉トグルは円形背景のシェブロンで視覚的に区別
- 開閉アニメーション（フェード + 高さ変化）を追加

## Test plan
- [x] メモ・コメントセクションがデフォルトで閉じていること
- [x] トグル（円形シェブロン）をタップで開閉できること
- [x] アニメーションがスムーズに動作すること
- [x] ヘッダーのタイトルタップで「すべて表示」画面に遷移すること（開閉どちらの状態でも）
- [x] 他セクション（最近読んだ、掲載誌別など）のシェブロンリンクも正常に動作すること
- [x] アプリ再起動後も開閉状態が保持されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)