### PR TITLE
Fix crash on duplicate entry IDs in Dictionary init

### DIFF
--- a/MangaLauncher/Models/ActivityItem.swift
+++ b/MangaLauncher/Models/ActivityItem.swift
@@ -48,7 +48,7 @@ enum ActivityBuilder {
     }
 
     private static func merged(entries: [MangaEntry], comments: [MangaComment]) -> [ActivityItem] {
-        let entriesByID = Dictionary(uniqueKeysWithValues: entries.map { ($0.id, $0) })
+        let entriesByID = Dictionary(entries.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
         var items: [ActivityItem] = entries
             .filter { !$0.memo.isEmpty }
             .map { .memo($0) }

--- a/MangaLauncher/Models/MangaLifetime.swift
+++ b/MangaLauncher/Models/MangaLifetime.swift
@@ -35,7 +35,7 @@ enum LifetimeBuilder {
             }
         }
 
-        let entriesByID = Dictionary(uniqueKeysWithValues: entries.map { ($0.id, $0) })
+        let entriesByID = Dictionary(entries.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
 
         return activityDatesByEntry.compactMap { entryID, dates in
             guard let entry = entriesByID[entryID],

--- a/MangaLauncher/Models/TimelineItem.swift
+++ b/MangaLauncher/Models/TimelineItem.swift
@@ -166,7 +166,7 @@ enum TimelineBuilder {
         let startOfDay = calendar.startOfDay(for: date)
         let endOfDay = calendar.date(byAdding: .day, value: 1, to: startOfDay) ?? startOfDay
 
-        let entriesByID = Dictionary(uniqueKeysWithValues: entries.map { ($0.id, $0) })
+        let entriesByID = Dictionary(entries.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
 
         var items: [TimelineItem] = []
 

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -726,7 +726,7 @@ final class MangaViewModel {
             predicate: #Predicate { idArray.contains($0.id) }
         )
         let entries = modelContext.fetchLogged(descriptor)
-        return Dictionary(uniqueKeysWithValues: entries.map { ($0.id, $0) })
+        return Dictionary(entries.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
     }
 
     func markAsRead(_ entry: MangaEntry) {

--- a/MangaLauncher/Views/Search/SearchView.swift
+++ b/MangaLauncher/Views/Search/SearchView.swift
@@ -53,7 +53,7 @@ struct SearchView: View {
 
         if contentMode == .comment {
             let candidateIDs = Set(colorFiltered.map(\.id))
-            let entriesByID = Dictionary(uniqueKeysWithValues: colorFiltered.map { ($0.id, $0) })
+            let entriesByID = Dictionary(colorFiltered.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
             let allComments = viewModel.allComments()
             let commentMatched: [(MangaComment, MangaEntry)] = allComments.compactMap { comment in
                 guard candidateIDs.contains(comment.mangaEntryID),
@@ -82,7 +82,7 @@ struct SearchView: View {
                 && $0.memo.localizedCaseInsensitiveContains(trimmed)
         }
         let filteredIDs = Set(candidates.map(\.id))
-        let entriesByID = Dictionary(uniqueKeysWithValues: candidates.map { ($0.id, $0) })
+        let entriesByID = Dictionary(candidates.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
         let allComments = viewModel.allComments()
         let commentMatched: [(MangaComment, MangaEntry)] = allComments.compactMap { comment in
             guard filteredIDs.contains(comment.mangaEntryID),

--- a/MangaLauncherTests/MangaEntryTests.swift
+++ b/MangaLauncherTests/MangaEntryTests.swift
@@ -207,6 +207,58 @@ struct MangaEntryMigrationTests {
     }
 }
 
+@Suite("MangaViewModel.findEntries – duplicate ID regression")
+struct MangaViewModelFindEntriesTests {
+
+    private func makeContainer() throws -> ModelContainer {
+        try ModelContainer(
+            for: MangaEntry.self, ReadingActivity.self, MangaComment.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+    }
+
+    @Test("同一 UUID のエントリが複数存在してもクラッシュしない")
+    @MainActor
+    func findEntriesWithDuplicateIDsDoesNotCrash() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+
+        let sharedID = UUID()
+        let entry1 = MangaEntry(id: sharedID, name: "Entry A")
+        let entry2 = MangaEntry(id: sharedID, name: "Entry B")
+        context.insert(entry1)
+        context.insert(entry2)
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        let result = vm.findEntries(by: [sharedID])
+
+        // クラッシュせず辞書が返り、重複は先勝ちで 1 件に集約される
+        #expect(result.count == 1)
+        #expect(result[sharedID] != nil)
+    }
+
+    @Test("重複なしの場合は全件返る")
+    @MainActor
+    func findEntriesWithUniqueIDs() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+
+        let id1 = UUID()
+        let id2 = UUID()
+        context.insert(MangaEntry(id: id1, name: "A"))
+        context.insert(MangaEntry(id: id2, name: "B"))
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        let result = vm.findEntries(by: [id1, id2])
+
+        #expect(result.count == 2)
+        #expect(result[id1]?.name == "A")
+        #expect(result[id2]?.name == "B")
+    }
+}
+
 @Suite("MangaViewModel.runStartupMigrationsIfNeeded")
 struct MangaViewModelStartupTests {
 

--- a/MangaLauncherTests/TimelineBuilderTests.swift
+++ b/MangaLauncherTests/TimelineBuilderTests.swift
@@ -111,6 +111,27 @@ struct TimelineBuilderTests {
         #expect(days.count == 2)
     }
 
+    // MARK: - duplicate entry IDs
+
+    @Test("同一 UUID のエントリが複数渡ってもクラッシュしない")
+    func itemsWithDuplicateEntryIDs() {
+        let today = calendar.startOfDay(for: Date())
+        let sharedID = UUID()
+        let entry1 = makeEntry(id: sharedID, name: "A")
+        let entry2 = makeEntry(id: sharedID, name: "B")
+        let comment = makeComment(entryID: sharedID, createdAt: today.addingTimeInterval(3600))
+
+        let items = TimelineBuilder.items(
+            for: today,
+            entries: [entry1, entry2],
+            comments: [comment],
+            activities: []
+        )
+
+        // クラッシュせずにコメントが正常に紐付く
+        #expect(items.contains { $0.id == "c-\(comment.id.uuidString)" })
+    }
+
     // MARK: - dailyCounts
 
     @Test("dailyCounts は日×種別で 0 件も含む")


### PR DESCRIPTION
## Summary

- TestFlight v2.3 (146) でのクラッシュ修正
- `Dictionary(uniqueKeysWithValues:)` を `Dictionary(_, uniquingKeysWith:)` に置換（6箇所）
- 同一UUIDの`MangaEntry`が返ってきてもクラッシュせずに動作するように

## クラッシュ詳細

```
EXC_BREAKPOINT (SIGTRAP)
0  libswiftCore  _assertionFailure
1  MangaLauncher specialized _NativeDictionary.merge
2  MangaLauncher Dictionary.init<A>(uniqueKeysWithValues:)
3  MangaLauncher MangaViewModel.findEntries(by:)         ← MangaViewModel.swift:729
4  MangaLauncher CatchUpView.reloadEntries()             ← CatchUpView.swift:300
```

`Dictionary(uniqueKeysWithValues:)` は重複キーを与えると即クラッシュするAPI。
SwiftDataから取得したエントリ配列に同一UUIDが含まれていると発生する（CloudKit同期や移行で稀に発生し得る既知のパターン）。

## 修正内容

以下6箇所すべてを`uniquingKeysWith: { first, _ in first }` に統一：

- `MangaViewModel.swift:729` (findEntries)
- `Models/ActivityItem.swift:51`
- `Models/MangaLifetime.swift:38`
- `Models/TimelineItem.swift:169`
- `Views/Search/SearchView.swift:56` (comment mode)
- `Views/Search/SearchView.swift:85` (default mode)

すべて同じパターン `(entry.id, entry)` を辞書化する箇所で、重複時は先頭を採用する方針（同一IDなのでどちらを選んでも論理的に等価）。

## Test plan

- [x] `xcodebuild ... build` 成功確認済み
- [ ] CatchUp画面の開閉・リロードで再現テスト
- [ ] Search画面（コメント・通常モード）で動作確認
- [ ] Library Timeline / MangaLifetime 表示確認
- [ ] 既存のユニットテストがパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)