### PR TITLE
Fix save race condition and data loss in EditEntryView

### DIFF
--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -330,7 +330,8 @@ final class MangaViewModel {
                     mangaEntryID: entry.id,
                     episodeLabel: label
                 )
-                modelContext.insert(activity)
+                // ReadingActivity は entry と同じ context に挿入
+                (entry.modelContext ?? modelContext).insert(activity)
             } else if let ep = currentEpisode {
                 entry.lastReadDate = now
                 let activity = ReadingActivity(
@@ -339,12 +340,21 @@ final class MangaViewModel {
                     mangaEntryID: entry.id,
                     episodeNumber: ep
                 )
-                modelContext.insert(activity)
+                (entry.modelContext ?? modelContext).insert(activity)
             } else {
                 entry.lastReadDate = now
             }
         }
 
+        // entry が属するコンテキストで保存する（refresh() で modelContext が
+        // 差し替わっている場合、self.modelContext と異なる可能性がある）
+        if let entryCtx = entry.modelContext, entryCtx !== modelContext {
+            do {
+                try entryCtx.save()
+            } catch {
+                print("[MangaViewModel] updateEntry entryCtx save failed: \(error)")
+            }
+        }
         save()
     }
 

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -293,7 +293,8 @@ final class MangaViewModel {
         readingState: ReadingState,
         memo: String,
         currentEpisode: Int? = nil,
-        episodeLabel: String? = nil
+        episodeLabel: String? = nil,
+        markAsReadOnSave: Bool = false
     ) {
         let memoChanged = entry.memo != memo
         entry.name = name
@@ -315,6 +316,35 @@ final class MangaViewModel {
         }
         entry.currentEpisode = currentEpisode
         entry.episodeLabel = episodeLabel
+
+        // 「保存時に既読にする」を同一トランザクション内で処理し、save() を1回に統合
+        if markAsReadOnSave, entry.modelContext != nil {
+            let now = Date()
+            let trimmedLabel = episodeLabel?.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let label = trimmedLabel, !label.isEmpty {
+                entry.episodeLabel = label
+                entry.lastReadDate = now
+                let activity = ReadingActivity(
+                    date: now,
+                    mangaName: entry.name,
+                    mangaEntryID: entry.id,
+                    episodeLabel: label
+                )
+                modelContext.insert(activity)
+            } else if let ep = currentEpisode {
+                entry.lastReadDate = now
+                let activity = ReadingActivity(
+                    date: now,
+                    mangaName: entry.name,
+                    mangaEntryID: entry.id,
+                    episodeNumber: ep
+                )
+                modelContext.insert(activity)
+            } else {
+                entry.lastReadDate = now
+            }
+        }
+
         save()
     }
 

--- a/MangaLauncher/Views/CatchUp/CatchUpView.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpView.swift
@@ -313,6 +313,10 @@ struct CatchUpView: View {
         }
 
         unreadItems = newItems
+        // リロード後に currentIndex が範囲外にならないよう検証
+        if currentIndex > newItems.count {
+            currentIndex = newItems.count
+        }
         undoStack = undoStack.compactMap { item in
             guard let fresh = freshEntries[item.entry.id] else { return nil }
             return (entry: fresh, action: item.action)

--- a/MangaLauncher/Views/Entry/EditEntryView.swift
+++ b/MangaLauncher/Views/Entry/EditEntryView.swift
@@ -500,17 +500,9 @@ struct EditEntryView: View {
                 readingState: readingState,
                 memo: memo,
                 currentEpisode: currentEpisode,
-                episodeLabel: labelToSave
+                episodeLabel: labelToSave,
+                markAsReadOnSave: markAsReadOnSave
             )
-            if markAsReadOnSave {
-                if let labelToSave {
-                    viewModel.recordSpecialEpisode(entry, label: labelToSave)
-                } else if let ep = currentEpisode {
-                    viewModel.recordEpisodeRead(entry, episodeNumber: ep)
-                } else {
-                    entry.lastReadDate = Date()
-                }
-            }
         } else {
             viewModel.addEntry(
                 name: name,


### PR DESCRIPTION
## Summary
- EditEntryViewの保存時に`save()`が複数回呼ばれることで発生するSwiftData detached objectクラッシュを修正
- 「保存時に既読にする」で`lastReadDate`が永続化されないデータ消失バグを修正
- CatchUpViewの`reloadEntries()`後に`currentIndex`が範囲外になる可能性を防止
- CloudKit同期中にsheet操作した場合のModelContext不一致による保存漏れを修正（`setHidden()`パターン踏襲）

## Changes
- `markAsReadOnSave`ロジックを`updateEntry()`に統合し、1回の`save()`で完結
- `entry.modelContext != nil`ガードでdetached object安全対策
- `updateEntry()`でentryのModelContextがViewModelと異なる場合、両方のcontextを保存
- `CatchUpView.reloadEntries()`後に`currentIndex`のbounds check追加

## Test plan
- [ ] 編集画面で次回更新日を変更して保存 → クラッシュしないこと
- [ ] 「保存時に既読にする」ONで保存 → 既読記録が正しく作成されること
- [ ] CatchUpモードで外部データ変更（CloudKit sync）発生時にクラッシュしないこと
- [ ] 既存の編集・保存フローが正常に動作すること（デグレなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)