### PR TITLE
Add MangaLink feature for SNS and related links

### DIFF
--- a/MangaLauncher.xcodeproj/project.pbxproj
+++ b/MangaLauncher.xcodeproj/project.pbxproj
@@ -57,6 +57,10 @@
 		BC000001 /* MangaComment.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000010 /* MangaComment.swift */; };
 		BC000002 /* MangaComment.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000010 /* MangaComment.swift */; };
 		BC000003 /* MangaComment.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000010 /* MangaComment.swift */; };
+		CD000001 /* MangaLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD000010 /* MangaLink.swift */; };
+		CD000002 /* MangaLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD000010 /* MangaLink.swift */; };
+		CD000003 /* MangaLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD000010 /* MangaLink.swift */; };
+		CD000101 /* EditLinkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD000110 /* EditLinkView.swift */; };
 		BC000101 /* CommentListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000110 /* CommentListView.swift */; };
 		BC000301 /* ActivityItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000310 /* ActivityItem.swift */; };
 		AB2001FF00112233AA000001 /* TimelineItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2001FF00112233AA000002 /* TimelineItem.swift */; };
@@ -222,6 +226,8 @@
 		A576F9BEFBD3B37AA9275FAB /* MangaWidget.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = MangaWidget.entitlements; sourceTree = "<group>"; };
 		AA000010 /* ReadingActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingActivity.swift; sourceTree = "<group>"; };
 		BC000010 /* MangaComment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaComment.swift; sourceTree = "<group>"; };
+		CD000010 /* MangaLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaLink.swift; sourceTree = "<group>"; };
+		CD000110 /* EditLinkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditLinkView.swift; sourceTree = "<group>"; };
 		BC000110 /* CommentListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentListView.swift; sourceTree = "<group>"; };
 		BC000310 /* ActivityItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityItem.swift; sourceTree = "<group>"; };
 		AB2001FF00112233AA000002 /* TimelineItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineItem.swift; sourceTree = "<group>"; };
@@ -418,6 +424,7 @@
 				3AFF912AECB7C6B219DD1600 /* BackupData.swift */,
 				AA000010 /* ReadingActivity.swift */,
 				BC000010 /* MangaComment.swift */,
+				CD000010 /* MangaLink.swift */,
 				BC000310 /* ActivityItem.swift */,
 				AB2001FF00112233AA000002 /* TimelineItem.swift */,
 				AB4001FF00112233AA000006 /* AppError.swift */,
@@ -578,6 +585,7 @@
 				EEC07D90615785B81C2E71C8 /* ImageCropView.swift */,
 				A2000005 /* EditEntryView.swift */,
 				AB4001FF00112233AA000004 /* EditEntryStatusSection.swift */,
+				CD000110 /* EditLinkView.swift */,
 			);
 			path = Entry;
 			sourceTree = "<group>";
@@ -792,6 +800,7 @@
 				EC440D83EFDF1B4B6F95E82D /* ModelContextExtensions.swift in Sources */,
 				AA000001 /* ReadingActivity.swift in Sources */,
 				BC000001 /* MangaComment.swift in Sources */,
+				CD000001 /* MangaLink.swift in Sources */,
 				ECFEA84A2F7F6E5700CE4DC0 /* MangaURLOpener.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -810,6 +819,7 @@
 				ECFEA8962F7F93AF00CE4DC0 /* ModelContextExtensions.swift in Sources */,
 				AA000002 /* ReadingActivity.swift in Sources */,
 				BC000002 /* MangaComment.swift in Sources */,
+				CD000002 /* MangaLink.swift in Sources */,
 				ECFEA8492F7F6E5700CE4DC0 /* MangaURLOpener.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -907,6 +917,8 @@
 				ECFEA82E2F7E91BD00CE4DC0 /* EntryIcon.swift in Sources */,
 				AA000003 /* ReadingActivity.swift in Sources */,
 				BC000003 /* MangaComment.swift in Sources */,
+				CD000003 /* MangaLink.swift in Sources */,
+				CD000101 /* EditLinkView.swift in Sources */,
 				ECFEA8602F7F7E2000CE4DC0 /* DayPageView.swift in Sources */,
 				AA000004 /* ReadingHeatmapView.swift in Sources */,
 			);

--- a/MangaLauncher/Models/BackupData.swift
+++ b/MangaLauncher/Models/BackupData.swift
@@ -8,6 +8,7 @@ struct BackupData: Codable {
     let entries: [BackupEntry]
     let activities: [BackupActivity]?
     let comments: [BackupComment]?
+    let links: [BackupLink]?
 
     struct BackupActivity: Codable {
         let id: UUID
@@ -45,6 +46,17 @@ struct BackupData: Codable {
         let id: UUID
         let mangaEntryID: UUID
         let content: String
+        let createdAt: Date
+        let updatedAt: Date?
+    }
+
+    struct BackupLink: Codable {
+        let id: UUID
+        let mangaEntryID: UUID
+        let linkTypeRawValue: Int
+        let title: String
+        let url: String
+        let sortOrder: Int
         let createdAt: Date
         let updatedAt: Date?
     }
@@ -136,9 +148,9 @@ struct BackupData: Codable {
         }
     }
 
-    static func from(_ entries: [MangaEntry], activities: [ReadingActivity] = [], comments: [MangaComment] = []) -> BackupData {
+    static func from(_ entries: [MangaEntry], activities: [ReadingActivity] = [], comments: [MangaComment] = [], links: [MangaLink] = []) -> BackupData {
         BackupData(
-            version: 13,
+            version: 14,
             exportDate: Date(),
             entries: entries.map {
                 BackupEntry(
@@ -179,6 +191,18 @@ struct BackupData: Codable {
                     id: $0.id,
                     mangaEntryID: $0.mangaEntryID,
                     content: $0.content,
+                    createdAt: $0.createdAt,
+                    updatedAt: $0.updatedAt
+                )
+            },
+            links: links.map {
+                BackupLink(
+                    id: $0.id,
+                    mangaEntryID: $0.mangaEntryID,
+                    linkTypeRawValue: $0.linkTypeRawValue,
+                    title: $0.title,
+                    url: $0.url,
+                    sortOrder: $0.sortOrder,
                     createdAt: $0.createdAt,
                     updatedAt: $0.updatedAt
                 )

--- a/MangaLauncher/Models/MangaLink.swift
+++ b/MangaLauncher/Models/MangaLink.swift
@@ -27,7 +27,7 @@ enum LinkType: Int, Codable, CaseIterable, Identifiable {
 
     var iconName: String {
         switch self {
-        case .twitter: "bird"
+        case .twitter: "at"
         case .website: "globe"
         case .pixiv: "paintbrush"
         case .youtube: "play.rectangle"
@@ -40,12 +40,13 @@ enum LinkType: Int, Codable, CaseIterable, Identifiable {
     /// URL 文字列からリンク種別を自動判定する。
     /// 判定できない場合は `.other` を返す。
     static func detect(from urlString: String) -> LinkType {
-        let lower = urlString.lowercased()
-        if lower.contains("twitter.com") || lower.contains("x.com") { return .twitter }
-        if lower.contains("pixiv.net") { return .pixiv }
-        if lower.contains("youtube.com") || lower.contains("youtu.be") { return .youtube }
-        if lower.contains("instagram.com") { return .instagram }
-        if lower.contains("tiktok.com") { return .tiktok }
+        guard let url = URL(string: urlString),
+              let host = url.host?.lowercased() else { return .other }
+        if host.hasSuffix("twitter.com") || host.hasSuffix("x.com") { return .twitter }
+        if host.hasSuffix("pixiv.net") { return .pixiv }
+        if host.hasSuffix("youtube.com") || host.hasSuffix("youtu.be") { return .youtube }
+        if host.hasSuffix("instagram.com") { return .instagram }
+        if host.hasSuffix("tiktok.com") { return .tiktok }
         return .other
     }
 }

--- a/MangaLauncher/Models/MangaLink.swift
+++ b/MangaLauncher/Models/MangaLink.swift
@@ -1,0 +1,87 @@
+import Foundation
+import SwiftData
+
+/// リンクの種類
+enum LinkType: Int, Codable, CaseIterable, Identifiable {
+    case twitter = 0
+    case website = 1
+    case pixiv = 2
+    case youtube = 3
+    case instagram = 4
+    case tiktok = 5
+    case other = 99
+
+    var id: Int { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .twitter: "X (Twitter)"
+        case .website: "公式サイト"
+        case .pixiv: "pixiv"
+        case .youtube: "YouTube"
+        case .instagram: "Instagram"
+        case .tiktok: "TikTok"
+        case .other: "その他"
+        }
+    }
+
+    var iconName: String {
+        switch self {
+        case .twitter: "bird"
+        case .website: "globe"
+        case .pixiv: "paintbrush"
+        case .youtube: "play.rectangle"
+        case .instagram: "camera"
+        case .tiktok: "music.note"
+        case .other: "link"
+        }
+    }
+
+    /// URL 文字列からリンク種別を自動判定する。
+    /// 判定できない場合は `.other` を返す。
+    static func detect(from urlString: String) -> LinkType {
+        let lower = urlString.lowercased()
+        if lower.contains("twitter.com") || lower.contains("x.com") { return .twitter }
+        if lower.contains("pixiv.net") { return .pixiv }
+        if lower.contains("youtube.com") || lower.contains("youtu.be") { return .youtube }
+        if lower.contains("instagram.com") { return .instagram }
+        if lower.contains("tiktok.com") { return .tiktok }
+        return .other
+    }
+}
+
+/// マンガ作品に紐付く関連リンク（SNS・公式サイトなど）
+@Model
+final class MangaLink: Identifiable {
+    var id: UUID = UUID()
+    var mangaEntryID: UUID = UUID()
+    var linkTypeRawValue: Int = 99
+    var title: String = ""
+    var url: String = ""
+    var sortOrder: Int = 0
+    var createdAt: Date = Date()
+    var updatedAt: Date?
+
+    @Transient
+    var linkType: LinkType {
+        get { LinkType(rawValue: linkTypeRawValue) ?? .other }
+        set { linkTypeRawValue = newValue.rawValue }
+    }
+
+    init(
+        mangaEntryID: UUID,
+        linkType: LinkType = .other,
+        title: String = "",
+        url: String,
+        sortOrder: Int = 0
+    ) {
+        self.id = UUID()
+        self.mangaEntryID = mangaEntryID
+        self.linkTypeRawValue = linkType.rawValue
+        self.title = title
+        self.url = url
+        self.sortOrder = sortOrder
+        self.createdAt = Date()
+        self.updatedAt = nil
+    }
+}

--- a/MangaLauncher/Shared/SharedModelContainer.swift
+++ b/MangaLauncher/Shared/SharedModelContainer.swift
@@ -14,7 +14,7 @@ enum SharedModelContainer {
     /// アプリ更新直後など CloudKit の準備が間に合わない一時的な失敗を吸収する。
     /// 全試行失敗時は最後のエラーを throw する。
     static func create(maxAttempts: Int = 3) throws -> ModelContainer {
-        let schema = Schema([MangaEntry.self, ReadingActivity.self, MangaComment.self])
+        let schema = Schema([MangaEntry.self, ReadingActivity.self, MangaComment.self, MangaLink.self])
         let config = ModelConfiguration(
             "MangaLauncher",
             schema: schema,
@@ -48,7 +48,7 @@ enum SharedModelContainer {
     /// データ連続性は保たれる。次回起動で CloudKit が回復していれば create() に
     /// 戻り、ローカル更新分も sync される (SwiftData が変更を検出して push)。
     static func createLocalOnly() throws -> ModelContainer {
-        let schema = Schema([MangaEntry.self, ReadingActivity.self, MangaComment.self])
+        let schema = Schema([MangaEntry.self, ReadingActivity.self, MangaComment.self, MangaLink.self])
         let config = ModelConfiguration(
             "MangaLauncher",
             schema: schema,

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -618,7 +618,9 @@ final class MangaViewModel {
         let activities = modelContext.fetchLogged(activityDescriptor).filter { activeEntryIDs.contains($0.mangaEntryID) }
         let commentDescriptor = FetchDescriptor<MangaComment>(sortBy: [SortDescriptor(\.createdAt)])
         let comments = modelContext.fetchLogged(commentDescriptor).filter { activeEntryIDs.contains($0.mangaEntryID) }
-        let backup = BackupData.from(entries, activities: activities, comments: comments)
+        let linkDescriptor = FetchDescriptor<MangaLink>(sortBy: [SortDescriptor(\.sortOrder)])
+        let links = modelContext.fetchLogged(linkDescriptor).filter { activeEntryIDs.contains($0.mangaEntryID) }
+        let backup = BackupData.from(entries, activities: activities, comments: comments, links: links)
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return try? encoder.encode(backup)
@@ -702,6 +704,24 @@ final class MangaViewModel {
                 activity.id = backupActivity.id
                 activity.timestamp = backupActivity.timestamp
                 modelContext.insert(activity)
+                importedCount += 1
+            }
+        }
+        if let backupLinks = backup.links {
+            let existingLinkIDs = Set(modelContext.fetchLogged(FetchDescriptor<MangaLink>()).map(\.id))
+            for backupLink in backupLinks {
+                guard !existingLinkIDs.contains(backupLink.id) else { continue }
+                let link = MangaLink(
+                    mangaEntryID: backupLink.mangaEntryID,
+                    linkType: LinkType(rawValue: backupLink.linkTypeRawValue) ?? .other,
+                    title: backupLink.title,
+                    url: backupLink.url,
+                    sortOrder: backupLink.sortOrder
+                )
+                link.id = backupLink.id
+                link.createdAt = backupLink.createdAt
+                link.updatedAt = backupLink.updatedAt
+                modelContext.insert(link)
                 importedCount += 1
             }
         }
@@ -862,6 +882,57 @@ final class MangaViewModel {
         let result = modelContext.fetchLogged(descriptor).filter { !pendingIDs.contains($0.id) }
         cachedComments = result
         return result
+    }
+
+    // MARK: - Links
+
+    func addLink(_ entry: MangaEntry, linkType: LinkType, title: String, url: String) {
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedURL = url.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedURL.isEmpty else { return }
+        let existingLinks = fetchLinks(for: entry)
+        let nextOrder = (existingLinks.map(\.sortOrder).max() ?? -1) + 1
+        let link = MangaLink(
+            mangaEntryID: entry.id,
+            linkType: linkType,
+            title: trimmedTitle,
+            url: trimmedURL,
+            sortOrder: nextOrder
+        )
+        modelContext.insert(link)
+        save()
+    }
+
+    func updateLink(_ link: MangaLink, linkType: LinkType, title: String, url: String) {
+        let trimmedURL = url.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedURL.isEmpty else { return }
+        link.linkType = linkType
+        link.title = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        link.url = trimmedURL
+        link.updatedAt = Date()
+        save()
+    }
+
+    func deleteLink(_ link: MangaLink) {
+        modelContext.delete(link)
+        save()
+    }
+
+    func fetchLinks(for entry: MangaEntry) -> [MangaLink] {
+        let _ = refreshCounter
+        let entryID = entry.id
+        let descriptor = FetchDescriptor<MangaLink>(
+            predicate: #Predicate { $0.mangaEntryID == entryID },
+            sortBy: [SortDescriptor(\.sortOrder)]
+        )
+        return modelContext.fetchLogged(descriptor)
+    }
+
+    func allLinks() -> [MangaLink] {
+        let descriptor = FetchDescriptor<MangaLink>(
+            sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
+        )
+        return modelContext.fetchLogged(descriptor)
     }
 
     /// タイムラインのアクティビティドットや日別集計に使う全 ReadingActivity。

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -708,7 +708,7 @@ final class MangaViewModel {
             }
         }
         if let backupLinks = backup.links {
-            let existingLinkIDs = Set(modelContext.fetchLogged(FetchDescriptor<MangaLink>()).map(\.id))
+            var existingLinkIDs = Set(modelContext.fetchLogged(FetchDescriptor<MangaLink>()).map(\.id))
             for backupLink in backupLinks {
                 guard !existingLinkIDs.contains(backupLink.id) else { continue }
                 let link = MangaLink(
@@ -722,6 +722,7 @@ final class MangaViewModel {
                 link.createdAt = backupLink.createdAt
                 link.updatedAt = backupLink.updatedAt
                 modelContext.insert(link)
+                existingLinkIDs.insert(backupLink.id)
                 importedCount += 1
             }
         }
@@ -933,6 +934,15 @@ final class MangaViewModel {
             sortBy: [SortDescriptor(\.createdAt, order: .reverse)]
         )
         return modelContext.fetchLogged(descriptor)
+    }
+
+    func moveLinks(for entry: MangaEntry, from source: IndexSet, to destination: Int) {
+        var links = fetchLinks(for: entry)
+        links.move(fromOffsets: source, toOffset: destination)
+        for (index, link) in links.enumerated() {
+            link.sortOrder = index
+        }
+        save()
     }
 
     /// タイムラインのアクティビティドットや日別集計に使う全 ReadingActivity。

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -470,6 +470,10 @@ final class MangaViewModel {
         if let comments = try? modelContext.fetch(commentDescriptor) {
             for comment in comments { modelContext.delete(comment) }
         }
+        let linkDescriptor = FetchDescriptor<MangaLink>(predicate: #Predicate { $0.mangaEntryID == entryID })
+        if let links = try? modelContext.fetch(linkDescriptor) {
+            for link in links { modelContext.delete(link) }
+        }
         modelContext.delete(entry)
     }
 
@@ -917,6 +921,7 @@ final class MangaViewModel {
     func deleteLink(_ link: MangaLink) {
         modelContext.delete(link)
         save()
+        refreshCounter += 1
     }
 
     func fetchLinks(for entry: MangaEntry) -> [MangaLink] {
@@ -943,6 +948,7 @@ final class MangaViewModel {
             link.sortOrder = index
         }
         save()
+        refreshCounter += 1
     }
 
     /// タイムラインのアクティビティドットや日別集計に使う全 ReadingActivity。

--- a/MangaLauncher/Views/Entry/EditEntryView.swift
+++ b/MangaLauncher/Views/Entry/EditEntryView.swift
@@ -478,10 +478,12 @@ struct EditEntryView: View {
                     }
                 }
                 .onDelete { indexSet in
-                    let links = viewModel.fetchLinks(for: entry)
                     for index in indexSet {
                         viewModel.deleteLink(links[index])
                     }
+                }
+                .onMove { source, destination in
+                    viewModel.moveLinks(for: entry, from: source, to: destination)
                 }
             }
             Button {

--- a/MangaLauncher/Views/Entry/EditEntryView.swift
+++ b/MangaLauncher/Views/Entry/EditEntryView.swift
@@ -36,6 +36,8 @@ struct EditEntryView: View {
     @State private var episodeText: String = ""
     @State private var episodeLabel: String = ""
     @State private var markAsReadOnSave: Bool = false
+    @State private var editingLink: MangaLink?
+    @State private var showingAddLink = false
 
     private var theme: ThemeStyle { ThemeManager.shared.style }
 
@@ -148,6 +150,11 @@ struct EditEntryView: View {
 
                 episodeSection
                 memoSection
+
+                if isEditing {
+                    linksSection
+                }
+
                 colorSection
 
                 if isEditing && showsDeleteButton {
@@ -197,6 +204,16 @@ struct EditEntryView: View {
                 }
             }
             #endif
+            .sheet(isPresented: $showingAddLink) {
+                if let entry {
+                    EditLinkView(viewModel: viewModel, entry: entry)
+                }
+            }
+            .sheet(item: $editingLink) { link in
+                if let entry {
+                    EditLinkView(viewModel: viewModel, entry: entry, link: link)
+                }
+            }
         }
     }
 
@@ -429,6 +446,53 @@ struct EditEntryView: View {
             Text("メモ")
         } footer: {
             Text("作品ごとに 1 つの長文メモを保存できます。コメントとは別物です。")
+        }
+    }
+
+    @ViewBuilder
+    private var linksSection: some View {
+        Section {
+            if let entry {
+                let links = viewModel.fetchLinks(for: entry)
+                ForEach(links) { link in
+                    Button {
+                        editingLink = link
+                    } label: {
+                        HStack {
+                            Image(systemName: link.linkType.iconName)
+                                .foregroundStyle(theme.primary)
+                                .frame(width: 24)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(link.title.isEmpty ? link.linkType.displayName : link.title)
+                                    .foregroundStyle(theme.onSurface)
+                                Text(link.url)
+                                    .font(theme.captionFont)
+                                    .foregroundStyle(theme.onSurfaceVariant)
+                                    .lineLimit(1)
+                            }
+                            Spacer()
+                            Image(systemName: "chevron.right")
+                                .font(.caption)
+                                .foregroundStyle(theme.onSurfaceVariant.opacity(0.5))
+                        }
+                    }
+                }
+                .onDelete { indexSet in
+                    let links = viewModel.fetchLinks(for: entry)
+                    for index in indexSet {
+                        viewModel.deleteLink(links[index])
+                    }
+                }
+            }
+            Button {
+                showingAddLink = true
+            } label: {
+                Label("リンクを追加", systemImage: "plus.circle")
+            }
+        } header: {
+            Text("関連リンク")
+        } footer: {
+            Text("作品の公式サイトやSNSアカウントなどのリンクを追加できます。")
         }
     }
 

--- a/MangaLauncher/Views/Entry/EditLinkView.swift
+++ b/MangaLauncher/Views/Entry/EditLinkView.swift
@@ -1,0 +1,112 @@
+import SwiftUI
+
+/// 関連リンクの追加・編集シート
+struct EditLinkView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    var viewModel: MangaViewModel
+    let entry: MangaEntry
+    var link: MangaLink?
+
+    @State private var linkType: LinkType = .other
+    @State private var title: String = ""
+    @State private var url: String = ""
+    @State private var didLoad = false
+
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
+    private var isEditing: Bool { link != nil }
+
+    private static let allowedSchemes: Set<String> = ["https", "http"]
+
+    private var isValidURL: Bool {
+        guard let parsed = URL(string: url),
+              let scheme = parsed.scheme?.lowercased() else { return false }
+        return Self.allowedSchemes.contains(scheme)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("リンク種別") {
+                    Picker("種別", selection: $linkType) {
+                        ForEach(LinkType.allCases) { type in
+                            Label(type.displayName, systemImage: type.iconName)
+                                .tag(type)
+                        }
+                    }
+                }
+
+                Section("リンク情報") {
+                    TextField("タイトル（任意）", text: $title)
+                        #if os(iOS) || os(visionOS)
+                        .textInputAutocapitalization(.never)
+                        #endif
+                    TextField("URL", text: $url)
+                        #if os(iOS) || os(visionOS)
+                        .textInputAutocapitalization(.never)
+                        .keyboardType(.URL)
+                        #endif
+                        .autocorrectionDisabled()
+                        .onChange(of: url) { _, newValue in
+                            if !isEditing && linkType == .other {
+                                let detected = LinkType.detect(from: newValue)
+                                if detected != .other {
+                                    linkType = detected
+                                }
+                            }
+                        }
+                    if !url.isEmpty && !isValidURL {
+                        Text("有効なURLを入力してください（例: https://...）")
+                            .font(theme.captionFont)
+                            .foregroundStyle(theme.error)
+                    }
+                }
+            }
+            .themedNavigationStyle()
+            .navigationTitle(isEditing ? "リンクを編集" : "リンクを追加")
+            #if os(iOS) || os(visionOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("キャンセル") {
+                        dismiss()
+                    }
+                    .if(theme.forceDarkMode) { view in
+                        view.foregroundStyle(theme.onSurfaceVariant)
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("保存") {
+                        saveLink()
+                        dismiss()
+                    }
+                    .disabled(url.isEmpty || !isValidURL)
+                    .if(theme.forceDarkMode) { view in
+                        view.foregroundStyle(theme.primary)
+                    }
+                }
+            }
+            .onAppear { loadLinkIfNeeded() }
+        }
+    }
+
+    private func loadLinkIfNeeded() {
+        guard !didLoad else { return }
+        if let link {
+            linkType = link.linkType
+            title = link.title
+            url = link.url
+        }
+        didLoad = true
+    }
+
+    private func saveLink() {
+        if let link {
+            viewModel.updateLink(link, linkType: linkType, title: title, url: url)
+        } else {
+            viewModel.addLink(entry, linkType: linkType, title: title, url: url)
+        }
+    }
+}

--- a/MangaLauncher/Views/Library/AllPublishersView.swift
+++ b/MangaLauncher/Views/Library/AllPublishersView.swift
@@ -111,7 +111,7 @@ struct PublisherEntriesView: View {
                     .buttonStyle(.plain)
                     .listRowBackground(Color.clear)
                     .contextMenu {
-                        MangaContextMenu(entry: entry, viewModel: viewModel, editingEntry: $editingEntry, commentingEntry: $commentingEntry, onShowLifetime: { lifetimeEntry = entry }, onRecordSpecialEpisode: {
+                        MangaContextMenu(entry: entry, viewModel: viewModel, editingEntry: $editingEntry, commentingEntry: $commentingEntry, links: viewModel.fetchLinks(for: entry), onShowLifetime: { lifetimeEntry = entry }, onRecordSpecialEpisode: {
                             specialEpisodeEntry = entry
                             showSpecialEpisodeAlert = true
                         })

--- a/MangaLauncher/Views/Library/LibraryCard.swift
+++ b/MangaLauncher/Views/Library/LibraryCard.swift
@@ -64,7 +64,7 @@ struct LibraryCard: View {
         }
         .buttonStyle(.plain)
         .contextMenu {
-            MangaContextMenu(entry: entry, viewModel: viewModel, editingEntry: $editingEntry, commentingEntry: $commentingEntry, onShowLifetime: { lifetimeEntry = entry }, onRecordSpecialEpisode: { showSpecialEpisodeAlert = true })
+            MangaContextMenu(entry: entry, viewModel: viewModel, editingEntry: $editingEntry, commentingEntry: $commentingEntry, links: viewModel.fetchLinks(for: entry), onShowLifetime: { lifetimeEntry = entry }, onRecordSpecialEpisode: { showSpecialEpisodeAlert = true })
         }
         .specialEpisodeAlert(entry: entry, viewModel: viewModel, isPresented: $showSpecialEpisodeAlert)
         .sheet(item: $lifetimeEntry) { entry in

--- a/MangaLauncher/Views/MangaCell/MangaContextMenu.swift
+++ b/MangaLauncher/Views/MangaCell/MangaContextMenu.swift
@@ -65,6 +65,31 @@ struct MangaContextMenu: View {
             Label("コメント", systemImage: "bubble.left.and.bubble.right")
         }
 
+        // MARK: 関連リンク
+        let links = viewModel.fetchLinks(for: entry)
+        if !links.isEmpty {
+            Menu {
+                ForEach(links) { link in
+                    Button {
+                        if let url = URL(string: link.url) {
+                            #if canImport(UIKit)
+                            UIApplication.shared.open(url)
+                            #elseif canImport(AppKit)
+                            NSWorkspace.shared.open(url)
+                            #endif
+                        }
+                    } label: {
+                        Label(
+                            link.title.isEmpty ? link.linkType.displayName : link.title,
+                            systemImage: link.linkType.iconName
+                        )
+                    }
+                }
+            } label: {
+                Label("関連リンク", systemImage: "link")
+            }
+        }
+
         if let onShowLifetime {
             Button {
                 onShowLifetime()

--- a/MangaLauncher/Views/MangaCell/MangaContextMenu.swift
+++ b/MangaLauncher/Views/MangaCell/MangaContextMenu.swift
@@ -5,9 +5,11 @@ struct MangaContextMenu: View {
     var viewModel: MangaViewModel
     @Binding var editingEntry: MangaEntry?
     @Binding var commentingEntry: MangaEntry?
+    var links: [MangaLink] = []
     var onShowLifetime: (() -> Void)? = nil
     var onRecordSpecialEpisode: (() -> Void)? = nil
     var onReorder: (() -> Void)? = nil
+    @Environment(\.openURL) private var openURL
 
     var body: some View {
         // MARK: 既読/未読トグル
@@ -66,17 +68,12 @@ struct MangaContextMenu: View {
         }
 
         // MARK: 関連リンク
-        let links = viewModel.fetchLinks(for: entry)
         if !links.isEmpty {
             Menu {
                 ForEach(links) { link in
                     Button {
                         if let url = URL(string: link.url) {
-                            #if canImport(UIKit)
-                            UIApplication.shared.open(url)
-                            #elseif canImport(AppKit)
-                            NSWorkspace.shared.open(url)
-                            #endif
+                            openURL(url)
                         }
                     } label: {
                         Label(

--- a/MangaLauncher/Views/MangaCell/MangaGridCell.swift
+++ b/MangaLauncher/Views/MangaCell/MangaGridCell.swift
@@ -103,7 +103,7 @@ struct MangaGridCell: View {
                 }
             }
             .contextMenu {
-                MangaContextMenu(entry: entry, viewModel: viewModel, editingEntry: $editingEntry, commentingEntry: $commentingEntry, onShowLifetime: { lifetimeEntry = entry }, onRecordSpecialEpisode: { showSpecialEpisodeAlert = true }) {
+                MangaContextMenu(entry: entry, viewModel: viewModel, editingEntry: $editingEntry, commentingEntry: $commentingEntry, links: viewModel.fetchLinks(for: entry), onShowLifetime: { lifetimeEntry = entry }, onRecordSpecialEpisode: { showSpecialEpisodeAlert = true }) {
                     withAnimation(.easeInOut(duration: 0.2)) {
                         isGridEditMode = true
                     }

--- a/MangaLauncher/Views/MangaCell/MangaRowCell.swift
+++ b/MangaLauncher/Views/MangaCell/MangaRowCell.swift
@@ -153,7 +153,7 @@ struct MangaRowCell: View {
                 }
             )
             .contextMenu {
-                MangaContextMenu(entry: entry, viewModel: viewModel, editingEntry: $editingEntry, commentingEntry: $commentingEntry, onShowLifetime: { lifetimeEntry = entry }, onRecordSpecialEpisode: { showSpecialEpisodeAlert = true }) {
+                MangaContextMenu(entry: entry, viewModel: viewModel, editingEntry: $editingEntry, commentingEntry: $commentingEntry, links: viewModel.fetchLinks(for: entry), onShowLifetime: { lifetimeEntry = entry }, onRecordSpecialEpisode: { showSpecialEpisodeAlert = true }) {
                     #if os(iOS) || os(visionOS)
                     withAnimation(.easeInOut(duration: 0.2)) {
                         listEditMode = .active

--- a/MangaLauncher/Views/Search/SearchResultRow.swift
+++ b/MangaLauncher/Views/Search/SearchResultRow.swift
@@ -57,7 +57,7 @@ struct SearchResultRow: View {
         .listRowBackground(Color.clear)
         .listRowSeparator(.hidden)
         .contextMenu {
-            MangaContextMenu(entry: entry, viewModel: viewModel, editingEntry: $editingEntry, commentingEntry: $commentingEntry, onShowLifetime: { lifetimeEntry = entry }, onRecordSpecialEpisode: { showSpecialEpisodeAlert = true })
+            MangaContextMenu(entry: entry, viewModel: viewModel, editingEntry: $editingEntry, commentingEntry: $commentingEntry, links: viewModel.fetchLinks(for: entry), onShowLifetime: { lifetimeEntry = entry }, onRecordSpecialEpisode: { showSpecialEpisodeAlert = true })
         }
         .specialEpisodeAlert(entry: entry, viewModel: viewModel, isPresented: $showSpecialEpisodeAlert)
         .sheet(item: $lifetimeEntry) { entry in

--- a/MangaLauncherTests/MangaEntryTests.swift
+++ b/MangaLauncherTests/MangaEntryTests.swift
@@ -465,6 +465,12 @@ struct LinkTypeDetectTests {
     func unknownIsOther() {
         #expect(LinkType.detect(from: "https://example.com") == .other)
     }
+
+    @Test("サブドメインマッチで誤検出しない")
+    func noFalsePositiveOnSubstring() {
+        #expect(LinkType.detect(from: "https://notx.com/user") == .other)
+        #expect(LinkType.detect(from: "https://faketiktok.com/user") == .other)
+    }
 }
 
 @Suite("MangaLink Backup")

--- a/MangaLauncherTests/MangaEntryTests.swift
+++ b/MangaLauncherTests/MangaEntryTests.swift
@@ -295,3 +295,243 @@ struct MangaViewModelStartupTests {
         #expect(legacy.readingState == .following) // migration が再走しないので戻されない
     }
 }
+
+// MARK: - MangaLink Tests
+
+@Suite("MangaLink CRUD")
+struct MangaLinkTests {
+
+    private func makeContainer() throws -> ModelContainer {
+        try ModelContainer(
+            for: MangaEntry.self, ReadingActivity.self, MangaComment.self, MangaLink.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+    }
+
+    @Test("リンクの追加と取得")
+    @MainActor
+    func addAndFetchLink() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let entry = MangaEntry(name: "Test Manga")
+        context.insert(entry)
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        vm.addLink(entry, linkType: .twitter, title: "公式X", url: "https://x.com/test")
+
+        let links = vm.fetchLinks(for: entry)
+        #expect(links.count == 1)
+        #expect(links[0].linkType == .twitter)
+        #expect(links[0].title == "公式X")
+        #expect(links[0].url == "https://x.com/test")
+    }
+
+    @Test("リンクの更新")
+    @MainActor
+    func updateLink() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let entry = MangaEntry(name: "Test Manga")
+        context.insert(entry)
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        vm.addLink(entry, linkType: .twitter, title: "旧タイトル", url: "https://x.com/old")
+
+        let link = vm.fetchLinks(for: entry)[0]
+        vm.updateLink(link, linkType: .website, title: "新タイトル", url: "https://example.com")
+
+        let updated = vm.fetchLinks(for: entry)[0]
+        #expect(updated.linkType == .website)
+        #expect(updated.title == "新タイトル")
+        #expect(updated.url == "https://example.com")
+        #expect(updated.updatedAt != nil)
+    }
+
+    @Test("リンクの削除")
+    @MainActor
+    func deleteLink() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let entry = MangaEntry(name: "Test Manga")
+        context.insert(entry)
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        vm.addLink(entry, linkType: .twitter, title: "", url: "https://x.com/test")
+        vm.addLink(entry, linkType: .pixiv, title: "", url: "https://pixiv.net/test")
+
+        let links = vm.fetchLinks(for: entry)
+        #expect(links.count == 2)
+
+        vm.deleteLink(links[0])
+        let remaining = vm.fetchLinks(for: entry)
+        #expect(remaining.count == 1)
+    }
+
+    @Test("sortOrder による並び順")
+    @MainActor
+    func sortOrderIsRespected() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let entry = MangaEntry(name: "Test Manga")
+        context.insert(entry)
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        vm.addLink(entry, linkType: .twitter, title: "First", url: "https://x.com/1")
+        vm.addLink(entry, linkType: .pixiv, title: "Second", url: "https://pixiv.net/2")
+        vm.addLink(entry, linkType: .youtube, title: "Third", url: "https://youtube.com/3")
+
+        let links = vm.fetchLinks(for: entry)
+        #expect(links[0].title == "First")
+        #expect(links[1].title == "Second")
+        #expect(links[2].title == "Third")
+    }
+
+    @Test("moveLinks で並べ替え")
+    @MainActor
+    func moveLinkReordersSortOrder() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let entry = MangaEntry(name: "Test Manga")
+        context.insert(entry)
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        vm.addLink(entry, linkType: .twitter, title: "A", url: "https://x.com/a")
+        vm.addLink(entry, linkType: .pixiv, title: "B", url: "https://pixiv.net/b")
+        vm.addLink(entry, linkType: .youtube, title: "C", url: "https://youtube.com/c")
+
+        // Move last item (C) to first position
+        vm.moveLinks(for: entry, from: IndexSet(integer: 2), to: 0)
+
+        let links = vm.fetchLinks(for: entry)
+        #expect(links[0].title == "C")
+        #expect(links[1].title == "A")
+        #expect(links[2].title == "B")
+    }
+
+    @Test("空URLはリンク追加されない")
+    @MainActor
+    func emptyURLDoesNotAddLink() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let entry = MangaEntry(name: "Test Manga")
+        context.insert(entry)
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        vm.addLink(entry, linkType: .twitter, title: "test", url: "")
+        vm.addLink(entry, linkType: .twitter, title: "test", url: "   ")
+
+        let links = vm.fetchLinks(for: entry)
+        #expect(links.isEmpty)
+    }
+}
+
+@Suite("LinkType.detect")
+struct LinkTypeDetectTests {
+
+    @Test("Twitter URL を検出")
+    func detectsTwitter() {
+        #expect(LinkType.detect(from: "https://twitter.com/user") == .twitter)
+        #expect(LinkType.detect(from: "https://x.com/user") == .twitter)
+    }
+
+    @Test("pixiv URL を検出")
+    func detectsPixiv() {
+        #expect(LinkType.detect(from: "https://www.pixiv.net/users/123") == .pixiv)
+    }
+
+    @Test("YouTube URL を検出")
+    func detectsYouTube() {
+        #expect(LinkType.detect(from: "https://www.youtube.com/watch?v=abc") == .youtube)
+        #expect(LinkType.detect(from: "https://youtu.be/abc") == .youtube)
+    }
+
+    @Test("Instagram URL を検出")
+    func detectsInstagram() {
+        #expect(LinkType.detect(from: "https://www.instagram.com/user") == .instagram)
+    }
+
+    @Test("TikTok URL を検出")
+    func detectsTikTok() {
+        #expect(LinkType.detect(from: "https://www.tiktok.com/@user") == .tiktok)
+    }
+
+    @Test("不明な URL は other")
+    func unknownIsOther() {
+        #expect(LinkType.detect(from: "https://example.com") == .other)
+    }
+}
+
+@Suite("MangaLink Backup")
+struct MangaLinkBackupTests {
+
+    private func makeContainer() throws -> ModelContainer {
+        try ModelContainer(
+            for: MangaEntry.self, ReadingActivity.self, MangaComment.self, MangaLink.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+    }
+
+    @Test("export → import ラウンドトリップ")
+    @MainActor
+    func exportImportRoundTrip() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let entry = MangaEntry(name: "Roundtrip Manga")
+        context.insert(entry)
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        vm.addLink(entry, linkType: .twitter, title: "Official", url: "https://x.com/manga")
+        vm.addLink(entry, linkType: .website, title: "Site", url: "https://manga.example.com")
+
+        guard let exportData = vm.exportBackupData() else {
+            Issue.record("Export returned nil")
+            return
+        }
+
+        // 新しいコンテナでインポート
+        let container2 = try makeContainer()
+        let context2 = container2.mainContext
+        let vm2 = MangaViewModel(modelContext: context2)
+        let importedCount = vm2.importBackupData(exportData)
+
+        // entry(1) + links(2) = 3
+        #expect(importedCount == 3)
+
+        let importedEntries = vm2.allEntries()
+        #expect(importedEntries.count == 1)
+
+        let importedLinks = vm2.fetchLinks(for: importedEntries[0])
+        #expect(importedLinks.count == 2)
+        #expect(importedLinks[0].title == "Official")
+        #expect(importedLinks[1].title == "Site")
+    }
+
+    @Test("import 時に重複 ID はスキップされる")
+    @MainActor
+    func importSkipsDuplicateIDs() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let entry = MangaEntry(name: "Dup Test")
+        context.insert(entry)
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        vm.addLink(entry, linkType: .twitter, title: "First", url: "https://x.com/first")
+
+        guard let exportData = vm.exportBackupData() else {
+            Issue.record("Export returned nil")
+            return
+        }
+
+        // 同じコンテナに再インポート → 既存と重複するのでスキップ
+        let importedCount = vm.importBackupData(exportData)
+        #expect(importedCount == 0)
+    }
+}


### PR DESCRIPTION
## Summary
- 作品ごとにSNS（X/Twitter, pixiv, YouTube, Instagram, TikTok）や公式サイトなどの関連リンクを管理できる機能を追加
- MangaLink モデル（LinkType enum + @Model）を新規作成し、MangaComment と同じ UUID 外部キーパターンを採用
- 編集画面に「関連リンク」セクション、コンテキストメニューに「関連リンク」サブメニューを追加
- バックアップデータ v14 に対応（MangaLink の import/export）

## Changes
| File | Description |
|------|-------------|
| `MangaLink.swift` | 新規: MangaLink モデル + LinkType enum（#203） |
| `SharedModelContainer.swift` | Schema に MangaLink を追加（#204） |
| `MangaViewModel.swift` | CRUD メソッド + backup import/export 対応（#205, #209） |
| `EditLinkView.swift` | 新規: リンク追加・編集シート（#206） |
| `EditEntryView.swift` | 「関連リンク」セクション追加（#207） |
| `MangaContextMenu.swift` | 関連リンクのサブメニュー追加（#208） |
| `BackupData.swift` | BackupLink 構造体 + v14 対応（#209） |
| `project.pbxproj` | 新規ファイルの追加 |

## Test plan
- [ ] 編集画面でリンクを追加・編集・削除できることを確認
- [ ] URL 入力時にリンク種別が自動判定されることを確認
- [ ] コンテキストメニューから関連リンクを開けることを確認
- [ ] バックアップ export/import でリンクデータが保持されることを確認
- [ ] 旧バージョン（v13以前）のバックアップを import してもエラーにならないことを確認

Closes #203, #204, #205, #206, #207, #208, #209, #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)