### PR TITLE
Fix widget image padding and duplicate entries (Closes #3)

### DIFF
--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -251,6 +251,8 @@ final class MangaViewModel {
     func addEntry(name: String, url: String, days: Set<DayOfWeek>, iconColor: String, publisher: String = "", imageData: Data? = nil, updateIntervalWeeks: Int = 1, nextExpectedUpdate: Date? = nil, publicationStatus: PublicationStatus = .active, readingState: ReadingState = .following, isOneShot: Bool = false, memo: String = "", currentEpisode: Int? = nil, episodeLabel: String? = nil) {
         for day in days {
             let existingEntries = fetchEntries(for: day)
+            // 同一URL + 同一曜日の重複登録を防止
+            if existingEntries.contains(where: { $0.url == url }) { continue }
             let maxOrder = existingEntries.map(\.sortOrder).max() ?? -1
             let entry = MangaEntry(
                 name: name,

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -250,9 +250,9 @@ final class MangaViewModel {
 
     func addEntry(name: String, url: String, days: Set<DayOfWeek>, iconColor: String, publisher: String = "", imageData: Data? = nil, updateIntervalWeeks: Int = 1, nextExpectedUpdate: Date? = nil, publicationStatus: PublicationStatus = .active, readingState: ReadingState = .following, isOneShot: Bool = false, memo: String = "", currentEpisode: Int? = nil, episodeLabel: String? = nil) {
         for day in days {
+            // 同一URL + 同一曜日の重複登録を防止（状態問わず全エントリ対象）
+            if allEntries().contains(where: { $0.dayOfWeek == day && $0.url == url }) { continue }
             let existingEntries = fetchEntries(for: day)
-            // 同一URL + 同一曜日の重複登録を防止
-            if existingEntries.contains(where: { $0.url == url }) { continue }
             let maxOrder = existingEntries.map(\.sortOrder).max() ?? -1
             let entry = MangaEntry(
                 name: name,
@@ -298,6 +298,15 @@ final class MangaViewModel {
         episodeLabel: String? = nil,
         markAsReadOnSave: Bool = false
     ) {
+        // URL または曜日が変更された場合、同一URL+曜日の重複を防止
+        let urlOrDayChanged = entry.url != url || entry.dayOfWeek != dayOfWeek
+        if urlOrDayChanged {
+            let conflict = allEntries().contains { existing in
+                existing.id != entry.id && existing.dayOfWeek == dayOfWeek && existing.url == url
+            }
+            if conflict { return }
+        }
+
         let memoChanged = entry.memo != memo
         entry.name = name
         entry.url = url

--- a/MangaWidget/MangaWidget.swift
+++ b/MangaWidget/MangaWidget.swift
@@ -60,16 +60,28 @@ struct MangaTimelineProvider: TimelineProvider {
             sortBy: [SortDescriptor(\.sortOrder)]
         )
         let results = (try? context.fetch(descriptor)) ?? []
-        var seenURLs = Set<String>()
-        let items = results.compactMap { entry -> MangaWidgetItem? in
-            guard seenURLs.insert(entry.url).inserted else { return nil }
-            return MangaWidgetItem(
-                id: entry.id, name: entry.name, url: entry.url,
-                iconColor: entry.iconColor, publisher: entry.publisher,
-                imageData: entry.imageData,
-                isRead: entry.isRead
-            )
+        var orderedURLs: [String] = []
+        var itemsByURL: [String: MangaWidgetItem] = [:]
+        for entry in results {
+            if let existing = itemsByURL[entry.url] {
+                // 重複がある場合、いずれか未読なら未読扱い
+                itemsByURL[entry.url] = MangaWidgetItem(
+                    id: existing.id, name: existing.name, url: existing.url,
+                    iconColor: existing.iconColor, publisher: existing.publisher,
+                    imageData: existing.imageData,
+                    isRead: existing.isRead && entry.isRead
+                )
+            } else {
+                orderedURLs.append(entry.url)
+                itemsByURL[entry.url] = MangaWidgetItem(
+                    id: entry.id, name: entry.name, url: entry.url,
+                    iconColor: entry.iconColor, publisher: entry.publisher,
+                    imageData: entry.imageData,
+                    isRead: entry.isRead
+                )
+            }
         }
+        let items = orderedURLs.compactMap { itemsByURL[$0] }
         return MangaTimelineEntry(
             date: date, items: items, dayOfWeek: selectedDay,
             isToday: selectedDay == DayOfWeek.today

--- a/MangaWidget/MangaWidget.swift
+++ b/MangaWidget/MangaWidget.swift
@@ -342,7 +342,7 @@ struct MangaWidgetEntryView: View {
                 if let imageData = item.imageData, let image = imageData.toSwiftUIImage() {
                     image
                         .resizable()
-                        .scaledToFit()
+                        .scaledToFill()
                 } else {
                     Rectangle()
                         .fill(Color.fromName(item.iconColor))

--- a/MangaWidget/MangaWidget.swift
+++ b/MangaWidget/MangaWidget.swift
@@ -60,12 +60,14 @@ struct MangaTimelineProvider: TimelineProvider {
             sortBy: [SortDescriptor(\.sortOrder)]
         )
         let results = (try? context.fetch(descriptor)) ?? []
-        let items = results.map {
-            MangaWidgetItem(
-                id: $0.id, name: $0.name, url: $0.url,
-                iconColor: $0.iconColor, publisher: $0.publisher,
-                imageData: $0.imageData,
-                isRead: $0.isRead
+        var seenURLs = Set<String>()
+        let items = results.compactMap { entry -> MangaWidgetItem? in
+            guard seenURLs.insert(entry.url).inserted else { return nil }
+            return MangaWidgetItem(
+                id: entry.id, name: entry.name, url: entry.url,
+                iconColor: entry.iconColor, publisher: entry.publisher,
+                imageData: entry.imageData,
+                isRead: entry.isRead
             )
         }
         return MangaTimelineEntry(


### PR DESCRIPTION
## Summary
- ウィジェットの `gridCell` で `scaledToFit()` → `scaledToFill()` に変更し、画像の余白を解消
- ウィジェットの重複排除: 同一URLエントリをマージ（いずれか未読なら未読ドット表示）
- `addEntry`: 全エントリ（状態問わず）を対象に同一URL+曜日の重複登録を防止
- `updateEntry`: URL/曜日変更時に既存エントリとの衝突を検出し、重複を防止

Closes #3

## Test plan
- [ ] Small / Medium / Large ウィジェットで画像が余白なく表示されることを確認
- [ ] 同じURLのエントリが重複していても、ウィジェットでは1つのみ表示されることを確認
- [ ] 重複エントリの片方が未読の場合、未読ドットが表示されることを確認
- [ ] 同じURLを同じ曜日に二重登録しようとした場合、スキップされることを確認
- [ ] 編集画面でURLや曜日を変更した際、既存エントリと衝突する場合は保存されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)