### PR TITLE
メモ・コメント内URLの自動リンク化

### DIFF
--- a/MangaLauncher.xcodeproj/project.pbxproj
+++ b/MangaLauncher.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		BC000001 /* MangaComment.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000010 /* MangaComment.swift */; };
 		BC000002 /* MangaComment.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000010 /* MangaComment.swift */; };
 		BC000003 /* MangaComment.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000010 /* MangaComment.swift */; };
+		CE000001 /* LinkedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE000010 /* LinkedText.swift */; };
 		CD000001 /* MangaLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD000010 /* MangaLink.swift */; };
 		CD000002 /* MangaLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD000010 /* MangaLink.swift */; };
 		CD000003 /* MangaLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD000010 /* MangaLink.swift */; };
@@ -227,6 +228,7 @@
 		AA000010 /* ReadingActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingActivity.swift; sourceTree = "<group>"; };
 		BC000010 /* MangaComment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaComment.swift; sourceTree = "<group>"; };
 		CD000010 /* MangaLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaLink.swift; sourceTree = "<group>"; };
+		CE000010 /* LinkedText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedText.swift; sourceTree = "<group>"; };
 		CD000110 /* EditLinkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditLinkView.swift; sourceTree = "<group>"; };
 		BC000110 /* CommentListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentListView.swift; sourceTree = "<group>"; };
 		BC000310 /* ActivityItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityItem.swift; sourceTree = "<group>"; };
@@ -623,6 +625,7 @@
 			isa = PBXGroup;
 			children = (
 				ECFEA8252F7E918E00CE4DC0 /* DeleteToastView.swift */,
+				CE000010 /* LinkedText.swift */,
 				EC04B7DB2F75301D00AEE45F /* OnboardingView.swift */,
 				EC04B7D72F74202400AEE45F /* SafariView.swift */,
 			);
@@ -914,6 +917,7 @@
 				ECFEA8762F7F8C4000CE4DC0 /* CatchUpCompletedView.swift in Sources */,
 				ECFEA82C2F7E91B500CE4DC0 /* MangaRowCell.swift in Sources */,
 				ECFEA8262F7E918E00CE4DC0 /* DeleteToastView.swift in Sources */,
+				CE000001 /* LinkedText.swift in Sources */,
 				ECFEA82E2F7E91BD00CE4DC0 /* EntryIcon.swift in Sources */,
 				AA000003 /* ReadingActivity.swift in Sources */,
 				BC000003 /* MangaComment.swift in Sources */,

--- a/MangaLauncher/Views/Comment/CommentListView.swift
+++ b/MangaLauncher/Views/Comment/CommentListView.swift
@@ -80,10 +80,12 @@ struct CommentListView: View {
     @ViewBuilder
     private func commentRow(_ comment: MangaComment) -> some View {
         VStack(alignment: .leading, spacing: 6) {
-            Text(comment.content)
-                .font(theme.bodyFont)
-                .foregroundStyle(theme.onSurface)
-                .textSelection(.enabled)
+            LinkedText(
+                comment.content,
+                font: theme.bodyFont,
+                foregroundColor: theme.onSurface
+            )
+            .textSelection(.enabled)
             HStack(spacing: 6) {
                 Text(comment.createdAt.formatted(.dateTime.year().month().day().hour().minute()))
                 if comment.updatedAt != nil {

--- a/MangaLauncher/Views/Common/LinkedText.swift
+++ b/MangaLauncher/Views/Common/LinkedText.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+/// テキスト中の URL を自動検出してタップ可能なリンクとして表示する View。
+/// SwiftUI の Text + AttributedString を利用し、リンク部分はテーマカラーで着色される。
+struct LinkedText: View {
+    let text: String
+    let font: Font
+    let foregroundColor: Color
+    let linkColor: Color
+
+    init(
+        _ text: String,
+        font: Font = .body,
+        foregroundColor: Color = .primary,
+        linkColor: Color? = nil
+    ) {
+        self.text = text
+        self.font = font
+        self.foregroundColor = foregroundColor
+        self.linkColor = linkColor ?? ThemeManager.shared.style.primary
+    }
+
+    var body: some View {
+        Text(buildAttributedString())
+            .font(font)
+            .tint(linkColor)
+    }
+
+    private func buildAttributedString() -> AttributedString {
+        var result = AttributedString(text)
+        result.foregroundColor = foregroundColor
+
+        guard let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else {
+            return result
+        }
+
+        let nsString = text as NSString
+        let fullRange = NSRange(location: 0, length: nsString.length)
+        let matches = detector.matches(in: text, options: [], range: fullRange)
+
+        for match in matches {
+            guard let url = match.url,
+                  let range = Range(match.range, in: text),
+                  let attrRange = result.range(of: text[range]) else { continue }
+            result[attrRange].link = url
+            result[attrRange].foregroundColor = linkColor
+            result[attrRange].underlineStyle = .single
+        }
+
+        return result
+    }
+}
+
+// MARK: - AttributedString range helper
+
+private extension AttributedString {
+    /// String の Range を AttributedString 内で検索して対応する範囲を返す。
+    /// 同じ部分文字列が複数回出現する場合に正しい位置を返すため、
+    /// 先頭からのオフセットを利用する。
+    func range(of substring: Substring) -> Range<AttributedString.Index>? {
+        let text = String(self.characters)
+        guard let stringRange = text.range(of: substring) else { return nil }
+        let startOffset = text.distance(from: text.startIndex, to: stringRange.lowerBound)
+        let endOffset = text.distance(from: text.startIndex, to: stringRange.upperBound)
+        let attrStart = self.index(self.startIndex, offsetByCharacters: startOffset)
+        let attrEnd = self.index(self.startIndex, offsetByCharacters: endOffset)
+        return attrStart..<attrEnd
+    }
+}

--- a/MangaLauncher/Views/Common/LinkedText.swift
+++ b/MangaLauncher/Views/Common/LinkedText.swift
@@ -7,63 +7,71 @@ struct LinkedText: View {
     let font: Font
     let foregroundColor: Color
     let linkColor: Color
+    let onOpenURL: ((URL) -> OpenURLAction.Result)?
+
+    /// URL 検出用の NSDataDetector。生成コストを避けるためインスタンスを共有する。
+    private static let linkDetector: NSDataDetector? = {
+        try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
+    }()
 
     init(
         _ text: String,
         font: Font = .body,
         foregroundColor: Color = .primary,
-        linkColor: Color? = nil
+        linkColor: Color? = nil,
+        onOpenURL: ((URL) -> OpenURLAction.Result)? = nil
     ) {
         self.text = text
         self.font = font
         self.foregroundColor = foregroundColor
         self.linkColor = linkColor ?? ThemeManager.shared.style.primary
+        self.onOpenURL = onOpenURL
     }
 
     var body: some View {
-        Text(buildAttributedString())
+        Text(Self.buildAttributedString(from: text, foregroundColor: foregroundColor, linkColor: linkColor))
             .font(font)
             .tint(linkColor)
+            .environment(\.openURL, OpenURLAction { url in
+                if let onOpenURL {
+                    return onOpenURL(url)
+                }
+                return .systemAction(url)
+            })
     }
 
-    private func buildAttributedString() -> AttributedString {
+    // MARK: - AttributedString 構築（テスト可能な static メソッド）
+
+    /// テキスト中の URL を検出してリンク属性を付与した AttributedString を返す。
+    static func buildAttributedString(
+        from text: String,
+        foregroundColor: Color,
+        linkColor: Color
+    ) -> AttributedString {
         var result = AttributedString(text)
         result.foregroundColor = foregroundColor
 
-        guard let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else {
-            return result
-        }
-
+        // URL を含まないテキストは早期リターン
+        guard let detector = linkDetector else { return result }
         let nsString = text as NSString
         let fullRange = NSRange(location: 0, length: nsString.length)
         let matches = detector.matches(in: text, options: [], range: fullRange)
+        guard !matches.isEmpty else { return result }
 
         for match in matches {
             guard let url = match.url,
-                  let range = Range(match.range, in: text),
-                  let attrRange = result.range(of: text[range]) else { continue }
+                  let swiftRange = Range(match.range, in: text) else { continue }
+            // String.Index のオフセットを使って AttributedString の範囲を算出
+            let startOffset = text.distance(from: text.startIndex, to: swiftRange.lowerBound)
+            let endOffset = text.distance(from: text.startIndex, to: swiftRange.upperBound)
+            let attrStart = result.index(result.startIndex, offsetByCharacters: startOffset)
+            let attrEnd = result.index(result.startIndex, offsetByCharacters: endOffset)
+            let attrRange = attrStart..<attrEnd
             result[attrRange].link = url
             result[attrRange].foregroundColor = linkColor
             result[attrRange].underlineStyle = .single
         }
 
         return result
-    }
-}
-
-// MARK: - AttributedString range helper
-
-private extension AttributedString {
-    /// String の Range を AttributedString 内で検索して対応する範囲を返す。
-    /// 同じ部分文字列が複数回出現する場合に正しい位置を返すため、
-    /// 先頭からのオフセットを利用する。
-    func range(of substring: Substring) -> Range<AttributedString.Index>? {
-        let text = String(self.characters)
-        guard let stringRange = text.range(of: substring) else { return nil }
-        let startOffset = text.distance(from: text.startIndex, to: stringRange.lowerBound)
-        let endOffset = text.distance(from: text.startIndex, to: stringRange.upperBound)
-        let attrStart = self.index(self.startIndex, offsetByCharacters: startOffset)
-        let attrEnd = self.index(self.startIndex, offsetByCharacters: endOffset)
-        return attrStart..<attrEnd
     }
 }

--- a/MangaLauncher/Views/Heatmap/MangaLifetimeView.swift
+++ b/MangaLauncher/Views/Heatmap/MangaLifetimeView.swift
@@ -411,9 +411,7 @@ struct LifetimeDetailSheet: View {
 
             // Right: content card
             VStack(alignment: .leading, spacing: 2) {
-                Text(eventText(for: item))
-                    .font(theme.captionFont)
-                    .foregroundStyle(theme.onSurface)
+                eventContent(for: item)
                 Text(Self.timeFormatter.string(from: item.timestamp))
                     .font(theme.caption2Font)
                     .foregroundStyle(theme.onSurfaceVariant)
@@ -478,6 +476,34 @@ struct LifetimeDetailSheet: View {
             } else {
                 "読みました"
             }
+        }
+    }
+
+    @ViewBuilder
+    private func eventContent(for item: TimelineItem) -> some View {
+        switch item {
+        case .comment(let comment, _):
+            LinkedText(
+                comment.content,
+                font: theme.captionFont,
+                foregroundColor: theme.onSurface
+            )
+        case .memo(let entry):
+            if entry.memo.isEmpty {
+                Text("(空)")
+                    .font(theme.captionFont)
+                    .foregroundStyle(theme.onSurface)
+            } else {
+                LinkedText(
+                    entry.memo,
+                    font: theme.captionFont,
+                    foregroundColor: theme.onSurface
+                )
+            }
+        case .read:
+            Text(eventText(for: item))
+                .font(theme.captionFont)
+                .foregroundStyle(theme.onSurface)
         }
     }
 

--- a/MangaLauncher/Views/Library/Timeline/TimelineRowView.swift
+++ b/MangaLauncher/Views/Library/Timeline/TimelineRowView.swift
@@ -71,8 +71,6 @@ struct TimelineRowView: View {
                     .foregroundStyle(theme.onSurface)
                     .lineLimit(1)
                 content
-                    .font(theme.captionFont)
-                    .foregroundStyle(theme.onSurfaceVariant)
                     .lineLimit(2)
             }
             Spacer(minLength: 0)
@@ -125,6 +123,8 @@ struct TimelineRowView: View {
         case .memo(let entry):
             if entry.memo.isEmpty {
                 Text("(空)")
+                    .font(theme.captionFont)
+                    .foregroundStyle(theme.onSurfaceVariant)
             } else {
                 LinkedText(
                     entry.memo,
@@ -135,10 +135,16 @@ struct TimelineRowView: View {
         case .read(let activity, _):
             if let label = activity.episodeLabel, !label.isEmpty {
                 Text("既読 \(label)に更新")
+                    .font(theme.captionFont)
+                    .foregroundStyle(theme.onSurfaceVariant)
             } else if let ep = activity.episodeNumber {
                 Text("既読 \(ep)話に更新")
+                    .font(theme.captionFont)
+                    .foregroundStyle(theme.onSurfaceVariant)
             } else {
                 Text("読みました")
+                    .font(theme.captionFont)
+                    .foregroundStyle(theme.onSurfaceVariant)
             }
         }
     }

--- a/MangaLauncher/Views/Library/Timeline/TimelineRowView.swift
+++ b/MangaLauncher/Views/Library/Timeline/TimelineRowView.swift
@@ -117,12 +117,20 @@ struct TimelineRowView: View {
     private var content: some View {
         switch item {
         case .comment(let comment, _):
-            Text(comment.content)
+            LinkedText(
+                comment.content,
+                font: theme.captionFont,
+                foregroundColor: theme.onSurfaceVariant
+            )
         case .memo(let entry):
             if entry.memo.isEmpty {
                 Text("(空)")
             } else {
-                Text(entry.memo)
+                LinkedText(
+                    entry.memo,
+                    font: theme.captionFont,
+                    foregroundColor: theme.onSurfaceVariant
+                )
             }
         case .read(let activity, _):
             if let label = activity.episodeLabel, !label.isEmpty {

--- a/MangaLauncherTests/MangaEntryTests.swift
+++ b/MangaLauncherTests/MangaEntryTests.swift
@@ -541,3 +541,89 @@ struct MangaLinkBackupTests {
         #expect(importedCount == 0)
     }
 }
+
+// MARK: - LinkedText Tests
+
+@Suite("LinkedText URL検出")
+struct LinkedTextTests {
+
+    @Test("単一URLを検出してリンク属性が付く")
+    func singleURL() {
+        let text = "詳細は https://example.com を参照"
+        let result = LinkedText.buildAttributedString(from: text, foregroundColor: .black, linkColor: .blue)
+
+        // リンクが1箇所含まれる
+        var linkCount = 0
+        for run in result.runs {
+            if run.link != nil { linkCount += 1 }
+        }
+        #expect(linkCount == 1)
+    }
+
+    @Test("同一URLが複数回登場しても全箇所にリンクが付く")
+    func duplicateURLs() {
+        let text = "https://example.com と https://example.com の2つ"
+        let result = LinkedText.buildAttributedString(from: text, foregroundColor: .black, linkColor: .blue)
+
+        var linkCount = 0
+        for run in result.runs {
+            if run.link != nil { linkCount += 1 }
+        }
+        #expect(linkCount == 2)
+    }
+
+    @Test("URLを含まないテキストはリンクなし")
+    func noURL() {
+        let text = "これはただのテキストです"
+        let result = LinkedText.buildAttributedString(from: text, foregroundColor: .black, linkColor: .blue)
+
+        var linkCount = 0
+        for run in result.runs {
+            if run.link != nil { linkCount += 1 }
+        }
+        #expect(linkCount == 0)
+    }
+
+    @Test("日本語混在テキストでURLが正しく検出される")
+    func japaneseWithURL() {
+        let text = "公式サイト: https://manga.example.com/漫画 をチェック"
+        let result = LinkedText.buildAttributedString(from: text, foregroundColor: .black, linkColor: .blue)
+
+        var foundURL: URL?
+        for run in result.runs {
+            if let link = run.link { foundURL = link }
+        }
+        #expect(foundURL != nil)
+        #expect(foundURL?.host == "manga.example.com")
+    }
+
+    @Test("絵文字混在テキストでURL検出が壊れない")
+    func emojiWithURL() {
+        let text = "🎉 https://x.com/manga 🎉"
+        let result = LinkedText.buildAttributedString(from: text, foregroundColor: .black, linkColor: .blue)
+
+        var linkCount = 0
+        for run in result.runs {
+            if run.link != nil { linkCount += 1 }
+        }
+        #expect(linkCount == 1)
+    }
+
+    @Test("複数の異なるURLが正しく検出される")
+    func multipleDistinctURLs() {
+        let text = "Twitter: https://x.com/user サイト: https://example.com"
+        let result = LinkedText.buildAttributedString(from: text, foregroundColor: .black, linkColor: .blue)
+
+        var urls: [URL] = []
+        for run in result.runs {
+            if let link = run.link { urls.append(link) }
+        }
+        #expect(urls.count == 2)
+    }
+
+    @Test("空文字列でクラッシュしない")
+    func emptyString() {
+        let result = LinkedText.buildAttributedString(from: "", foregroundColor: .black, linkColor: .blue)
+        #expect(String(result.characters).isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- `NSDataDetector` でテキスト中のURLを自動検出し、タップ可能なリンクとして表示する `LinkedText` ビューを追加
- コメント全文表示（CommentListView）、タイムライン（TimelineRowView）、ライフタイム詳細（MangaLifetimeView）に適用
- リンク部分はテーマカラー＋下線で表示され、タップでブラウザが開く

## Test plan
- [ ] コメントにURLを含むテキストを投稿し、リンク部分がタップ可能か確認
- [ ] メモにURLを含むテキストを保存し、タイムラインでリンクが表示されるか確認
- [ ] ライフタイム詳細画面でコメント・メモ内のリンクがタップ可能か確認
- [ ] URLを含まないテキストが通常通り表示されるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)