### PR TITLE
ソフトデリート（最近削除した項目）機能を追加

### DIFF
--- a/MangaLauncher.xcodeproj/project.pbxproj
+++ b/MangaLauncher.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		AB50040000112233AA000003 /* HiddenEntriesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB50040000112233AA000004 /* HiddenEntriesView.swift */; };
+		AB50040000112233AA000005 /* RecentlyDeletedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB50040000112233AA000006 /* RecentlyDeletedView.swift */; };
 		AB50040000112233AA000001 /* BiometricAuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB50040000112233AA000002 /* BiometricAuthService.swift */; };
 		AB50050000112233AA000001 /* SpecialEpisodeAlertModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB50050000112233AA000002 /* SpecialEpisodeAlertModifier.swift */; };
 		AB50030000112233AA000003 /* MangaLifetimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB50030000112233AA000004 /* MangaLifetimeView.swift */; };
@@ -177,6 +178,7 @@
 
 /* Begin PBXFileReference section */
 		AB50040000112233AA000004 /* HiddenEntriesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiddenEntriesView.swift; sourceTree = "<group>"; };
+		AB50040000112233AA000006 /* RecentlyDeletedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentlyDeletedView.swift; sourceTree = "<group>"; };
 		AB50040000112233AA000002 /* BiometricAuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricAuthService.swift; sourceTree = "<group>"; };
 		AB50050000112233AA000002 /* SpecialEpisodeAlertModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecialEpisodeAlertModifier.swift; sourceTree = "<group>"; };
 		AB50030000112233AA000004 /* MangaLifetimeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaLifetimeView.swift; sourceTree = "<group>"; };
@@ -467,6 +469,7 @@
 			children = (
 				BB000104 /* LibraryView.swift */,
 				AB50040000112233AA000004 /* HiddenEntriesView.swift */,
+				AB50040000112233AA000006 /* RecentlyDeletedView.swift */,
 				BB000105 /* LibraryCard.swift */,
 				BC000610 /* ActivityRowView.swift */,
 				BC000620 /* AllActivityView.swift */,
@@ -825,6 +828,7 @@
 				A1000002 /* MangaEntry.swift in Sources */,
 				AB50040000112233AA000001 /* BiometricAuthService.swift in Sources */,
 				AB50040000112233AA000003 /* HiddenEntriesView.swift in Sources */,
+				AB50040000112233AA000005 /* RecentlyDeletedView.swift in Sources */,
 				AB50050000112233AA000001 /* SpecialEpisodeAlertModifier.swift in Sources */,
 				AB50030000112233AA000001 /* MangaLifetime.swift in Sources */,
 				AB50030000112233AA000003 /* MangaLifetimeView.swift in Sources */,

--- a/MangaLauncher/Models/BackupData.swift
+++ b/MangaLauncher/Models/BackupData.swift
@@ -75,12 +75,14 @@ struct BackupData: Codable {
         let episodeLabel: String?
         // v11+
         let isHidden: Bool?
+        // v13+
+        let deletedAt: Date?
         // Legacy fields (kept for backward-compat with v5 backups)
         let isOnHiatus: Bool?
         let isCompleted: Bool?
         let isBacklog: Bool?
 
-        init(id: UUID, name: String, url: String, dayOfWeekRawValue: Int, sortOrder: Int, iconColor: String, publisher: String, imageData: Data?, lastReadDate: Date? = nil, updateIntervalWeeks: Int = 1, nextExpectedUpdate: Date? = nil, isOneShot: Bool = false, publicationStatusRawValue: Int = 0, readingStateRawValue: Int = 0, memo: String = "", memoUpdatedAt: Date? = nil, currentEpisode: Int? = nil, episodeLabel: String? = nil, isHidden: Bool = false) {
+        init(id: UUID, name: String, url: String, dayOfWeekRawValue: Int, sortOrder: Int, iconColor: String, publisher: String, imageData: Data?, lastReadDate: Date? = nil, updateIntervalWeeks: Int = 1, nextExpectedUpdate: Date? = nil, isOneShot: Bool = false, publicationStatusRawValue: Int = 0, readingStateRawValue: Int = 0, memo: String = "", memoUpdatedAt: Date? = nil, currentEpisode: Int? = nil, episodeLabel: String? = nil, isHidden: Bool = false, deletedAt: Date? = nil) {
             self.id = id
             self.name = name
             self.url = url
@@ -100,6 +102,7 @@ struct BackupData: Codable {
             self.currentEpisode = currentEpisode
             self.episodeLabel = episodeLabel
             self.isHidden = isHidden
+            self.deletedAt = deletedAt
             self.isOnHiatus = nil
             self.isCompleted = nil
             self.isBacklog = nil
@@ -126,6 +129,7 @@ struct BackupData: Codable {
             currentEpisode = try container.decodeIfPresent(Int.self, forKey: .currentEpisode)
             episodeLabel = try container.decodeIfPresent(String.self, forKey: .episodeLabel)
             isHidden = try container.decodeIfPresent(Bool.self, forKey: .isHidden)
+            deletedAt = try container.decodeIfPresent(Date.self, forKey: .deletedAt)
             isOnHiatus = try container.decodeIfPresent(Bool.self, forKey: .isOnHiatus)
             isCompleted = try container.decodeIfPresent(Bool.self, forKey: .isCompleted)
             isBacklog = try container.decodeIfPresent(Bool.self, forKey: .isBacklog)
@@ -134,7 +138,7 @@ struct BackupData: Codable {
 
     static func from(_ entries: [MangaEntry], activities: [ReadingActivity] = [], comments: [MangaComment] = []) -> BackupData {
         BackupData(
-            version: 12,
+            version: 13,
             exportDate: Date(),
             entries: entries.map {
                 BackupEntry(

--- a/MangaLauncher/Models/MangaEntry.swift
+++ b/MangaLauncher/Models/MangaEntry.swift
@@ -117,6 +117,8 @@ final class MangaEntry {
     var episodeLabel: String?
     /// 非表示フラグ（シークレットモード）
     var isHidden: Bool = false
+    /// ソフトデリート日時（nil = 未削除）
+    var deletedAt: Date?
 
     /// 掲載状況の Int 値（PublicationStatus.rawValue）
     var publicationStatusRawValue: Int = 0

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -353,6 +353,7 @@ final class MangaViewModel {
     func deleteEntry(_ entry: MangaEntry) {
         entry.deletedAt = Date()
         deletedIDs.insert(entry.id)
+        hiddenIDs.remove(entry.id)
         save()
     }
 
@@ -375,6 +376,7 @@ final class MangaViewModel {
         for entry in pendingDeleteEntries {
             entry.deletedAt = Date()
             deletedIDs.insert(entry.id)
+            hiddenIDs.remove(entry.id)
         }
         pendingDeleteEntries.removeAll()
         save()
@@ -392,7 +394,13 @@ final class MangaViewModel {
     // MARK: - Soft Delete
 
     func permanentlyDelete(_ entry: MangaEntry) {
+        permanentlyDeleteWithoutSave(entry)
+        save()
+    }
+
+    private func permanentlyDeleteWithoutSave(_ entry: MangaEntry) {
         deletedIDs.remove(entry.id)
+        hiddenIDs.remove(entry.id)
         let entryID = entry.id
         let activityDescriptor = FetchDescriptor<ReadingActivity>(predicate: #Predicate { $0.mangaEntryID == entryID })
         if let activities = try? modelContext.fetch(activityDescriptor) {
@@ -403,25 +411,41 @@ final class MangaViewModel {
             for comment in comments { modelContext.delete(comment) }
         }
         modelContext.delete(entry)
-        save()
     }
 
     func restoreEntry(_ entry: MangaEntry) {
+        restoreEntryWithoutSave(entry)
+        save()
+    }
+
+    private func restoreEntryWithoutSave(_ entry: MangaEntry) {
         entry.deletedAt = nil
         deletedIDs.remove(entry.id)
         // Recalculate sortOrder to end of its day group
         let day = entry.dayOfWeekRawValue
         let descriptor = FetchDescriptor<MangaEntry>(predicate: #Predicate { $0.dayOfWeekRawValue == day && $0.deletedAt == nil })
-        let maxOrder = (try? modelContext.fetch(descriptor))?.map(\.sortOrder).max() ?? 0
+        let maxOrder = (try? modelContext.fetch(descriptor))?.map(\.sortOrder).max() ?? -1
         entry.sortOrder = maxOrder + 1
+    }
+
+    func restoreEntries(_ entries: [MangaEntry]) {
+        for entry in entries { restoreEntryWithoutSave(entry) }
+        save()
+    }
+
+    func permanentlyDeleteEntries(_ entries: [MangaEntry]) {
+        for entry in entries { permanentlyDeleteWithoutSave(entry) }
         save()
     }
 
     func deletedEntries() -> [MangaEntry] {
         let currentDeletedIDs = deletedIDs
-        let descriptor = FetchDescriptor<MangaEntry>(sortBy: [SortDescriptor(\.name)])
-        let all = modelContext.fetchLogged(descriptor)
-        return all.filter { currentDeletedIDs.contains($0.id) && !$0.isHidden }
+        let descriptor = FetchDescriptor<MangaEntry>(
+            predicate: #Predicate { $0.deletedAt != nil && $0.isHidden == false }
+        )
+        let results = modelContext.fetchLogged(descriptor)
+        // SwiftData stale fetch 対策: in-memory deletedIDs でも照合
+        return results.filter { currentDeletedIDs.contains($0.id) }
             .sorted { ($0.deletedAt ?? .distantPast) > ($1.deletedAt ?? .distantPast) }
     }
 
@@ -434,8 +458,9 @@ final class MangaViewModel {
         let descriptor = FetchDescriptor<MangaEntry>(predicate: #Predicate { $0.deletedAt != nil && $0.deletedAt! < cutoff })
         guard let expired = try? modelContext.fetch(descriptor), !expired.isEmpty else { return }
         for entry in expired {
-            permanentlyDelete(entry)
+            permanentlyDeleteWithoutSave(entry)
         }
+        save()
     }
 
     /// 別の曜日に移動。曜日のみ変更し、状態は触らない。

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -392,6 +392,7 @@ final class MangaViewModel {
     // MARK: - Soft Delete
 
     func permanentlyDelete(_ entry: MangaEntry) {
+        deletedIDs.remove(entry.id)
         let entryID = entry.id
         let activityDescriptor = FetchDescriptor<ReadingActivity>(predicate: #Predicate { $0.mangaEntryID == entryID })
         if let activities = try? modelContext.fetch(activityDescriptor) {
@@ -407,6 +408,7 @@ final class MangaViewModel {
 
     func restoreEntry(_ entry: MangaEntry) {
         entry.deletedAt = nil
+        deletedIDs.remove(entry.id)
         // Recalculate sortOrder to end of its day group
         let day = entry.dayOfWeekRawValue
         let descriptor = FetchDescriptor<MangaEntry>(predicate: #Predicate { $0.dayOfWeekRawValue == day && $0.deletedAt == nil })
@@ -416,16 +418,15 @@ final class MangaViewModel {
     }
 
     func deletedEntries() -> [MangaEntry] {
-        let descriptor = FetchDescriptor<MangaEntry>(
-            predicate: #Predicate { $0.deletedAt != nil && $0.isHidden == false },
-            sortBy: [SortDescriptor(\.deletedAt, order: .reverse)]
-        )
-        return (try? modelContext.fetch(descriptor)) ?? []
+        let currentDeletedIDs = deletedIDs
+        let descriptor = FetchDescriptor<MangaEntry>(sortBy: [SortDescriptor(\.name)])
+        let all = modelContext.fetchLogged(descriptor)
+        return all.filter { currentDeletedIDs.contains($0.id) && !$0.isHidden }
+            .sorted { ($0.deletedAt ?? .distantPast) > ($1.deletedAt ?? .distantPast) }
     }
 
     func deletedEntryCount() -> Int {
-        let descriptor = FetchDescriptor<MangaEntry>(predicate: #Predicate { $0.deletedAt != nil && $0.isHidden == false })
-        return (try? modelContext.fetchCount(descriptor)) ?? 0
+        deletedIDs.count
     }
 
     func purgeExpiredSoftDeletes() {

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -194,10 +194,14 @@ final class MangaViewModel {
 
     func hiddenEntries() -> [MangaEntry] {
         let descriptor = FetchDescriptor<MangaEntry>(
-            predicate: #Predicate { $0.isHidden == true && $0.deletedAt == nil },
+            predicate: #Predicate { $0.isHidden == true },
             sortBy: [SortDescriptor(\.name)]
         )
-        return modelContext.fetchLogged(descriptor)
+        let pendingIDs = Set(pendingDeleteEntries.map(\.id))
+        let currentDeletedIDs = deletedIDs
+        return modelContext.fetchLogged(descriptor).filter { entry in
+            !pendingIDs.contains(entry.id) && !currentDeletedIDs.contains(entry.id)
+        }
     }
 
     func recordSpecialEpisode(_ entry: MangaEntry, label: String) {
@@ -421,6 +425,9 @@ final class MangaViewModel {
     private func restoreEntryWithoutSave(_ entry: MangaEntry) {
         entry.deletedAt = nil
         deletedIDs.remove(entry.id)
+        if entry.isHidden {
+            hiddenIDs.insert(entry.id)
+        }
         // Recalculate sortOrder to end of its day group
         let day = entry.dayOfWeekRawValue
         let descriptor = FetchDescriptor<MangaEntry>(predicate: #Predicate { $0.dayOfWeekRawValue == day && $0.deletedAt == nil })
@@ -441,12 +448,17 @@ final class MangaViewModel {
     func deletedEntries() -> [MangaEntry] {
         let currentDeletedIDs = deletedIDs
         let descriptor = FetchDescriptor<MangaEntry>(
-            predicate: #Predicate { $0.deletedAt != nil && $0.isHidden == false }
+            predicate: #Predicate { $0.deletedAt != nil }
         )
         let results = modelContext.fetchLogged(descriptor)
         // SwiftData stale fetch 対策: in-memory deletedIDs でも照合
         return results.filter { currentDeletedIDs.contains($0.id) }
             .sorted { ($0.deletedAt ?? .distantPast) > ($1.deletedAt ?? .distantPast) }
+    }
+
+    /// 非表示の削除済みエントリが存在するか
+    func hasHiddenDeletedEntries() -> Bool {
+        deletedEntries().contains { $0.isHidden }
     }
 
     func deletedEntryCount() -> Int {

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -426,7 +426,7 @@ final class MangaViewModel {
     }
 
     func deletedEntryCount() -> Int {
-        deletedIDs.count
+        deletedEntries().count
     }
 
     func purgeExpiredSoftDeletes() {
@@ -480,6 +480,8 @@ final class MangaViewModel {
         }
         UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.lastStreakShownDate)
         UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.shownMilestones)
+        deletedIDs.removeAll()
+        hiddenIDs.removeAll()
         do {
             try modelContext.save()
         } catch {
@@ -501,22 +503,28 @@ final class MangaViewModel {
         let results = modelContext.fetchLogged(descriptor)
         let pendingIDs = Set(pendingDeleteEntries.map(\.id))
         let currentHiddenIDs = hiddenIDs
+        let currentDeletedIDs = deletedIDs
         var seenIDs = Set<UUID>()
         return results.filter { entry in
             guard !currentHiddenIDs.contains(entry.id) else { return false }
             guard !pendingIDs.contains(entry.id) else { return false }
+            guard !currentDeletedIDs.contains(entry.id) else { return false }
             return seenIDs.insert(entry.id).inserted
         }.count
     }
 
     func exportBackupData() -> Data? {
-        let descriptor = FetchDescriptor<MangaEntry>(sortBy: [SortDescriptor(\.dayOfWeekRawValue), SortDescriptor(\.sortOrder)])
+        let descriptor = FetchDescriptor<MangaEntry>(
+            predicate: #Predicate { $0.deletedAt == nil },
+            sortBy: [SortDescriptor(\.dayOfWeekRawValue), SortDescriptor(\.sortOrder)]
+        )
         let entries = modelContext.fetchLogged(descriptor)
         guard !entries.isEmpty else { return nil }
+        let activeEntryIDs = Set(entries.map(\.id))
         let activityDescriptor = FetchDescriptor<ReadingActivity>(sortBy: [SortDescriptor(\.date)])
-        let activities = modelContext.fetchLogged(activityDescriptor)
+        let activities = modelContext.fetchLogged(activityDescriptor).filter { activeEntryIDs.contains($0.mangaEntryID) }
         let commentDescriptor = FetchDescriptor<MangaComment>(sortBy: [SortDescriptor(\.createdAt)])
-        let comments = modelContext.fetchLogged(commentDescriptor)
+        let comments = modelContext.fetchLogged(commentDescriptor).filter { activeEntryIDs.contains($0.mangaEntryID) }
         let backup = BackupData.from(entries, activities: activities, comments: comments)
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -127,10 +127,12 @@ final class MangaViewModel {
         let results = modelContext.fetchLogged(descriptor)
         let pendingIDs = Set(pendingDeleteEntries.map(\.id))
         let currentHiddenIDs = hiddenIDs
+        let currentDeletedIDs = deletedIDs
         var seenIDs = Set<UUID>()
         return results.filter { entry in
             guard !currentHiddenIDs.contains(entry.id) else { return false }
             guard !pendingIDs.contains(entry.id) else { return false }
+            guard !currentDeletedIDs.contains(entry.id) else { return false }
             return seenIDs.insert(entry.id).inserted
         }
     }
@@ -326,10 +328,12 @@ final class MangaViewModel {
         )
         let pendingIDs = Set(pendingDeleteEntries.map(\.id))
         let currentHiddenIDs = hiddenIDs
+        let currentDeletedIDs = deletedIDs
         var seenIDs = Set<UUID>()
         let result = modelContext.fetchLogged(descriptor).filter { entry in
             guard !currentHiddenIDs.contains(entry.id) else { return false }
             guard !pendingIDs.contains(entry.id) else { return false }
+            guard !currentDeletedIDs.contains(entry.id) else { return false }
             return seenIDs.insert(entry.id).inserted
         }
         cachedEntries = result
@@ -348,6 +352,7 @@ final class MangaViewModel {
 
     func deleteEntry(_ entry: MangaEntry) {
         entry.deletedAt = Date()
+        deletedIDs.insert(entry.id)
         save()
     }
 
@@ -369,6 +374,7 @@ final class MangaViewModel {
         deleteTimer = nil
         for entry in pendingDeleteEntries {
             entry.deletedAt = Date()
+            deletedIDs.insert(entry.id)
         }
         pendingDeleteEntries.removeAll()
         save()

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -12,6 +12,7 @@ final class MangaViewModel {
     var selectedDay: DayOfWeek = .today
     private(set) var refreshCounter = 0
     private(set) var hiddenIDs: Set<UUID> = []
+    private(set) var deletedIDs: Set<UUID> = []
     var pendingDeleteEntries: [MangaEntry] = []
     private var deleteTimer: Timer?
     var pendingDeleteComments: [MangaComment] = []
@@ -36,6 +37,7 @@ final class MangaViewModel {
     init(modelContext: ModelContext) {
         self.modelContext = modelContext
         reloadHiddenIDs()
+        reloadDeletedIDs()
         // 起動時の重い処理 (migration / backfill) は init では実行しない。
         // CloudKit 同期前のローカル DB を書き換えると、cloud で持っている値を
         // デフォルトで上書きしてしまうリスクがある (Vision Pro 初回起動などで観測)。
@@ -178,6 +180,14 @@ final class MangaViewModel {
         )
         let entries = (try? modelContext.fetch(descriptor)) ?? []
         hiddenIDs = Set(entries.map(\.id))
+    }
+
+    func reloadDeletedIDs() {
+        let descriptor = FetchDescriptor<MangaEntry>(
+            predicate: #Predicate { $0.deletedAt != nil }
+        )
+        let entries = (try? modelContext.fetch(descriptor)) ?? []
+        deletedIDs = Set(entries.map(\.id))
     }
 
     func hiddenEntries() -> [MangaEntry] {
@@ -590,6 +600,7 @@ final class MangaViewModel {
         if importedCount > 0 {
             save()
             reloadHiddenIDs()
+            reloadDeletedIDs()
         }
         return importedCount
     }
@@ -796,6 +807,7 @@ final class MangaViewModel {
     func refresh() {
         modelContext = ModelContext(modelContext.container)
         reloadHiddenIDs()
+        reloadDeletedIDs()
         refreshCounter += 1
     }
 

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -50,6 +50,7 @@ final class MangaViewModel {
         didRunStartupMigrations = true
         migrateLegacyStateIfNeeded()
         backfillMemoUpdatedAtIfNeeded()
+        purgeExpiredSoftDeletes()
     }
 
     /// 旧 Bool 状態（isOnHiatus / isCompleted / isBacklog）を
@@ -117,6 +118,7 @@ final class MangaViewModel {
                 $0.dayOfWeekRawValue == dayRawValue
                     && $0.readingStateRawValue == followingRaw
                     && $0.publicationStatusRawValue == activeRaw
+                    && $0.deletedAt == nil
             },
             sortBy: [SortDescriptor(\.sortOrder)]
         )
@@ -172,7 +174,7 @@ final class MangaViewModel {
 
     func reloadHiddenIDs() {
         let descriptor = FetchDescriptor<MangaEntry>(
-            predicate: #Predicate { $0.isHidden == true }
+            predicate: #Predicate { $0.isHidden == true && $0.deletedAt == nil }
         )
         let entries = (try? modelContext.fetch(descriptor)) ?? []
         hiddenIDs = Set(entries.map(\.id))
@@ -180,7 +182,7 @@ final class MangaViewModel {
 
     func hiddenEntries() -> [MangaEntry] {
         let descriptor = FetchDescriptor<MangaEntry>(
-            predicate: #Predicate { $0.isHidden == true },
+            predicate: #Predicate { $0.isHidden == true && $0.deletedAt == nil },
             sortBy: [SortDescriptor(\.name)]
         )
         return modelContext.fetchLogged(descriptor)
@@ -309,6 +311,7 @@ final class MangaViewModel {
         invalidateCacheIfStale()
         if let cached = cachedEntries { return cached }
         let descriptor = FetchDescriptor<MangaEntry>(
+            predicate: #Predicate { $0.deletedAt == nil },
             sortBy: [SortDescriptor(\.lastReadDate, order: .reverse), SortDescriptor(\.name)]
         )
         let pendingIDs = Set(pendingDeleteEntries.map(\.id))
@@ -324,7 +327,9 @@ final class MangaViewModel {
     }
 
     func allPublishers() -> [String] {
-        let descriptor = FetchDescriptor<MangaEntry>()
+        let descriptor = FetchDescriptor<MangaEntry>(
+            predicate: #Predicate { $0.deletedAt == nil }
+        )
         let entries = modelContext.fetchLogged(descriptor)
         let currentHiddenIDs = hiddenIDs
         let publishers = Set(entries.filter { !currentHiddenIDs.contains($0.id) }.map(\.publisher)).filter { !$0.isEmpty }
@@ -332,7 +337,7 @@ final class MangaViewModel {
     }
 
     func deleteEntry(_ entry: MangaEntry) {
-        modelContext.delete(entry)
+        entry.deletedAt = Date()
         save()
     }
 
@@ -353,7 +358,7 @@ final class MangaViewModel {
         deleteTimer?.invalidate()
         deleteTimer = nil
         for entry in pendingDeleteEntries {
-            modelContext.delete(entry)
+            entry.deletedAt = Date()
         }
         pendingDeleteEntries.removeAll()
         save()
@@ -365,6 +370,54 @@ final class MangaViewModel {
             Task { @MainActor in
                 self?.commitPendingDeletes()
             }
+        }
+    }
+
+    // MARK: - Soft Delete
+
+    func permanentlyDelete(_ entry: MangaEntry) {
+        let entryID = entry.id
+        let activityDescriptor = FetchDescriptor<ReadingActivity>(predicate: #Predicate { $0.mangaEntryID == entryID })
+        if let activities = try? modelContext.fetch(activityDescriptor) {
+            for activity in activities { modelContext.delete(activity) }
+        }
+        let commentDescriptor = FetchDescriptor<MangaComment>(predicate: #Predicate { $0.mangaEntryID == entryID })
+        if let comments = try? modelContext.fetch(commentDescriptor) {
+            for comment in comments { modelContext.delete(comment) }
+        }
+        modelContext.delete(entry)
+        save()
+    }
+
+    func restoreEntry(_ entry: MangaEntry) {
+        entry.deletedAt = nil
+        // Recalculate sortOrder to end of its day group
+        let day = entry.dayOfWeekRawValue
+        let descriptor = FetchDescriptor<MangaEntry>(predicate: #Predicate { $0.dayOfWeekRawValue == day && $0.deletedAt == nil })
+        let maxOrder = (try? modelContext.fetch(descriptor))?.map(\.sortOrder).max() ?? 0
+        entry.sortOrder = maxOrder + 1
+        save()
+    }
+
+    func deletedEntries() -> [MangaEntry] {
+        let descriptor = FetchDescriptor<MangaEntry>(
+            predicate: #Predicate { $0.deletedAt != nil && $0.isHidden == false },
+            sortBy: [SortDescriptor(\.deletedAt, order: .reverse)]
+        )
+        return (try? modelContext.fetch(descriptor)) ?? []
+    }
+
+    func deletedEntryCount() -> Int {
+        let descriptor = FetchDescriptor<MangaEntry>(predicate: #Predicate { $0.deletedAt != nil && $0.isHidden == false })
+        return (try? modelContext.fetchCount(descriptor)) ?? 0
+    }
+
+    func purgeExpiredSoftDeletes() {
+        let cutoff = Calendar.current.date(byAdding: .day, value: -30, to: Date())!
+        let descriptor = FetchDescriptor<MangaEntry>(predicate: #Predicate { $0.deletedAt != nil && $0.deletedAt! < cutoff })
+        guard let expired = try? modelContext.fetch(descriptor), !expired.isEmpty else { return }
+        for entry in expired {
+            permanentlyDelete(entry)
         }
     }
 
@@ -425,7 +478,9 @@ final class MangaViewModel {
 
     func totalEntryCount() -> Int {
         let _ = refreshCounter
-        let descriptor = FetchDescriptor<MangaEntry>()
+        let descriptor = FetchDescriptor<MangaEntry>(
+            predicate: #Predicate { $0.deletedAt == nil }
+        )
         let results = modelContext.fetchLogged(descriptor)
         let pendingIDs = Set(pendingDeleteEntries.map(\.id))
         let currentHiddenIDs = hiddenIDs

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -350,7 +350,8 @@ final class MangaViewModel {
         )
         let entries = modelContext.fetchLogged(descriptor)
         let currentHiddenIDs = hiddenIDs
-        let publishers = Set(entries.filter { !currentHiddenIDs.contains($0.id) }.map(\.publisher)).filter { !$0.isEmpty }
+        let currentDeletedIDs = deletedIDs
+        let publishers = Set(entries.filter { !currentHiddenIDs.contains($0.id) && !currentDeletedIDs.contains($0.id) }.map(\.publisher)).filter { !$0.isEmpty }
         return publishers.sorted()
     }
 

--- a/MangaLauncher/Views/Library/HiddenEntriesView.swift
+++ b/MangaLauncher/Views/Library/HiddenEntriesView.swift
@@ -42,7 +42,14 @@ struct HiddenEntriesView: View {
             }
         }
         .onAppear { authenticate() }
-        .sheet(item: $editingEntry) { entry in
+        .onChange(of: viewModel.refreshCounter) { _, _ in
+            if isAuthenticated {
+                entries = viewModel.hiddenEntries()
+            }
+        }
+        .sheet(item: $editingEntry, onDismiss: {
+            entries = viewModel.hiddenEntries()
+        }) { entry in
             EditEntryView(viewModel: viewModel, entry: entry)
         }
         .sheet(item: $commentingEntry) { entry in

--- a/MangaLauncher/Views/Library/LibrarySection.swift
+++ b/MangaLauncher/Views/Library/LibrarySection.swift
@@ -30,4 +30,5 @@ enum LibraryDestination: Hashable {
     case allPublishers
     case timeline
     case hiddenEntries
+    case recentlyDeleted
 }

--- a/MangaLauncher/Views/Library/LibraryView.swift
+++ b/MangaLauncher/Views/Library/LibraryView.swift
@@ -87,6 +87,7 @@ struct LibraryView: View {
                 LazyVStack(alignment: .leading, spacing: 24) {
                     timelineLink
                     hiddenSectionLink
+                    recentlyDeletedLink
                     if !recentActivity.isEmpty {
                         recentActivitySection(items: recentActivity, totalCount: totalActivityCount)
                     }
@@ -122,6 +123,8 @@ struct LibraryView: View {
             TimelineView(viewModel: viewModel)
         case .hiddenEntries:
             HiddenEntriesView(viewModel: viewModel)
+        case .recentlyDeleted:
+            RecentlyDeletedView(viewModel: viewModel)
         }
     }
 
@@ -173,6 +176,40 @@ struct LibraryView: View {
                             .font(theme.captionFont)
                             .foregroundStyle(theme.onSurfaceVariant)
                     }
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(theme.onSurfaceVariant)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .background(
+                    RoundedRectangle(cornerRadius: 12)
+                        .fill(theme.surfaceContainerHigh)
+                )
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal)
+        }
+    }
+
+    @ViewBuilder
+    private var recentlyDeletedLink: some View {
+        let count = viewModel.deletedEntryCount()
+        if count > 0 {
+            NavigationLink(value: LibraryDestination.recentlyDeleted) {
+                HStack(spacing: 10) {
+                    Image(systemName: "trash.fill")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(.white)
+                        .frame(width: 28, height: 28)
+                        .background(Color.red, in: RoundedRectangle(cornerRadius: 6))
+                    Text("最近削除した項目")
+                        .font(theme.subheadlineFont.weight(.semibold))
+                        .foregroundStyle(theme.onSurface)
+                    Spacer()
+                    Text("\(count)")
+                        .font(theme.captionFont)
+                        .foregroundStyle(theme.onSurfaceVariant)
                     Image(systemName: "chevron.right")
                         .font(.caption)
                         .foregroundStyle(theme.onSurfaceVariant)

--- a/MangaLauncher/Views/Library/RecentlyDeletedView.swift
+++ b/MangaLauncher/Views/Library/RecentlyDeletedView.swift
@@ -3,6 +3,8 @@ import PlatformKit
 
 struct RecentlyDeletedView: View {
     var viewModel: MangaViewModel
+    @State private var isAuthenticated = false
+    @State private var needsAuth = false
     @State private var entries: [MangaEntry] = []
     @State private var showDeleteAllConfirmation = false
     @State private var showDeleteConfirmation: MangaEntry?
@@ -11,7 +13,9 @@ struct RecentlyDeletedView: View {
 
     var body: some View {
         Group {
-            if entries.isEmpty {
+            if needsAuth && !isAuthenticated {
+                lockedView
+            } else if entries.isEmpty {
                 ContentUnavailableView {
                     Label("最近削除した項目はありません", systemImage: "trash")
                         .foregroundStyle(theme.onSurfaceVariant)
@@ -22,68 +26,35 @@ struct RecentlyDeletedView: View {
             } else {
                 List {
                     ForEach(entries, id: \.id) { entry in
-                        HStack(spacing: 12) {
-                            if let data = entry.imageData, let image = data.toSwiftUIImage() {
-                                image
-                                    .resizable()
-                                    .scaledToFill()
-                                    .frame(width: 44, height: 44)
-                                    .clipShape(RoundedRectangle(cornerRadius: 8))
-                            } else {
-                                RoundedRectangle(cornerRadius: 8)
-                                    .fill(Color.fromName(entry.iconColor))
-                                    .frame(width: 44, height: 44)
-                                    .overlay {
-                                        Text(entry.name.prefix(1))
-                                            .font(.headline.bold())
-                                            .foregroundStyle(.white)
-                                    }
+                        entryRow(entry)
+                            .swipeActions(edge: .leading) {
+                                Button {
+                                    restore(entry)
+                                } label: {
+                                    Label("復元", systemImage: "arrow.uturn.backward")
+                                }
+                                .tint(.blue)
                             }
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(entry.name)
-                                    .font(theme.bodyFont)
-                                    .foregroundStyle(theme.onSurface)
-                                if !entry.publisher.isEmpty {
-                                    Text(entry.publisher)
-                                        .font(theme.captionFont)
-                                        .foregroundStyle(theme.onSurfaceVariant)
+                            .swipeActions(edge: .trailing) {
+                                Button(role: .destructive) {
+                                    showDeleteConfirmation = entry
+                                } label: {
+                                    Label("完全に削除", systemImage: "trash")
                                 }
                             }
-                            Spacer()
-                            if let deletedAt = entry.deletedAt {
-                                Text(remainingDaysText(from: deletedAt))
-                                    .font(.caption2)
-                                    .foregroundStyle(theme.onSurfaceVariant)
+                            .contextMenu {
+                                Button {
+                                    restore(entry)
+                                } label: {
+                                    Label("復元", systemImage: "arrow.uturn.backward")
+                                }
+                                Divider()
+                                Button(role: .destructive) {
+                                    showDeleteConfirmation = entry
+                                } label: {
+                                    Label("完全に削除", systemImage: "trash")
+                                }
                             }
-                        }
-                        .swipeActions(edge: .leading) {
-                            Button {
-                                restore(entry)
-                            } label: {
-                                Label("復元", systemImage: "arrow.uturn.backward")
-                            }
-                            .tint(.blue)
-                        }
-                        .swipeActions(edge: .trailing) {
-                            Button(role: .destructive) {
-                                showDeleteConfirmation = entry
-                            } label: {
-                                Label("完全に削除", systemImage: "trash")
-                            }
-                        }
-                        .contextMenu {
-                            Button {
-                                restore(entry)
-                            } label: {
-                                Label("復元", systemImage: "arrow.uturn.backward")
-                            }
-                            Divider()
-                            Button(role: .destructive) {
-                                showDeleteConfirmation = entry
-                            } label: {
-                                Label("完全に削除", systemImage: "trash")
-                            }
-                        }
                     }
                 }
                 .listStyle(.plain)
@@ -115,7 +86,7 @@ struct RecentlyDeletedView: View {
             }
         }
         .onAppear {
-            entries = viewModel.deletedEntries()
+            loadEntries()
         }
         .alert("完全に削除", isPresented: $showDeleteAllConfirmation) {
             Button("すべて削除", role: .destructive) {
@@ -138,6 +109,86 @@ struct RecentlyDeletedView: View {
         } message: {
             if let entry = showDeleteConfirmation {
                 Text("「\(entry.name)」を完全に削除します。この操作は取り消せません。")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var lockedView: some View {
+        ContentUnavailableView {
+            Label("認証が必要です", systemImage: "lock.fill")
+                .foregroundStyle(theme.onSurfaceVariant)
+        } description: {
+            Text("非表示のマンガが含まれているため認証が必要です")
+                .foregroundStyle(theme.onSurfaceVariant.opacity(0.7))
+        } actions: {
+            Button("認証する") { authenticate() }
+        }
+    }
+
+    @ViewBuilder
+    private func entryRow(_ entry: MangaEntry) -> some View {
+        HStack(spacing: 12) {
+            if let data = entry.imageData, let image = data.toSwiftUIImage() {
+                image
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: 44, height: 44)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+            } else {
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color.fromName(entry.iconColor))
+                    .frame(width: 44, height: 44)
+                    .overlay {
+                        Text(entry.name.prefix(1))
+                            .font(.headline.bold())
+                            .foregroundStyle(.white)
+                    }
+            }
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 4) {
+                    Text(entry.name)
+                        .font(theme.bodyFont)
+                        .foregroundStyle(theme.onSurface)
+                    if entry.isHidden {
+                        Image(systemName: "eye.slash")
+                            .font(.caption2)
+                            .foregroundStyle(theme.onSurfaceVariant)
+                    }
+                }
+                if !entry.publisher.isEmpty {
+                    Text(entry.publisher)
+                        .font(theme.captionFont)
+                        .foregroundStyle(theme.onSurfaceVariant)
+                }
+            }
+            Spacer()
+            if let deletedAt = entry.deletedAt {
+                Text(remainingDaysText(from: deletedAt))
+                    .font(.caption2)
+                    .foregroundStyle(theme.onSurfaceVariant)
+            }
+        }
+    }
+
+    private func loadEntries() {
+        if viewModel.hasHiddenDeletedEntries() {
+            needsAuth = true
+            authenticate()
+        } else {
+            needsAuth = false
+            entries = viewModel.deletedEntries()
+        }
+    }
+
+    private func authenticate() {
+        Task {
+            let success = await BiometricAuthService.authenticate(
+                reason: "削除した項目を表示するために認証が必要です"
+            )
+            isAuthenticated = success
+            if success {
+                entries = viewModel.deletedEntries()
             }
         }
     }

--- a/MangaLauncher/Views/Library/RecentlyDeletedView.swift
+++ b/MangaLauncher/Views/Library/RecentlyDeletedView.swift
@@ -163,18 +163,14 @@ struct RecentlyDeletedView: View {
     }
 
     private func restoreAll() {
-        for entry in entries {
-            viewModel.restoreEntry(entry)
-        }
+        viewModel.restoreEntries(entries)
         withAnimation {
             entries.removeAll()
         }
     }
 
     private func permanentlyDeleteAll() {
-        for entry in entries {
-            viewModel.permanentlyDelete(entry)
-        }
+        viewModel.permanentlyDeleteEntries(entries)
         withAnimation {
             entries.removeAll()
         }

--- a/MangaLauncher/Views/Library/RecentlyDeletedView.swift
+++ b/MangaLauncher/Views/Library/RecentlyDeletedView.swift
@@ -1,0 +1,182 @@
+import SwiftUI
+import PlatformKit
+
+struct RecentlyDeletedView: View {
+    var viewModel: MangaViewModel
+    @State private var entries: [MangaEntry] = []
+    @State private var showDeleteAllConfirmation = false
+    @State private var showDeleteConfirmation: MangaEntry?
+
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
+    var body: some View {
+        Group {
+            if entries.isEmpty {
+                ContentUnavailableView {
+                    Label("最近削除した項目はありません", systemImage: "trash")
+                        .foregroundStyle(theme.onSurfaceVariant)
+                } description: {
+                    Text("削除したマンガは30日間ここに保管されます。\n30日後に自動的に完全削除されます。")
+                        .foregroundStyle(theme.onSurfaceVariant.opacity(0.7))
+                }
+            } else {
+                List {
+                    ForEach(entries, id: \.id) { entry in
+                        HStack(spacing: 12) {
+                            if let data = entry.imageData, let image = data.toSwiftUIImage() {
+                                image
+                                    .resizable()
+                                    .scaledToFill()
+                                    .frame(width: 44, height: 44)
+                                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                            } else {
+                                RoundedRectangle(cornerRadius: 8)
+                                    .fill(Color.fromName(entry.iconColor))
+                                    .frame(width: 44, height: 44)
+                                    .overlay {
+                                        Text(entry.name.prefix(1))
+                                            .font(.headline.bold())
+                                            .foregroundStyle(.white)
+                                    }
+                            }
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(entry.name)
+                                    .font(theme.bodyFont)
+                                    .foregroundStyle(theme.onSurface)
+                                if !entry.publisher.isEmpty {
+                                    Text(entry.publisher)
+                                        .font(theme.captionFont)
+                                        .foregroundStyle(theme.onSurfaceVariant)
+                                }
+                            }
+                            Spacer()
+                            if let deletedAt = entry.deletedAt {
+                                Text(remainingDaysText(from: deletedAt))
+                                    .font(.caption2)
+                                    .foregroundStyle(theme.onSurfaceVariant)
+                            }
+                        }
+                        .swipeActions(edge: .leading) {
+                            Button {
+                                restore(entry)
+                            } label: {
+                                Label("復元", systemImage: "arrow.uturn.backward")
+                            }
+                            .tint(.blue)
+                        }
+                        .swipeActions(edge: .trailing) {
+                            Button(role: .destructive) {
+                                showDeleteConfirmation = entry
+                            } label: {
+                                Label("完全に削除", systemImage: "trash")
+                            }
+                        }
+                        .contextMenu {
+                            Button {
+                                restore(entry)
+                            } label: {
+                                Label("復元", systemImage: "arrow.uturn.backward")
+                            }
+                            Divider()
+                            Button(role: .destructive) {
+                                showDeleteConfirmation = entry
+                            } label: {
+                                Label("完全に削除", systemImage: "trash")
+                            }
+                        }
+                    }
+                }
+                .listStyle(.plain)
+            }
+        }
+        .themedNavigationStyle()
+        .navigationTitle("最近削除した項目")
+        #if os(iOS) || os(visionOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .toolbar {
+            if !entries.isEmpty {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Menu {
+                        Button {
+                            restoreAll()
+                        } label: {
+                            Label("すべて復元", systemImage: "arrow.uturn.backward")
+                        }
+                        Button(role: .destructive) {
+                            showDeleteAllConfirmation = true
+                        } label: {
+                            Label("すべて削除", systemImage: "trash")
+                        }
+                    } label: {
+                        Image(systemName: "ellipsis.circle")
+                    }
+                }
+            }
+        }
+        .onAppear {
+            entries = viewModel.deletedEntries()
+        }
+        .alert("完全に削除", isPresented: $showDeleteAllConfirmation) {
+            Button("すべて削除", role: .destructive) {
+                permanentlyDeleteAll()
+            }
+            Button("キャンセル", role: .cancel) {}
+        } message: {
+            Text("\(entries.count)件のマンガを完全に削除します。この操作は取り消せません。")
+        }
+        .alert("完全に削除", isPresented: Binding(
+            get: { showDeleteConfirmation != nil },
+            set: { if !$0 { showDeleteConfirmation = nil } }
+        )) {
+            Button("削除", role: .destructive) {
+                if let entry = showDeleteConfirmation {
+                    permanentlyDelete(entry)
+                }
+            }
+            Button("キャンセル", role: .cancel) {}
+        } message: {
+            if let entry = showDeleteConfirmation {
+                Text("「\(entry.name)」を完全に削除します。この操作は取り消せません。")
+            }
+        }
+    }
+
+    private func remainingDaysText(from deletedAt: Date) -> String {
+        let days = Calendar.current.dateComponents([.day], from: deletedAt, to: Date()).day ?? 0
+        let remaining = max(0, 30 - days)
+        return "あと\(remaining)日"
+    }
+
+    private func restore(_ entry: MangaEntry) {
+        viewModel.restoreEntry(entry)
+        withAnimation {
+            entries.removeAll { $0.id == entry.id }
+        }
+    }
+
+    private func permanentlyDelete(_ entry: MangaEntry) {
+        viewModel.permanentlyDelete(entry)
+        withAnimation {
+            entries.removeAll { $0.id == entry.id }
+        }
+    }
+
+    private func restoreAll() {
+        for entry in entries {
+            viewModel.restoreEntry(entry)
+        }
+        withAnimation {
+            entries.removeAll()
+        }
+    }
+
+    private func permanentlyDeleteAll() {
+        for entry in entries {
+            viewModel.permanentlyDelete(entry)
+        }
+        withAnimation {
+            entries.removeAll()
+        }
+    }
+}

--- a/MangaWidget/MangaWidget.swift
+++ b/MangaWidget/MangaWidget.swift
@@ -55,6 +55,7 @@ struct MangaTimelineProvider: TimelineProvider {
                     && $0.publicationStatusRawValue == activeRaw
                     && $0.readingStateRawValue == followingRaw
                     && $0.isHidden == false
+                    && $0.deletedAt == nil
             },
             sortBy: [SortDescriptor(\.sortOrder)]
         )


### PR DESCRIPTION
## Summary
- MangaEntry に `deletedAt: Date?` を追加し、削除時に即座に完全削除せずソフトデリートする仕組みを導入
- 「最近削除した項目」画面（RecentlyDeletedView）を追加し、復元・完全削除が可能に
- 30日経過したエントリは起動時に自動パージ
- ウィジェット・バックアップ・フィルタリングなど関連箇所すべてに対応

## Changes
- **MangaEntry**: `deletedAt: Date?` フィールド追加
- **MangaViewModel**: ソフトデリート / 復元 / 完全削除 / 自動パージ / `deletedIDs` によるインメモリ追跡
- **RecentlyDeletedView**: 残り日数表示、スワイプ操作、一括復元/削除、確認アラート
- **LibraryView**: ゴミ箱アイコン付きナビゲーションリンク追加
- **BackupData**: バージョン13に更新、削除済みエントリはエクスポート対象外
- **MangaWidget**: 削除済みエントリをウィジェットから除外

## Test plan
- [ ] マンガを削除 → 通常一覧から消え、「最近削除した項目」に表示される
- [ ] 復元 → 通常一覧に戻る（末尾に追加）
- [ ] 完全削除 → 確認アラート → 関連データごと消える
- [ ] 5秒以内のundo → 元に戻る
- [ ] ウィジェットに削除済みが表示されない
- [ ] エクスポートに削除済みが含まれない
- [ ] 非表示エントリの削除が「最近削除した項目」に露出しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)