### PR TITLE
Add grab bar to Quick View bottom sheet

### DIFF
--- a/MangaLauncher/Views/Common/SafariView.swift
+++ b/MangaLauncher/Views/Common/SafariView.swift
@@ -64,6 +64,14 @@ struct QuickViewBrowserScreen: View {
                 VStack(spacing: 0) {
                     toolbarView
 
+                    Capsule()
+                        .fill(.white.opacity(0.4))
+                        .frame(width: 36, height: 5)
+                        .padding(.top, 10)
+                        .padding(.bottom, 6)
+                        .frame(maxWidth: .infinity)
+                        .background(.black.opacity(0.85))
+
                     if context.entryName != nil {
                         entryCard
                     }


### PR DESCRIPTION
## Summary
- クイックビューのツールバーとマンガカードの間にグラブバー（カプセル型インジケーター）を追加
- 上スワイプで閉じられることを視覚的に示す

## Test plan
- [x] クイックビューでツールバーとカードの間にグラブバーが表示されること
- [x] グラブバーの位置・サイズが適切であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)