### PR TITLE
Add Quick View browser mode with WKWebView

### DIFF
--- a/MangaLauncher/Shared/MangaURLOpener.swift
+++ b/MangaLauncher/Shared/MangaURLOpener.swift
@@ -1,16 +1,36 @@
 import SwiftUI
 
+struct BrowserContext: Identifiable {
+    let id = UUID()
+    let url: URL
+    let entryName: String?
+    let entryPublisher: String?
+    let entryImageData: Data?
+
+    init(url: URL, entryName: String? = nil, entryPublisher: String? = nil, entryImageData: Data? = nil) {
+        self.url = url
+        self.entryName = entryName
+        self.entryPublisher = entryPublisher
+        self.entryImageData = entryImageData
+    }
+}
+
 struct MangaURLOpener {
     let browserMode: String
     let openURL: OpenURLAction
-    var onSafariURL: ((URL) -> Void)?
+    var onBrowserContext: ((BrowserContext) -> Void)?
 
-    func open(_ urlString: String) {
+    func open(_ urlString: String, entry: MangaEntry? = nil) {
         guard let url = URL(string: urlString) else { return }
         #if canImport(UIKit)
         let isWebURL = url.scheme?.lowercased() == "http" || url.scheme?.lowercased() == "https"
-        if browserMode == "inApp" && isWebURL {
-            onSafariURL?(url)
+        if (browserMode == "inApp" || browserMode == "overlay") && isWebURL {
+            onBrowserContext?(BrowserContext(
+                url: url,
+                entryName: entry?.name,
+                entryPublisher: entry?.publisher,
+                entryImageData: entry?.imageData
+            ))
         } else {
             openURL(url)
         }

--- a/MangaLauncher/Shared/MangaURLOpener.swift
+++ b/MangaLauncher/Shared/MangaURLOpener.swift
@@ -26,7 +26,7 @@ struct MangaURLOpener {
         guard let url = URL(string: urlString) else { return }
         #if canImport(UIKit)
         let isWebURL = url.scheme?.lowercased() == "http" || url.scheme?.lowercased() == "https"
-        if browserMode == "quickView" && isWebURL {
+        if (browserMode == "quickView" || browserMode == "overlay") && isWebURL {
             let info = entryLookup?(urlString)
             let ctx = BrowserContext(url: url, entryName: info?.name, entryPublisher: info?.publisher, entryImageData: info?.imageData)
             onQuickView?(ctx)

--- a/MangaLauncher/Shared/MangaURLOpener.swift
+++ b/MangaLauncher/Shared/MangaURLOpener.swift
@@ -24,7 +24,7 @@ struct MangaURLOpener {
         guard let url = URL(string: urlString) else { return }
         #if canImport(UIKit)
         let isWebURL = url.scheme?.lowercased() == "http" || url.scheme?.lowercased() == "https"
-        if (browserMode == "inApp" || browserMode == "overlay") && isWebURL {
+        if (browserMode == "inApp" || browserMode == "quickView") && isWebURL {
             onBrowserContext?(BrowserContext(
                 url: url,
                 entryName: entry?.name,

--- a/MangaLauncher/Shared/MangaURLOpener.swift
+++ b/MangaLauncher/Shared/MangaURLOpener.swift
@@ -18,19 +18,20 @@ struct BrowserContext: Identifiable {
 struct MangaURLOpener {
     let browserMode: String
     let openURL: OpenURLAction
-    var onBrowserContext: ((BrowserContext) -> Void)?
+    var onSafariURL: ((URL) -> Void)?
+    var onQuickView: ((BrowserContext) -> Void)?
+    var entryLookup: ((String) -> (name: String?, publisher: String?, imageData: Data?)?)?
 
-    func open(_ urlString: String, entry: MangaEntry? = nil) {
+    func open(_ urlString: String) {
         guard let url = URL(string: urlString) else { return }
         #if canImport(UIKit)
         let isWebURL = url.scheme?.lowercased() == "http" || url.scheme?.lowercased() == "https"
-        if (browserMode == "inApp" || browserMode == "quickView") && isWebURL {
-            onBrowserContext?(BrowserContext(
-                url: url,
-                entryName: entry?.name,
-                entryPublisher: entry?.publisher,
-                entryImageData: entry?.imageData
-            ))
+        if browserMode == "quickView" && isWebURL {
+            let info = entryLookup?(urlString)
+            let ctx = BrowserContext(url: url, entryName: info?.name, entryPublisher: info?.publisher, entryImageData: info?.imageData)
+            onQuickView?(ctx)
+        } else if browserMode == "inApp" && isWebURL {
+            onSafariURL?(url)
         } else {
             openURL(url)
         }

--- a/MangaLauncher/ViewModels/HomeState.swift
+++ b/MangaLauncher/ViewModels/HomeState.swift
@@ -19,7 +19,6 @@ final class HomeState {
     // MARK: - Layout
     var headerHeight: CGFloat = 50
     var selectedPublisher: String?
-    var safariURL: URL?
     var commentingEntry: MangaEntry?
 }
 

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -28,6 +28,8 @@ final class MangaViewModel {
     /// 直近の重大エラー（移行/インポート/同期）。View 側で alert 表示する用。
     var lastError: AppError?
 
+    var browserContext: BrowserContext?
+
     private(set) var modelContext: ModelContext
     @ObservationIgnored private var didRunStartupMigrations = false
 

--- a/MangaLauncher/Views/CatchUp/CatchUpView.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpView.swift
@@ -410,14 +410,15 @@ struct CatchUpView: View {
     }
 
     private func openMangaURL(_ urlString: String) {
-        guard let url = URL(string: urlString) else { return }
-        let entry = viewModel.allEntries().first { $0.url == urlString }
-        if browserMode == "quickView" {
-            quickViewContext = BrowserContext(url: url, entryName: entry?.name, entryPublisher: entry?.publisher, entryImageData: entry?.imageData)
-        } else if browserMode == "inApp" {
-            safariURL = url
-        } else {
-            openURL(url)
-        }
+        MangaURLOpener(
+            browserMode: browserMode,
+            openURL: openURL,
+            onSafariURL: { safariURL = $0 },
+            onQuickView: { quickViewContext = $0 },
+            entryLookup: { url in
+                guard let e = viewModel.allEntries().first(where: { $0.url == url }) else { return nil }
+                return (e.name, e.publisher, e.imageData)
+            }
+        ).open(urlString)
     }
 }

--- a/MangaLauncher/Views/CatchUp/CatchUpView.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpView.swift
@@ -125,8 +125,7 @@ struct CatchUpView: View {
         }
         #if canImport(UIKit)
         .sheet(item: $safariURL) { url in
-            SafariView(url: url)
-                .ignoresSafeArea()
+            SafariView(url: url).ignoresSafeArea()
         }
         #endif
         .gesture(dismissDragGesture, including: isCompleted || unreadItems.isEmpty ? .all : .subviews)
@@ -402,6 +401,14 @@ struct CatchUpView: View {
     }
 
     private func openMangaURL(_ urlString: String) {
-        MangaURLOpener(browserMode: browserMode, openURL: openURL) { safariURL = $0 }.open(urlString)
+        guard let url = URL(string: urlString) else { return }
+        let entry = viewModel.allEntries().first { $0.url == urlString }
+        if browserMode == "overlay" {
+            viewModel.browserContext = BrowserContext(url: url, entryName: entry?.name, entryPublisher: entry?.publisher, entryImageData: entry?.imageData)
+        } else if browserMode == "inApp" {
+            safariURL = url
+        } else {
+            openURL(url)
+        }
     }
 }

--- a/MangaLauncher/Views/CatchUp/CatchUpView.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpView.swift
@@ -16,7 +16,7 @@ struct CatchUpView: View {
     @State private var undoStack: [(entry: MangaEntry, action: SwipeAction)] = []
     @State private var completionAnimated = false
     @State private var safariURL: URL?
-    @State private var overlayContext: BrowserContext?
+    @State private var quickViewContext: BrowserContext?
     @AppStorage(UserDefaultsKeys.hasSeenCatchUpTutorial) private var hasSeenTutorial = false
     @State private var showTutorial = false
     @State private var editingEntry: MangaEntry?
@@ -129,9 +129,9 @@ struct CatchUpView: View {
             SafariView(url: url).ignoresSafeArea()
         }
         .overlay {
-            if let ctx = overlayContext {
-                OverlayBrowserScreen(context: ctx) {
-                    overlayContext = nil
+            if let ctx = quickViewContext {
+                QuickViewBrowserScreen(context: ctx) {
+                    quickViewContext = nil
                 }
                 .ignoresSafeArea()
             }
@@ -412,8 +412,8 @@ struct CatchUpView: View {
     private func openMangaURL(_ urlString: String) {
         guard let url = URL(string: urlString) else { return }
         let entry = viewModel.allEntries().first { $0.url == urlString }
-        if browserMode == "overlay" {
-            overlayContext = BrowserContext(url: url, entryName: entry?.name, entryPublisher: entry?.publisher, entryImageData: entry?.imageData)
+        if browserMode == "quickView" {
+            quickViewContext = BrowserContext(url: url, entryName: entry?.name, entryPublisher: entry?.publisher, entryImageData: entry?.imageData)
         } else if browserMode == "inApp" {
             safariURL = url
         } else {

--- a/MangaLauncher/Views/CatchUp/CatchUpView.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpView.swift
@@ -16,6 +16,7 @@ struct CatchUpView: View {
     @State private var undoStack: [(entry: MangaEntry, action: SwipeAction)] = []
     @State private var completionAnimated = false
     @State private var safariURL: URL?
+    @State private var overlayContext: BrowserContext?
     @AppStorage(UserDefaultsKeys.hasSeenCatchUpTutorial) private var hasSeenTutorial = false
     @State private var showTutorial = false
     @State private var editingEntry: MangaEntry?
@@ -126,6 +127,14 @@ struct CatchUpView: View {
         #if canImport(UIKit)
         .sheet(item: $safariURL) { url in
             SafariView(url: url).ignoresSafeArea()
+        }
+        .overlay {
+            if let ctx = overlayContext {
+                OverlayBrowserScreen(context: ctx) {
+                    overlayContext = nil
+                }
+                .ignoresSafeArea()
+            }
         }
         #endif
         .gesture(dismissDragGesture, including: isCompleted || unreadItems.isEmpty ? .all : .subviews)
@@ -404,7 +413,7 @@ struct CatchUpView: View {
         guard let url = URL(string: urlString) else { return }
         let entry = viewModel.allEntries().first { $0.url == urlString }
         if browserMode == "overlay" {
-            viewModel.browserContext = BrowserContext(url: url, entryName: entry?.name, entryPublisher: entry?.publisher, entryImageData: entry?.imageData)
+            overlayContext = BrowserContext(url: url, entryName: entry?.name, entryPublisher: entry?.publisher, entryImageData: entry?.imageData)
         } else if browserMode == "inApp" {
             safariURL = url
         } else {

--- a/MangaLauncher/Views/Common/SafariView.swift
+++ b/MangaLauncher/Views/Common/SafariView.swift
@@ -52,37 +52,60 @@ struct OverlayBrowserScreen: View {
     let onDismiss: () -> Void
     @State private var currentURL: URL?
     @State private var showShareSheet = false
+    @State private var isRevealed = false
     private var displayURL: URL { currentURL ?? context.url }
+    private let screenHeight = UIScreen.main.bounds.height
 
     var body: some View {
-        VStack(spacing: 0) {
-            WebViewRepresentable(url: context.url, currentURL: $currentURL)
+        ZStack {
+            VStack(spacing: 0) {
+                WebViewRepresentable(url: context.url, currentURL: $currentURL)
 
-            toolbarView
+                toolbarView
 
-            if context.entryName != nil {
-                entryCard
-                    .contentShape(Rectangle())
-                    .gesture(
-                        DragGesture()
-                            .onEnded { value in
-                                if value.translation.height < -60 {
-                                    onDismiss()
+                if context.entryName != nil {
+                    entryCard
+                        .contentShape(Rectangle())
+                        .gesture(
+                            DragGesture()
+                                .onEnded { value in
+                                    if value.translation.height < -60 {
+                                        dismissAnimated()
+                                    }
                                 }
-                            }
-                    )
+                        )
+                }
             }
+            .background(Color(.systemBackground))
+
+            Color(.systemBackground)
+                .ignoresSafeArea()
+                .offset(y: isRevealed ? screenHeight : 0)
+                .allowsHitTesting(false)
         }
-        .background(Color(.systemBackground))
         .sheet(isPresented: $showShareSheet) {
             ShareSheet(url: displayURL)
+        }
+        .onAppear {
+            withAnimation(.easeInOut(duration: 0.35)) {
+                isRevealed = true
+            }
+        }
+    }
+
+    private func dismissAnimated() {
+        withAnimation(.easeInOut(duration: 0.3)) {
+            isRevealed = false
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            onDismiss()
         }
     }
 
     @ViewBuilder
     private var toolbarView: some View {
         HStack(spacing: 0) {
-            Button { onDismiss() } label: {
+            Button { dismissAnimated() } label: {
                 Image(systemName: "xmark")
                     .font(.system(size: 12, weight: .bold))
                     .foregroundStyle(.secondary)

--- a/MangaLauncher/Views/Common/SafariView.swift
+++ b/MangaLauncher/Views/Common/SafariView.swift
@@ -13,40 +13,9 @@ struct SafariView: UIViewControllerRepresentable {
     func updateUIViewController(_ uiViewController: SFSafariViewController, context: Context) {}
 }
 
-// MARK: - Overlay Browser Modifier
+// MARK: - Quick View Browser Screen
 
-struct OverlayBrowserModifier: ViewModifier {
-    @Binding var context: BrowserContext?
-    @AppStorage(UserDefaultsKeys.browserMode) private var browserMode: String = "external"
-
-    private var isActive: Bool { browserMode == "overlay" && context != nil }
-
-    func body(content: Content) -> some View {
-        content
-            .overlay {
-                if browserMode == "overlay", let ctx = context {
-                    OverlayBrowserScreen(context: ctx) { context = nil }
-                        .transition(.move(edge: .top).combined(with: .opacity))
-                        .ignoresSafeArea(edges: .all)
-                }
-            }
-            .animation(.easeInOut(duration: 0.35), value: isActive)
-            .sheet(item: browserMode != "overlay" ? $context : .constant(nil)) { ctx in
-                SafariView(url: ctx.url)
-                    .ignoresSafeArea()
-            }
-    }
-}
-
-extension View {
-    func overlayBrowser(context: Binding<BrowserContext?>) -> some View {
-        modifier(OverlayBrowserModifier(context: context))
-    }
-}
-
-// MARK: - Web Layer (behind original content)
-
-struct OverlayBrowserScreen: View {
+struct QuickViewBrowserScreen: View {
     @Environment(\.openURL) private var openURL
     @Environment(\.scenePhase) private var scenePhase
     let context: BrowserContext

--- a/MangaLauncher/Views/Common/SafariView.swift
+++ b/MangaLauncher/Views/Common/SafariView.swift
@@ -42,7 +42,8 @@ struct QuickViewBrowserScreen: View {
     private var safeAreaTop: CGFloat {
         UIApplication.shared.connectedScenes
             .compactMap { $0 as? UIWindowScene }
-            .first?.windows.first?.safeAreaInsets.top ?? 0
+            .flatMap(\.windows)
+            .first(where: { $0.isKeyWindow })?.safeAreaInsets.top ?? 0
     }
 
     var body: some View {
@@ -51,8 +52,7 @@ struct QuickViewBrowserScreen: View {
                 Color(.systemBackground)
                     .frame(height: safeAreaTop)
 
-                WebViewRepresentable(url: context.url, currentURL: $currentURL)
-                    .id(reloadID)
+                WebViewRepresentable(url: context.url, currentURL: $currentURL, reloadTrigger: $reloadID)
             }
 
             VStack(spacing: 0) {
@@ -117,7 +117,8 @@ struct QuickViewBrowserScreen: View {
     private func captureScreenshot() -> UIImage? {
         guard let window = UIApplication.shared.connectedScenes
             .compactMap({ $0 as? UIWindowScene })
-            .first?.windows.first else { return nil }
+            .flatMap(\.windows)
+            .first(where: { $0.isKeyWindow }) else { return nil }
         let renderer = UIGraphicsImageRenderer(bounds: window.bounds)
         return renderer.image { _ in
             window.drawHierarchy(in: window.bounds, afterScreenUpdates: false)
@@ -223,7 +224,8 @@ struct QuickViewBrowserScreen: View {
         .padding(.vertical, 12)
         .padding(.bottom, UIApplication.shared.connectedScenes
             .compactMap { $0 as? UIWindowScene }
-            .first?.windows.first?.safeAreaInsets.bottom ?? 0)
+            .flatMap(\.windows)
+            .first(where: { $0.isKeyWindow })?.safeAreaInsets.bottom ?? 0)
         .background(.black.opacity(0.85))
     }
 }
@@ -233,25 +235,35 @@ struct QuickViewBrowserScreen: View {
 private struct WebViewRepresentable: UIViewRepresentable {
     let url: URL
     @Binding var currentURL: URL?
+    @Binding var reloadTrigger: UUID
 
     func makeUIView(context: Context) -> WKWebView {
         let webView = WKWebView()
         webView.navigationDelegate = context.coordinator
         webView.load(URLRequest(url: url))
+        context.coordinator.webView = webView
         return webView
     }
 
-    func updateUIView(_ uiView: WKWebView, context: Context) {}
+    func updateUIView(_ uiView: WKWebView, context: Context) {
+        if context.coordinator.lastReloadTrigger != reloadTrigger {
+            context.coordinator.lastReloadTrigger = reloadTrigger
+            uiView.reload()
+        }
+    }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(currentURL: $currentURL)
+        Coordinator(currentURL: $currentURL, reloadTrigger: reloadTrigger)
     }
 
     final class Coordinator: NSObject, WKNavigationDelegate {
         @Binding var currentURL: URL?
+        weak var webView: WKWebView?
+        var lastReloadTrigger: UUID
 
-        init(currentURL: Binding<URL?>) {
+        init(currentURL: Binding<URL?>, reloadTrigger: UUID) {
             _currentURL = currentURL
+            self.lastReloadTrigger = reloadTrigger
         }
 
         func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {

--- a/MangaLauncher/Views/Common/SafariView.swift
+++ b/MangaLauncher/Views/Common/SafariView.swift
@@ -1,6 +1,7 @@
 #if canImport(UIKit)
 import SwiftUI
 import SafariServices
+import WebKit
 
 struct SafariView: UIViewControllerRepresentable {
     let url: URL
@@ -10,5 +11,206 @@ struct SafariView: UIViewControllerRepresentable {
     }
 
     func updateUIViewController(_ uiViewController: SFSafariViewController, context: Context) {}
+}
+
+// MARK: - Overlay Browser Modifier
+
+struct OverlayBrowserModifier: ViewModifier {
+    @Binding var context: BrowserContext?
+    @AppStorage(UserDefaultsKeys.browserMode) private var browserMode: String = "external"
+
+    private var isActive: Bool { browserMode == "overlay" && context != nil }
+
+    func body(content: Content) -> some View {
+        content
+            .overlay {
+                if browserMode == "overlay", let ctx = context {
+                    OverlayBrowserScreen(context: ctx) { context = nil }
+                        .transition(.move(edge: .top).combined(with: .opacity))
+                        .ignoresSafeArea(edges: .all)
+                }
+            }
+            .animation(.easeInOut(duration: 0.35), value: isActive)
+            .sheet(item: browserMode != "overlay" ? $context : .constant(nil)) { ctx in
+                SafariView(url: ctx.url)
+                    .ignoresSafeArea()
+            }
+    }
+}
+
+extension View {
+    func overlayBrowser(context: Binding<BrowserContext?>) -> some View {
+        modifier(OverlayBrowserModifier(context: context))
+    }
+}
+
+// MARK: - Web Layer (behind original content)
+
+struct OverlayBrowserScreen: View {
+    @Environment(\.openURL) private var openURL
+    let context: BrowserContext
+    let onDismiss: () -> Void
+    @State private var currentURL: URL?
+    @State private var showShareSheet = false
+    private var displayURL: URL { currentURL ?? context.url }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            WebViewRepresentable(url: context.url, currentURL: $currentURL)
+
+            toolbarView
+
+            if context.entryName != nil {
+                entryCard
+                    .contentShape(Rectangle())
+                    .gesture(
+                        DragGesture()
+                            .onEnded { value in
+                                if value.translation.height < -60 {
+                                    onDismiss()
+                                }
+                            }
+                    )
+            }
+        }
+        .background(Color(.systemBackground))
+        .sheet(isPresented: $showShareSheet) {
+            ShareSheet(url: displayURL)
+        }
+    }
+
+    @ViewBuilder
+    private var toolbarView: some View {
+        HStack(spacing: 0) {
+            Button { onDismiss() } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 32, height: 32)
+                    .background(Color(.systemGray5))
+                    .clipShape(Circle())
+            }
+
+            Spacer()
+
+            Menu {
+                Button {
+                    showShareSheet = true
+                } label: {
+                    Label("共有する", systemImage: "square.and.arrow.up")
+                }
+                Button {
+                    openURL(displayURL)
+                } label: {
+                    Label("ブラウザで開く", systemImage: "safari")
+                }
+                Button {
+                    UIPasteboard.general.url = displayURL
+                } label: {
+                    Label("リンクをコピー", systemImage: "doc.on.doc")
+                }
+            } label: {
+                HStack(spacing: 4) {
+                    Text(displayURL.host ?? "")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                    Image(systemName: "ellipsis")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(Color(.systemGray5))
+                .clipShape(Capsule())
+            }
+
+            Spacer()
+
+            Button {} label: {
+                Image(systemName: "arrow.clockwise")
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 32, height: 32)
+                    .background(Color(.systemGray5))
+                    .clipShape(Circle())
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+    }
+
+    @ViewBuilder
+    private var entryCard: some View {
+        Divider()
+        HStack(spacing: 12) {
+            if let data = context.entryImageData, let image = data.toSwiftUIImage() {
+                image
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: 44, height: 44)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+            }
+            VStack(alignment: .leading, spacing: 2) {
+                if let name = context.entryName {
+                    Text(name)
+                        .font(.subheadline.bold())
+                        .lineLimit(1)
+                }
+                if let publisher = context.entryPublisher, !publisher.isEmpty {
+                    Text(publisher)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+}
+
+// MARK: - WebView
+
+private struct WebViewRepresentable: UIViewRepresentable {
+    let url: URL
+    @Binding var currentURL: URL?
+
+    func makeUIView(context: Context) -> WKWebView {
+        let webView = WKWebView()
+        webView.navigationDelegate = context.coordinator
+        webView.load(URLRequest(url: url))
+        return webView
+    }
+
+    func updateUIView(_ uiView: WKWebView, context: Context) {}
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(currentURL: $currentURL)
+    }
+
+    final class Coordinator: NSObject, WKNavigationDelegate {
+        @Binding var currentURL: URL?
+
+        init(currentURL: Binding<URL?>) {
+            _currentURL = currentURL
+        }
+
+        func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
+            currentURL = webView.url
+        }
+    }
+}
+
+// MARK: - Share Sheet
+
+private struct ShareSheet: UIViewControllerRepresentable {
+    let url: URL
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: [url], applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
 }
 #endif

--- a/MangaLauncher/Views/Common/SafariView.swift
+++ b/MangaLauncher/Views/Common/SafariView.swift
@@ -55,6 +55,7 @@ struct OverlayBrowserScreen: View {
     @State private var isRevealed = false
     @State private var snapshot: UIImage?
     @State private var dragOffset: CGFloat = 0
+    @State private var reloadID = UUID()
     private var displayURL: URL { currentURL ?? context.url }
     private let screenHeight = UIScreen.main.bounds.height
 
@@ -68,46 +69,49 @@ struct OverlayBrowserScreen: View {
         return max(0, 1.0 + Double(dragOffset) / (Double(screenHeight) * 0.25))
     }
 
+    private var safeAreaTop: CGFloat {
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first?.windows.first?.safeAreaInsets.top ?? 0
+    }
+
     var body: some View {
-        ZStack {
+        ZStack(alignment: .bottom) {
             VStack(spacing: 0) {
                 Color(.systemBackground)
-                    .frame(height: UIApplication.shared.connectedScenes
-                        .compactMap { $0 as? UIWindowScene }
-                        .first?.windows.first?.safeAreaInsets.top ?? 0)
+                    .frame(height: safeAreaTop)
 
                 WebViewRepresentable(url: context.url, currentURL: $currentURL)
-
-                VStack(spacing: 0) {
-                    toolbarView
-
-                    if context.entryName != nil {
-                        entryCard
-                    }
-                }
-                .background(Color(.systemBackground))
-                .offset(y: dragOffset < 0 ? dragOffset : 0)
-                .opacity(bottomBarOpacity)
-                .contentShape(Rectangle())
-                .gesture(
-                    DragGesture()
-                        .onChanged { value in
-                            if value.translation.height < 0 {
-                                dragOffset = value.translation.height
-                            }
-                        }
-                        .onEnded { value in
-                            if abs(dragOffset) > screenHeight * 0.3 || value.predictedEndTranslation.height < -200 {
-                                dismissAnimated()
-                            } else {
-                                withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
-                                    dragOffset = 0
-                                }
-                            }
-                        }
-                )
+                    .id(reloadID)
             }
-            .background(Color(.systemBackground))
+
+            VStack(spacing: 0) {
+                toolbarView
+
+                if context.entryName != nil {
+                    entryCard
+                }
+            }
+            .offset(y: dragOffset < 0 ? dragOffset : 0)
+            .opacity(bottomBarOpacity)
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture()
+                    .onChanged { value in
+                        if value.translation.height < 0 {
+                            dragOffset = value.translation.height
+                        }
+                    }
+                    .onEnded { value in
+                        if abs(dragOffset) > screenHeight * 0.3 || value.predictedEndTranslation.height < -200 {
+                            dismissAnimated()
+                        } else {
+                            withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                                dragOffset = 0
+                            }
+                        }
+                    }
+            )
 
             if let snapshot {
                 let coverOpacity = isRevealed ? min(1.0, abs(dragOffset) / (screenHeight * 0.3)) : 1.0
@@ -153,13 +157,13 @@ struct OverlayBrowserScreen: View {
 
     @ViewBuilder
     private var toolbarView: some View {
-        HStack(spacing: 0) {
+        HStack(spacing: 8) {
             Button { dismissAnimated() } label: {
                 Image(systemName: "xmark")
                     .font(.system(size: 12, weight: .bold))
-                    .foregroundStyle(.secondary)
-                    .frame(width: 32, height: 32)
-                    .background(Color(.systemGray5))
+                    .foregroundColor(.white)
+                    .frame(width: 36, height: 36)
+                    .background(.black.opacity(0.85))
                     .clipShape(Circle())
             }
 
@@ -184,37 +188,35 @@ struct OverlayBrowserScreen: View {
             } label: {
                 HStack(spacing: 4) {
                     Text(displayURL.host ?? "")
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
+                        .font(.footnote.weight(.medium))
                         .lineLimit(1)
                     Image(systemName: "ellipsis")
                         .font(.system(size: 10, weight: .bold))
-                        .foregroundStyle(.secondary)
                 }
-                .padding(.horizontal, 12)
-                .padding(.vertical, 6)
-                .background(Color(.systemGray5))
+                .foregroundColor(.white)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 8)
+                .background(.black.opacity(0.85))
                 .clipShape(Capsule())
             }
 
             Spacer()
 
-            Button {} label: {
+            Button { reloadID = UUID() } label: {
                 Image(systemName: "arrow.clockwise")
                     .font(.system(size: 12, weight: .bold))
-                    .foregroundStyle(.secondary)
-                    .frame(width: 32, height: 32)
-                    .background(Color(.systemGray5))
+                    .foregroundColor(.white)
+                    .frame(width: 36, height: 36)
+                    .background(.black.opacity(0.85))
                     .clipShape(Circle())
             }
         }
-        .padding(.horizontal, 12)
+        .padding(.horizontal, 10)
         .padding(.vertical, 6)
     }
 
     @ViewBuilder
     private var entryCard: some View {
-        Divider()
         HStack(spacing: 12) {
             if let data = context.entryImageData, let image = data.toSwiftUIImage() {
                 image
@@ -227,12 +229,13 @@ struct OverlayBrowserScreen: View {
                 if let name = context.entryName {
                     Text(name)
                         .font(.subheadline.bold())
+                        .foregroundColor(.white)
                         .lineLimit(1)
                 }
                 if let publisher = context.entryPublisher, !publisher.isEmpty {
                     Text(publisher)
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(.white.opacity(0.7))
                 }
             }
             Spacer()
@@ -242,6 +245,7 @@ struct OverlayBrowserScreen: View {
         .padding(.bottom, UIApplication.shared.connectedScenes
             .compactMap { $0 as? UIWindowScene }
             .first?.windows.first?.safeAreaInsets.bottom ?? 0)
+        .background(.black.opacity(0.85))
     }
 }
 

--- a/MangaLauncher/Views/Common/SafariView.swift
+++ b/MangaLauncher/Views/Common/SafariView.swift
@@ -54,8 +54,19 @@ struct OverlayBrowserScreen: View {
     @State private var showShareSheet = false
     @State private var isRevealed = false
     @State private var snapshot: UIImage?
+    @State private var dragOffset: CGFloat = 0
     private var displayURL: URL { currentURL ?? context.url }
     private let screenHeight = UIScreen.main.bounds.height
+
+    private var coverOffset: CGFloat {
+        if !isRevealed { return 0 }
+        return max(0, screenHeight + dragOffset * 2.5)
+    }
+
+    private var bottomBarOpacity: Double {
+        if dragOffset >= 0 { return 1.0 }
+        return max(0, 1.0 + Double(dragOffset) / (Double(screenHeight) * 0.25))
+    }
 
     var body: some View {
         ZStack {
@@ -67,29 +78,45 @@ struct OverlayBrowserScreen: View {
 
                 WebViewRepresentable(url: context.url, currentURL: $currentURL)
 
-                toolbarView
+                VStack(spacing: 0) {
+                    toolbarView
 
-                if context.entryName != nil {
-                    entryCard
-                        .contentShape(Rectangle())
-                        .gesture(
-                            DragGesture()
-                                .onEnded { value in
-                                    if value.translation.height < -60 {
-                                        dismissAnimated()
-                                    }
-                                }
-                        )
+                    if context.entryName != nil {
+                        entryCard
+                    }
                 }
+                .background(Color(.systemBackground))
+                .offset(y: dragOffset < 0 ? dragOffset : 0)
+                .opacity(bottomBarOpacity)
+                .contentShape(Rectangle())
+                .gesture(
+                    DragGesture()
+                        .onChanged { value in
+                            if value.translation.height < 0 {
+                                dragOffset = value.translation.height
+                            }
+                        }
+                        .onEnded { value in
+                            if abs(dragOffset) > screenHeight * 0.3 || value.predictedEndTranslation.height < -200 {
+                                dismissAnimated()
+                            } else {
+                                withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                                    dragOffset = 0
+                                }
+                            }
+                        }
+                )
             }
             .background(Color(.systemBackground))
 
             if let snapshot {
+                let coverOpacity = isRevealed ? min(1.0, abs(dragOffset) / (screenHeight * 0.3)) : 1.0
                 Image(uiImage: snapshot)
                     .resizable()
                     .scaledToFill()
                     .ignoresSafeArea()
-                    .offset(y: isRevealed ? screenHeight : 0)
+                    .offset(y: coverOffset)
+                    .opacity(coverOpacity)
                     .allowsHitTesting(false)
             }
         }
@@ -98,7 +125,7 @@ struct OverlayBrowserScreen: View {
         }
         .onAppear {
             snapshot = captureScreenshot()
-            withAnimation(.easeInOut(duration: 0.35)) {
+            withAnimation(.spring(response: 0.45, dampingFraction: 0.85)) {
                 isRevealed = true
             }
         }
@@ -115,10 +142,11 @@ struct OverlayBrowserScreen: View {
     }
 
     private func dismissAnimated() {
-        withAnimation(.easeInOut(duration: 0.3)) {
+        withAnimation(.spring(response: 0.35, dampingFraction: 0.9)) {
             isRevealed = false
+            dragOffset = 0
         }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
             onDismiss()
         }
     }

--- a/MangaLauncher/Views/Common/SafariView.swift
+++ b/MangaLauncher/Views/Common/SafariView.swift
@@ -26,6 +26,7 @@ struct QuickViewBrowserScreen: View {
     @State private var snapshot: UIImage?
     @State private var dragOffset: CGFloat = 0
     @State private var reloadID = UUID()
+    @State private var showControls = true
     private var displayURL: URL { currentURL ?? context.url }
     private let screenHeight = UIScreen.main.bounds.height
 
@@ -52,19 +53,25 @@ struct QuickViewBrowserScreen: View {
                 Color(.systemBackground)
                     .frame(height: safeAreaTop)
 
-                WebViewRepresentable(url: context.url, currentURL: $currentURL, reloadTrigger: $reloadID)
+                WebViewRepresentable(url: context.url, currentURL: $currentURL, reloadTrigger: $reloadID, onCenterTap: {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        showControls.toggle()
+                    }
+                })
             }
 
-            VStack(spacing: 0) {
-                toolbarView
+            if showControls {
+                VStack(spacing: 0) {
+                    toolbarView
 
-                if context.entryName != nil {
-                    entryCard
+                    if context.entryName != nil {
+                        entryCard
+                    }
                 }
-            }
-            .offset(y: dragOffset < 0 ? dragOffset : 0)
-            .opacity(bottomBarOpacity)
-            .contentShape(Rectangle())
+                .offset(y: dragOffset < 0 ? dragOffset : 0)
+                .opacity(bottomBarOpacity)
+                .contentShape(Rectangle())
+                .transition(.move(edge: .bottom).combined(with: .opacity))
             .gesture(
                 DragGesture()
                     .onChanged { value in
@@ -82,6 +89,7 @@ struct QuickViewBrowserScreen: View {
                         }
                     }
             )
+            }
 
             if let snapshot {
                 let coverOpacity = isRevealed ? min(1.0, abs(dragOffset) / (screenHeight * 0.3)) : 1.0
@@ -236,16 +244,23 @@ private struct WebViewRepresentable: UIViewRepresentable {
     let url: URL
     @Binding var currentURL: URL?
     @Binding var reloadTrigger: UUID
+    var onCenterTap: (() -> Void)?
 
     func makeUIView(context: Context) -> WKWebView {
         let webView = WKWebView()
         webView.navigationDelegate = context.coordinator
         webView.load(URLRequest(url: url))
         context.coordinator.webView = webView
+
+        let tap = UITapGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handleTap(_:)))
+        tap.delegate = context.coordinator
+        webView.addGestureRecognizer(tap)
+
         return webView
     }
 
     func updateUIView(_ uiView: WKWebView, context: Context) {
+        context.coordinator.onCenterTap = onCenterTap
         if context.coordinator.lastReloadTrigger != reloadTrigger {
             context.coordinator.lastReloadTrigger = reloadTrigger
             uiView.reload()
@@ -253,21 +268,41 @@ private struct WebViewRepresentable: UIViewRepresentable {
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(currentURL: $currentURL, reloadTrigger: reloadTrigger)
+        Coordinator(currentURL: $currentURL, reloadTrigger: reloadTrigger, onCenterTap: onCenterTap)
     }
 
-    final class Coordinator: NSObject, WKNavigationDelegate {
+    final class Coordinator: NSObject, WKNavigationDelegate, UIGestureRecognizerDelegate {
         @Binding var currentURL: URL?
         weak var webView: WKWebView?
         var lastReloadTrigger: UUID
+        var onCenterTap: (() -> Void)?
 
-        init(currentURL: Binding<URL?>, reloadTrigger: UUID) {
+        init(currentURL: Binding<URL?>, reloadTrigger: UUID, onCenterTap: (() -> Void)?) {
             _currentURL = currentURL
             self.lastReloadTrigger = reloadTrigger
+            self.onCenterTap = onCenterTap
         }
 
         func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
             currentURL = webView.url
+        }
+
+        @objc func handleTap(_ gesture: UITapGestureRecognizer) {
+            guard let webView = gesture.view as? WKWebView else { return }
+            let location = gesture.location(in: webView)
+
+            let js = "document.elementFromPoint(\(location.x), \(location.y))?.closest('a, button, [onclick]') !== null"
+            webView.evaluateJavaScript(js) { [weak self] result, _ in
+                if let isInteractive = result as? Bool, !isInteractive {
+                    DispatchQueue.main.async {
+                        self?.onCenterTap?()
+                    }
+                }
+            }
+        }
+
+        func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+            true
         }
     }
 }

--- a/MangaLauncher/Views/Common/SafariView.swift
+++ b/MangaLauncher/Views/Common/SafariView.swift
@@ -48,6 +48,7 @@ extension View {
 
 struct OverlayBrowserScreen: View {
     @Environment(\.openURL) private var openURL
+    @Environment(\.scenePhase) private var scenePhase
     let context: BrowserContext
     let onDismiss: () -> Void
     @State private var currentURL: URL?
@@ -131,6 +132,15 @@ struct OverlayBrowserScreen: View {
             snapshot = captureScreenshot()
             withAnimation(.spring(response: 0.45, dampingFraction: 0.85)) {
                 isRevealed = true
+            }
+        }
+        .onChange(of: scenePhase) { _, newPhase in
+            if newPhase == .active {
+                var transaction = Transaction()
+                transaction.disablesAnimations = true
+                withTransaction(transaction) {
+                    dragOffset = 0
+                }
             }
         }
     }

--- a/MangaLauncher/Views/Common/SafariView.swift
+++ b/MangaLauncher/Views/Common/SafariView.swift
@@ -53,12 +53,18 @@ struct OverlayBrowserScreen: View {
     @State private var currentURL: URL?
     @State private var showShareSheet = false
     @State private var isRevealed = false
+    @State private var snapshot: UIImage?
     private var displayURL: URL { currentURL ?? context.url }
     private let screenHeight = UIScreen.main.bounds.height
 
     var body: some View {
         ZStack {
             VStack(spacing: 0) {
+                Color(.systemBackground)
+                    .frame(height: UIApplication.shared.connectedScenes
+                        .compactMap { $0 as? UIWindowScene }
+                        .first?.windows.first?.safeAreaInsets.top ?? 0)
+
                 WebViewRepresentable(url: context.url, currentURL: $currentURL)
 
                 toolbarView
@@ -78,18 +84,33 @@ struct OverlayBrowserScreen: View {
             }
             .background(Color(.systemBackground))
 
-            Color(.systemBackground)
-                .ignoresSafeArea()
-                .offset(y: isRevealed ? screenHeight : 0)
-                .allowsHitTesting(false)
+            if let snapshot {
+                Image(uiImage: snapshot)
+                    .resizable()
+                    .scaledToFill()
+                    .ignoresSafeArea()
+                    .offset(y: isRevealed ? screenHeight : 0)
+                    .allowsHitTesting(false)
+            }
         }
         .sheet(isPresented: $showShareSheet) {
             ShareSheet(url: displayURL)
         }
         .onAppear {
+            snapshot = captureScreenshot()
             withAnimation(.easeInOut(duration: 0.35)) {
                 isRevealed = true
             }
+        }
+    }
+
+    private func captureScreenshot() -> UIImage? {
+        guard let window = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .first?.windows.first else { return nil }
+        let renderer = UIGraphicsImageRenderer(bounds: window.bounds)
+        return renderer.image { _ in
+            window.drawHierarchy(in: window.bounds, afterScreenUpdates: false)
         }
     }
 
@@ -190,6 +211,9 @@ struct OverlayBrowserScreen: View {
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 12)
+        .padding(.bottom, UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first?.windows.first?.safeAreaInsets.bottom ?? 0)
     }
 }
 

--- a/MangaLauncher/Views/Heatmap/MangaLifetimeView.swift
+++ b/MangaLauncher/Views/Heatmap/MangaLifetimeView.swift
@@ -154,7 +154,15 @@ struct MangaLifetimeView: View {
     }
 
     private func openMangaURL(_ urlString: String) {
-        MangaURLOpener(browserMode: browserMode, openURL: openURL) { safariURL = $0 }.open(urlString)
+        guard let url = URL(string: urlString) else { return }
+        let entry = viewModel.allEntries().first { $0.url == urlString }
+        if browserMode == "overlay" {
+            viewModel.browserContext = BrowserContext(url: url, entryName: entry?.name, entryPublisher: entry?.publisher, entryImageData: entry?.imageData)
+        } else if browserMode == "inApp" {
+            safariURL = url
+        } else {
+            openURL(url)
+        }
     }
 
     // MARK: - Domain
@@ -310,7 +318,15 @@ struct LifetimeDetailSheet: View {
     }
 
     private func openDetailURL(_ urlString: String) {
-        MangaURLOpener(browserMode: browserMode, openURL: openURL) { safariURL = $0 }.open(urlString)
+        guard let url = URL(string: urlString) else { return }
+        let entry = viewModel.allEntries().first { $0.url == urlString }
+        if browserMode == "overlay" {
+            viewModel.browserContext = BrowserContext(url: url, entryName: entry?.name, entryPublisher: entry?.publisher, entryImageData: entry?.imageData)
+        } else if browserMode == "inApp" {
+            safariURL = url
+        } else {
+            openURL(url)
+        }
     }
 
     @ViewBuilder

--- a/MangaLauncher/Views/Heatmap/MangaLifetimeView.swift
+++ b/MangaLauncher/Views/Heatmap/MangaLifetimeView.swift
@@ -154,15 +154,16 @@ struct MangaLifetimeView: View {
     }
 
     private func openMangaURL(_ urlString: String) {
-        guard let url = URL(string: urlString) else { return }
-        let entry = viewModel.allEntries().first { $0.url == urlString }
-        if browserMode == "quickView" {
-            viewModel.browserContext = BrowserContext(url: url, entryName: entry?.name, entryPublisher: entry?.publisher, entryImageData: entry?.imageData)
-        } else if browserMode == "inApp" {
-            safariURL = url
-        } else {
-            openURL(url)
-        }
+        MangaURLOpener(
+            browserMode: browserMode,
+            openURL: openURL,
+            onSafariURL: { safariURL = $0 },
+            onQuickView: { viewModel.browserContext = $0 },
+            entryLookup: { url in
+                guard let e = viewModel.allEntries().first(where: { $0.url == url }) else { return nil }
+                return (e.name, e.publisher, e.imageData)
+            }
+        ).open(urlString)
     }
 
     // MARK: - Domain
@@ -318,15 +319,16 @@ struct LifetimeDetailSheet: View {
     }
 
     private func openDetailURL(_ urlString: String) {
-        guard let url = URL(string: urlString) else { return }
-        let entry = viewModel.allEntries().first { $0.url == urlString }
-        if browserMode == "quickView" {
-            viewModel.browserContext = BrowserContext(url: url, entryName: entry?.name, entryPublisher: entry?.publisher, entryImageData: entry?.imageData)
-        } else if browserMode == "inApp" {
-            safariURL = url
-        } else {
-            openURL(url)
-        }
+        MangaURLOpener(
+            browserMode: browserMode,
+            openURL: openURL,
+            onSafariURL: { safariURL = $0 },
+            onQuickView: { viewModel.browserContext = $0 },
+            entryLookup: { url in
+                guard let e = viewModel.allEntries().first(where: { $0.url == url }) else { return nil }
+                return (e.name, e.publisher, e.imageData)
+            }
+        ).open(urlString)
     }
 
     @ViewBuilder

--- a/MangaLauncher/Views/Heatmap/MangaLifetimeView.swift
+++ b/MangaLauncher/Views/Heatmap/MangaLifetimeView.swift
@@ -156,7 +156,7 @@ struct MangaLifetimeView: View {
     private func openMangaURL(_ urlString: String) {
         guard let url = URL(string: urlString) else { return }
         let entry = viewModel.allEntries().first { $0.url == urlString }
-        if browserMode == "overlay" {
+        if browserMode == "quickView" {
             viewModel.browserContext = BrowserContext(url: url, entryName: entry?.name, entryPublisher: entry?.publisher, entryImageData: entry?.imageData)
         } else if browserMode == "inApp" {
             safariURL = url
@@ -320,7 +320,7 @@ struct LifetimeDetailSheet: View {
     private func openDetailURL(_ urlString: String) {
         guard let url = URL(string: urlString) else { return }
         let entry = viewModel.allEntries().first { $0.url == urlString }
-        if browserMode == "overlay" {
+        if browserMode == "quickView" {
             viewModel.browserContext = BrowserContext(url: url, entryName: entry?.name, entryPublisher: entry?.publisher, entryImageData: entry?.imageData)
         } else if browserMode == "inApp" {
             safariURL = url

--- a/MangaLauncher/Views/Heatmap/ReadingHeatmapView.swift
+++ b/MangaLauncher/Views/Heatmap/ReadingHeatmapView.swift
@@ -337,7 +337,7 @@ private struct DayActivitySheet: View {
             }
             #if canImport(UIKit)
             .sheet(item: $safariURL) { url in
-                SafariView(url: url)
+                SafariView(url: url).ignoresSafeArea()
             }
             #endif
             .sheet(isPresented: $showingDatePicker) {
@@ -391,7 +391,15 @@ private struct DayActivitySheet: View {
     }
 
     private func openMangaURL(_ urlString: String) {
-        MangaURLOpener(browserMode: browserMode, openURL: openURL) { safariURL = $0 }.open(urlString)
+        guard let url = URL(string: urlString) else { return }
+        let entry = viewModel.allEntries().first { $0.url == urlString }
+        if browserMode == "overlay" {
+            viewModel.browserContext = BrowserContext(url: url, entryName: entry?.name, entryPublisher: entry?.publisher, entryImageData: entry?.imageData)
+        } else if browserMode == "inApp" {
+            safariURL = url
+        } else {
+            openURL(url)
+        }
     }
 
     @ViewBuilder

--- a/MangaLauncher/Views/Heatmap/ReadingHeatmapView.swift
+++ b/MangaLauncher/Views/Heatmap/ReadingHeatmapView.swift
@@ -393,7 +393,7 @@ private struct DayActivitySheet: View {
     private func openMangaURL(_ urlString: String) {
         guard let url = URL(string: urlString) else { return }
         let entry = viewModel.allEntries().first { $0.url == urlString }
-        if browserMode == "overlay" {
+        if browserMode == "quickView" {
             viewModel.browserContext = BrowserContext(url: url, entryName: entry?.name, entryPublisher: entry?.publisher, entryImageData: entry?.imageData)
         } else if browserMode == "inApp" {
             safariURL = url

--- a/MangaLauncher/Views/Heatmap/ReadingHeatmapView.swift
+++ b/MangaLauncher/Views/Heatmap/ReadingHeatmapView.swift
@@ -391,15 +391,16 @@ private struct DayActivitySheet: View {
     }
 
     private func openMangaURL(_ urlString: String) {
-        guard let url = URL(string: urlString) else { return }
-        let entry = viewModel.allEntries().first { $0.url == urlString }
-        if browserMode == "quickView" {
-            viewModel.browserContext = BrowserContext(url: url, entryName: entry?.name, entryPublisher: entry?.publisher, entryImageData: entry?.imageData)
-        } else if browserMode == "inApp" {
-            safariURL = url
-        } else {
-            openURL(url)
-        }
+        MangaURLOpener(
+            browserMode: browserMode,
+            openURL: openURL,
+            onSafariURL: { safariURL = $0 },
+            onQuickView: { viewModel.browserContext = $0 },
+            entryLookup: { url in
+                guard let e = viewModel.allEntries().first(where: { $0.url == url }) else { return nil }
+                return (e.name, e.publisher, e.imageData)
+            }
+        ).open(urlString)
     }
 
     @ViewBuilder

--- a/MangaLauncher/Views/Home/ContentView.swift
+++ b/MangaLauncher/Views/Home/ContentView.swift
@@ -18,6 +18,7 @@ struct ContentView: View {
     @State private var homeState = HomeState()
     @AppStorage(UserDefaultsKeys.displayMode) private var displayMode: DisplayMode = .grid
     @AppStorage(UserDefaultsKeys.browserMode) private var browserMode: String = "external"
+    @State private var safariURL: URL?
 
     @Namespace private var tabUnderline
 
@@ -151,9 +152,8 @@ struct ContentView: View {
             }
         }
         #if canImport(UIKit)
-        .sheet(item: $homeState.safariURL) { url in
-            SafariView(url: url)
-                .ignoresSafeArea()
+        .sheet(item: $safariURL) { url in
+            SafariView(url: url).ignoresSafeArea()
         }
         #endif
     }
@@ -199,7 +199,15 @@ struct ContentView: View {
     // MARK: - Helpers
 
     private func openMangaURL(_ urlString: String) {
-        MangaURLOpener(browserMode: browserMode, openURL: openURL) { homeState.safariURL = $0 }.open(urlString)
+        guard let url = URL(string: urlString) else { return }
+        let entry = viewModel.allEntries().first { $0.url == urlString }
+        if browserMode == "overlay" {
+            viewModel.browserContext = BrowserContext(url: url, entryName: entry?.name, entryPublisher: entry?.publisher, entryImageData: entry?.imageData)
+        } else if browserMode == "inApp" {
+            safariURL = url
+        } else {
+            openURL(url)
+        }
     }
 }
 

--- a/MangaLauncher/Views/Home/ContentView.swift
+++ b/MangaLauncher/Views/Home/ContentView.swift
@@ -201,7 +201,7 @@ struct ContentView: View {
     private func openMangaURL(_ urlString: String) {
         guard let url = URL(string: urlString) else { return }
         let entry = viewModel.allEntries().first { $0.url == urlString }
-        if browserMode == "overlay" {
+        if browserMode == "quickView" {
             viewModel.browserContext = BrowserContext(url: url, entryName: entry?.name, entryPublisher: entry?.publisher, entryImageData: entry?.imageData)
         } else if browserMode == "inApp" {
             safariURL = url

--- a/MangaLauncher/Views/Home/ContentView.swift
+++ b/MangaLauncher/Views/Home/ContentView.swift
@@ -199,15 +199,16 @@ struct ContentView: View {
     // MARK: - Helpers
 
     private func openMangaURL(_ urlString: String) {
-        guard let url = URL(string: urlString) else { return }
-        let entry = viewModel.allEntries().first { $0.url == urlString }
-        if browserMode == "quickView" {
-            viewModel.browserContext = BrowserContext(url: url, entryName: entry?.name, entryPublisher: entry?.publisher, entryImageData: entry?.imageData)
-        } else if browserMode == "inApp" {
-            safariURL = url
-        } else {
-            openURL(url)
-        }
+        MangaURLOpener(
+            browserMode: browserMode,
+            openURL: openURL,
+            onSafariURL: { safariURL = $0 },
+            onQuickView: { viewModel.browserContext = $0 },
+            entryLookup: { url in
+                guard let e = viewModel.allEntries().first(where: { $0.url == url }) else { return nil }
+                return (e.name, e.publisher, e.imageData)
+            }
+        ).open(urlString)
     }
 }
 

--- a/MangaLauncher/Views/Library/HiddenEntriesView.swift
+++ b/MangaLauncher/Views/Library/HiddenEntriesView.swift
@@ -66,7 +66,7 @@ struct HiddenEntriesView: View {
     private func openMangaURL(_ urlString: String) {
         guard let url = URL(string: urlString) else { return }
         let entry = entries.first { $0.url == urlString }
-        if browserMode == "overlay" {
+        if browserMode == "quickView" {
             viewModel.browserContext = BrowserContext(url: url, entryName: entry?.name, entryPublisher: entry?.publisher, entryImageData: entry?.imageData)
         } else if browserMode == "inApp" {
             safariURL = url

--- a/MangaLauncher/Views/Library/HiddenEntriesView.swift
+++ b/MangaLauncher/Views/Library/HiddenEntriesView.swift
@@ -64,15 +64,16 @@ struct HiddenEntriesView: View {
     }
 
     private func openMangaURL(_ urlString: String) {
-        guard let url = URL(string: urlString) else { return }
-        let entry = entries.first { $0.url == urlString }
-        if browserMode == "quickView" {
-            viewModel.browserContext = BrowserContext(url: url, entryName: entry?.name, entryPublisher: entry?.publisher, entryImageData: entry?.imageData)
-        } else if browserMode == "inApp" {
-            safariURL = url
-        } else {
-            openURL(url)
-        }
+        MangaURLOpener(
+            browserMode: browserMode,
+            openURL: openURL,
+            onSafariURL: { safariURL = $0 },
+            onQuickView: { viewModel.browserContext = $0 },
+            entryLookup: { url in
+                guard let e = entries.first(where: { $0.url == url }) else { return nil }
+                return (e.name, e.publisher, e.imageData)
+            }
+        ).open(urlString)
     }
 
     @ViewBuilder

--- a/MangaLauncher/Views/Library/HiddenEntriesView.swift
+++ b/MangaLauncher/Views/Library/HiddenEntriesView.swift
@@ -64,7 +64,15 @@ struct HiddenEntriesView: View {
     }
 
     private func openMangaURL(_ urlString: String) {
-        MangaURLOpener(browserMode: browserMode, openURL: openURL) { safariURL = $0 }.open(urlString)
+        guard let url = URL(string: urlString) else { return }
+        let entry = entries.first { $0.url == urlString }
+        if browserMode == "overlay" {
+            viewModel.browserContext = BrowserContext(url: url, entryName: entry?.name, entryPublisher: entry?.publisher, entryImageData: entry?.imageData)
+        } else if browserMode == "inApp" {
+            safariURL = url
+        } else {
+            openURL(url)
+        }
     }
 
     @ViewBuilder

--- a/MangaLauncher/Views/Library/LibraryView.swift
+++ b/MangaLauncher/Views/Library/LibraryView.swift
@@ -50,8 +50,7 @@ struct LibraryView: View {
             }
             #if canImport(UIKit)
             .sheet(item: $safariURL) { url in
-                SafariView(url: url)
-                    .ignoresSafeArea()
+                SafariView(url: url).ignoresSafeArea()
             }
             #endif
             .onAppear {
@@ -288,6 +287,14 @@ struct LibraryView: View {
     }
 
     private func openMangaURL(_ urlString: String) {
-        MangaURLOpener(browserMode: browserMode, openURL: openURL) { safariURL = $0 }.open(urlString)
+        guard let url = URL(string: urlString) else { return }
+        let entry = viewModel.allEntries().first { $0.url == urlString }
+        if browserMode == "overlay" {
+            viewModel.browserContext = BrowserContext(url: url, entryName: entry?.name, entryPublisher: entry?.publisher, entryImageData: entry?.imageData)
+        } else if browserMode == "inApp" {
+            safariURL = url
+        } else {
+            openURL(url)
+        }
     }
 }

--- a/MangaLauncher/Views/Library/LibraryView.swift
+++ b/MangaLauncher/Views/Library/LibraryView.swift
@@ -289,7 +289,7 @@ struct LibraryView: View {
     private func openMangaURL(_ urlString: String) {
         guard let url = URL(string: urlString) else { return }
         let entry = viewModel.allEntries().first { $0.url == urlString }
-        if browserMode == "overlay" {
+        if browserMode == "quickView" {
             viewModel.browserContext = BrowserContext(url: url, entryName: entry?.name, entryPublisher: entry?.publisher, entryImageData: entry?.imageData)
         } else if browserMode == "inApp" {
             safariURL = url

--- a/MangaLauncher/Views/Library/LibraryView.swift
+++ b/MangaLauncher/Views/Library/LibraryView.swift
@@ -287,14 +287,15 @@ struct LibraryView: View {
     }
 
     private func openMangaURL(_ urlString: String) {
-        guard let url = URL(string: urlString) else { return }
-        let entry = viewModel.allEntries().first { $0.url == urlString }
-        if browserMode == "quickView" {
-            viewModel.browserContext = BrowserContext(url: url, entryName: entry?.name, entryPublisher: entry?.publisher, entryImageData: entry?.imageData)
-        } else if browserMode == "inApp" {
-            safariURL = url
-        } else {
-            openURL(url)
-        }
+        MangaURLOpener(
+            browserMode: browserMode,
+            openURL: openURL,
+            onSafariURL: { safariURL = $0 },
+            onQuickView: { viewModel.browserContext = $0 },
+            entryLookup: { url in
+                guard let e = viewModel.allEntries().first(where: { $0.url == url }) else { return nil }
+                return (e.name, e.publisher, e.imageData)
+            }
+        ).open(urlString)
     }
 }

--- a/MangaLauncher/Views/Library/Timeline/TimelineView.swift
+++ b/MangaLauncher/Views/Library/Timeline/TimelineView.swift
@@ -124,8 +124,7 @@ struct TimelineView: View {
         }
         #if canImport(UIKit)
         .sheet(item: $safariURL) { url in
-            SafariView(url: url)
-                .ignoresSafeArea()
+            SafariView(url: url).ignoresSafeArea()
         }
         #endif
         .sheet(item: $lifetimeEntry) { entry in
@@ -250,7 +249,19 @@ struct TimelineView: View {
             editingEntry = entry
         case .read(_, let entry):
             guard let entry else { return }
-            MangaURLOpener(browserMode: browserMode, openURL: openURL) { safariURL = $0 }.open(entry.url)
+            openMangaURL(entry.url)
+        }
+    }
+
+    private func openMangaURL(_ urlString: String) {
+        guard let url = URL(string: urlString) else { return }
+        let entry = viewModel.allEntries().first { $0.url == urlString }
+        if browserMode == "overlay" {
+            viewModel.browserContext = BrowserContext(url: url, entryName: entry?.name, entryPublisher: entry?.publisher, entryImageData: entry?.imageData)
+        } else if browserMode == "inApp" {
+            safariURL = url
+        } else {
+            openURL(url)
         }
     }
 

--- a/MangaLauncher/Views/Library/Timeline/TimelineView.swift
+++ b/MangaLauncher/Views/Library/Timeline/TimelineView.swift
@@ -256,7 +256,7 @@ struct TimelineView: View {
     private func openMangaURL(_ urlString: String) {
         guard let url = URL(string: urlString) else { return }
         let entry = viewModel.allEntries().first { $0.url == urlString }
-        if browserMode == "overlay" {
+        if browserMode == "quickView" {
             viewModel.browserContext = BrowserContext(url: url, entryName: entry?.name, entryPublisher: entry?.publisher, entryImageData: entry?.imageData)
         } else if browserMode == "inApp" {
             safariURL = url

--- a/MangaLauncher/Views/Library/Timeline/TimelineView.swift
+++ b/MangaLauncher/Views/Library/Timeline/TimelineView.swift
@@ -254,15 +254,16 @@ struct TimelineView: View {
     }
 
     private func openMangaURL(_ urlString: String) {
-        guard let url = URL(string: urlString) else { return }
-        let entry = viewModel.allEntries().first { $0.url == urlString }
-        if browserMode == "quickView" {
-            viewModel.browserContext = BrowserContext(url: url, entryName: entry?.name, entryPublisher: entry?.publisher, entryImageData: entry?.imageData)
-        } else if browserMode == "inApp" {
-            safariURL = url
-        } else {
-            openURL(url)
-        }
+        MangaURLOpener(
+            browserMode: browserMode,
+            openURL: openURL,
+            onSafariURL: { safariURL = $0 },
+            onQuickView: { viewModel.browserContext = $0 },
+            entryLookup: { url in
+                guard let e = viewModel.allEntries().first(where: { $0.url == url }) else { return nil }
+                return (e.name, e.publisher, e.imageData)
+            }
+        ).open(urlString)
     }
 
     // MARK: - Formatters

--- a/MangaLauncher/Views/RootTabView.swift
+++ b/MangaLauncher/Views/RootTabView.swift
@@ -75,7 +75,7 @@ struct RootTabView: View {
         #if canImport(UIKit)
         .overlay {
             if let ctx = viewModel.browserContext {
-                OverlayBrowserScreen(context: ctx) {
+                QuickViewBrowserScreen(context: ctx) {
                     viewModel.browserContext = nil
                 }
                 .ignoresSafeArea()

--- a/MangaLauncher/Views/RootTabView.swift
+++ b/MangaLauncher/Views/RootTabView.swift
@@ -1,4 +1,7 @@
 import SwiftUI
+#if canImport(UIKit)
+import WebKit
+#endif
 
 enum RootTab: Hashable {
     case home, library, settings, search
@@ -69,6 +72,18 @@ struct RootTabView: View {
         } message: { error in
             Text(error.message)
         }
+        #if canImport(UIKit)
+        .overlay {
+            if let ctx = viewModel.browserContext {
+                OverlayBrowserScreen(context: ctx) {
+                    viewModel.browserContext = nil
+                }
+                .ignoresSafeArea()
+                .transition(.opacity)
+            }
+        }
+        .animation(.easeInOut(duration: 0.3), value: viewModel.browserContext != nil)
+        #endif
         }
     }
 }

--- a/MangaLauncher/Views/RootTabView.swift
+++ b/MangaLauncher/Views/RootTabView.swift
@@ -79,10 +79,8 @@ struct RootTabView: View {
                     viewModel.browserContext = nil
                 }
                 .ignoresSafeArea()
-                .transition(.opacity)
             }
         }
-        .animation(.easeInOut(duration: 0.3), value: viewModel.browserContext != nil)
         #endif
         }
     }

--- a/MangaLauncher/Views/RootTabView.swift
+++ b/MangaLauncher/Views/RootTabView.swift
@@ -1,7 +1,4 @@
 import SwiftUI
-#if canImport(UIKit)
-import WebKit
-#endif
 
 enum RootTab: Hashable {
     case home, library, settings, search

--- a/MangaLauncher/Views/Search/SearchView.swift
+++ b/MangaLauncher/Views/Search/SearchView.swift
@@ -325,14 +325,15 @@ struct SearchView: View {
     }
 
     private func openMangaURL(_ urlString: String) {
-        guard let url = URL(string: urlString) else { return }
-        let entry = viewModel.allEntries().first { $0.url == urlString }
-        if browserMode == "quickView" {
-            viewModel.browserContext = BrowserContext(url: url, entryName: entry?.name, entryPublisher: entry?.publisher, entryImageData: entry?.imageData)
-        } else if browserMode == "inApp" {
-            safariURL = url
-        } else {
-            openURL(url)
-        }
+        MangaURLOpener(
+            browserMode: browserMode,
+            openURL: openURL,
+            onSafariURL: { safariURL = $0 },
+            onQuickView: { viewModel.browserContext = $0 },
+            entryLookup: { url in
+                guard let e = viewModel.allEntries().first(where: { $0.url == url }) else { return nil }
+                return (e.name, e.publisher, e.imageData)
+            }
+        ).open(urlString)
     }
 }

--- a/MangaLauncher/Views/Search/SearchView.swift
+++ b/MangaLauncher/Views/Search/SearchView.swift
@@ -327,7 +327,7 @@ struct SearchView: View {
     private func openMangaURL(_ urlString: String) {
         guard let url = URL(string: urlString) else { return }
         let entry = viewModel.allEntries().first { $0.url == urlString }
-        if browserMode == "overlay" {
+        if browserMode == "quickView" {
             viewModel.browserContext = BrowserContext(url: url, entryName: entry?.name, entryPublisher: entry?.publisher, entryImageData: entry?.imageData)
         } else if browserMode == "inApp" {
             safariURL = url

--- a/MangaLauncher/Views/Search/SearchView.swift
+++ b/MangaLauncher/Views/Search/SearchView.swift
@@ -188,8 +188,7 @@ struct SearchView: View {
             }
             #if canImport(UIKit)
             .sheet(item: $safariURL) { url in
-                SafariView(url: url)
-                    .ignoresSafeArea()
+                SafariView(url: url).ignoresSafeArea()
             }
             #endif
         }
@@ -326,6 +325,14 @@ struct SearchView: View {
     }
 
     private func openMangaURL(_ urlString: String) {
-        MangaURLOpener(browserMode: browserMode, openURL: openURL) { safariURL = $0 }.open(urlString)
+        guard let url = URL(string: urlString) else { return }
+        let entry = viewModel.allEntries().first { $0.url == urlString }
+        if browserMode == "overlay" {
+            viewModel.browserContext = BrowserContext(url: url, entryName: entry?.name, entryPublisher: entry?.publisher, entryImageData: entry?.imageData)
+        } else if browserMode == "inApp" {
+            safariURL = url
+        } else {
+            openURL(url)
+        }
     }
 }

--- a/MangaLauncher/Views/Settings/SettingsView.swift
+++ b/MangaLauncher/Views/Settings/SettingsView.swift
@@ -205,13 +205,13 @@ struct SettingsView: View {
                 Section {
                     Picker("ブラウザ", selection: $browserMode) {
                         Text("アプリ内（Safari）").tag("inApp")
-                        Text("オーバーレイ").tag("overlay")
+                        Text("クイックビュー").tag("quickView")
                         Text("デフォルトブラウザ").tag("external")
                     }
                 } header: {
                     Text("ブラウザ")
                 } footer: {
-                    Text("「アプリ内」はSafariベースのブラウザで表示します。「オーバーレイ」はWebViewで表示し、マンガ情報と共有機能を備えます。「デフォルトブラウザ」はiOSで設定したブラウザで開きます。")
+                    Text("「アプリ内」はSafariベースのブラウザで表示します。「クイックビュー」はマンガ情報付きのブラウザで素早く閲覧できます。「デフォルトブラウザ」はiOSで設定したブラウザで開きます。")
                 }
 
                 NotificationSection(viewModel: viewModel)

--- a/MangaLauncher/Views/Settings/SettingsView.swift
+++ b/MangaLauncher/Views/Settings/SettingsView.swift
@@ -205,12 +205,13 @@ struct SettingsView: View {
                 Section {
                     Picker("ブラウザ", selection: $browserMode) {
                         Text("アプリ内（Safari）").tag("inApp")
+                        Text("オーバーレイ").tag("overlay")
                         Text("デフォルトブラウザ").tag("external")
                     }
                 } header: {
                     Text("ブラウザ")
                 } footer: {
-                    Text("「アプリ内」はSafariベースのブラウザで表示します。「デフォルトブラウザ」はiOSで設定したブラウザで開きます。")
+                    Text("「アプリ内」はSafariベースのブラウザで表示します。「オーバーレイ」はWebViewで表示し、マンガ情報と共有機能を備えます。「デフォルトブラウザ」はiOSで設定したブラウザで開きます。")
                 }
 
                 NotificationSection(viewModel: viewModel)


### PR DESCRIPTION
## Summary
- 設定に3つ目のブラウザモード「クイックビュー」を追加
- WKWebViewでサイトを表示し、マンガ情報カードをボトムに表示
- フローティングツールバー（×閉じる / URLメニュー / リロード）
- URLメニューから共有・ブラウザで開く・リンクコピーが可能
- スクリーンショットによるスライドイン/アウトアニメーション
- ボトムカードの上スワイプで閉じる（ドラッグ追従+スクショフェードイン）
- browserContextをMangaViewModelに集約し、RootTabViewレベルでオーバーレイ表示
- CatchUp画面はローカル状態でクイックビューを表示
- バックグラウンド復帰時のdragOffsetリセット対応

## Test plan
- [ ] 設定で「クイックビュー」を選択し、マンガタップでWebViewが表示されること
- [ ] スライドインアニメーション（スクショが下にスライド）が動作すること
- [ ] ×ボタンでスライドアウトして閉じること
- [ ] ボトムカード上スワイプで閉じること（スクショがフェードインして覆う）
- [ ] URLタップでメニュー（共有/ブラウザで開く/コピー）が表示されること
- [ ] リロードボタンが動作すること
- [ ] CatchUp画面でもクイックビューが動作すること
- [ ] バックグラウンド復帰時に半透明が残らないこと
- [ ] 「アプリ内（Safari）」「デフォルトブラウザ」モードが引き続き動作すること
- [ ] ホーム画面のナビ/タブバーの背景が正常であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)