### PR TITLE
Add cross-day catch-up entry point in Library

### DIFF
--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -807,7 +807,11 @@ final class MangaViewModel {
     /// 曜日横断の未読エントリ。Library から起動する全未読キャッチアップ用。
     /// 集計のソースは `allEntries()` と揃えて Library 「未読」セクションと件数が必ず一致するようにする
     /// （独立フェッチにすると `isHidden` 述語と in-memory `hiddenIDs` のズレで件数が食い違う）。
-    /// 並びは期日が古い順、nil は末尾、同期日や nil 同士は曜日順で安定化。
+    ///
+    /// 並び順の優先度:
+    ///   1. 期日が古い順 (`nextExpectedUpdate` が nil のものは末尾)
+    ///   2. UI 共通の曜日順 (`DayOfWeek.orderedDays` = Mon→Sun)
+    ///   3. 同曜日内は `sortOrder` で安定化 (曜日タブと一致)
     func allUnreadEntries() -> [MangaEntry] {
         let _ = refreshCounter
         let unread = allEntries().filter {
@@ -817,14 +821,34 @@ final class MangaViewModel {
         }
         return unread.sorted { lhs, rhs in
             switch (lhs.nextExpectedUpdate, rhs.nextExpectedUpdate) {
-            case let (l?, r?):
-                if l != r { return l < r }
-                return lhs.dayOfWeekRawValue < rhs.dayOfWeekRawValue
+            case let (l?, r?) where l != r: return l < r
             case (nil, _?): return false
             case (_?, nil): return true
-            case (nil, nil): return lhs.dayOfWeekRawValue < rhs.dayOfWeekRawValue
+            default: break
             }
+            let lWeekday = Self.weekdayOrderIndex(rawValue: lhs.dayOfWeekRawValue)
+            let rWeekday = Self.weekdayOrderIndex(rawValue: rhs.dayOfWeekRawValue)
+            if lWeekday != rWeekday { return lWeekday < rWeekday }
+            return lhs.sortOrder < rhs.sortOrder
         }
+    }
+
+    /// `allUnreadEntries()` と同じ集計ソースを使った件数のみの軽量版。
+    /// Library のバッジ表示など毎レンダリング呼ばれる箇所では sort のコストを避けるためこちらを使う。
+    func allUnreadCount() -> Int {
+        let _ = refreshCounter
+        return allEntries().lazy.filter {
+            !$0.isRead
+                && $0.readingState == .following
+                && $0.publicationStatus == .active
+        }.count
+    }
+
+    /// `DayOfWeek.orderedDays` (Mon→Sun) における順序 index を返す。
+    /// `dayOfWeekRawValue` (Sun=0..Sat=6) のまま比較すると Sun が先頭になり、UI と並びがズレる。
+    private static func weekdayOrderIndex(rawValue: Int) -> Int {
+        // Sun(0) → 6, Mon(1) → 0, Tue(2) → 1, ..., Sat(6) → 5
+        (rawValue + 6) % 7
     }
 
     // 注意: アクティビティ・メモ集約は ActivityBuilder に移譲。

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -805,32 +805,17 @@ final class MangaViewModel {
     }
 
     /// 曜日横断の未読エントリ。Library から起動する全未読キャッチアップ用。
-    /// fetchEntries(for:) と同じ可視性条件（追っかけ中・連載中・未削除・未非表示・未保留削除）
-    /// に未読フィルタを加えた上で、期日が古い順（nil は末尾、同順は曜日順）で並べる。
+    /// 集計のソースは `allEntries()` と揃えて Library 「未読」セクションと件数が必ず一致するようにする
+    /// （独立フェッチにすると `isHidden` 述語と in-memory `hiddenIDs` のズレで件数が食い違う）。
+    /// 並びは期日が古い順、nil は末尾、同期日や nil 同士は曜日順で安定化。
     func allUnreadEntries() -> [MangaEntry] {
         let _ = refreshCounter
-        let followingRaw = ReadingState.following.rawValue
-        let activeRaw = PublicationStatus.active.rawValue
-        let descriptor = FetchDescriptor<MangaEntry>(
-            predicate: #Predicate {
-                $0.readingStateRawValue == followingRaw
-                    && $0.publicationStatusRawValue == activeRaw
-                    && $0.deletedAt == nil
-            }
-        )
-        let results = modelContext.fetchLogged(descriptor)
-        let pendingIDs = Set(pendingDeleteEntries.map(\.id))
-        let currentHiddenIDs = hiddenIDs
-        let currentDeletedIDs = deletedIDs
-        var seenIDs = Set<UUID>()
-        let visible = results.filter { entry in
-            guard !currentHiddenIDs.contains(entry.id),
-                  !pendingIDs.contains(entry.id),
-                  !currentDeletedIDs.contains(entry.id),
-                  !entry.isRead else { return false }
-            return seenIDs.insert(entry.id).inserted
+        let unread = allEntries().filter {
+            !$0.isRead
+                && $0.readingState == .following
+                && $0.publicationStatus == .active
         }
-        return visible.sorted { lhs, rhs in
+        return unread.sorted { lhs, rhs in
             switch (lhs.nextExpectedUpdate, rhs.nextExpectedUpdate) {
             case let (l?, r?):
                 if l != r { return l < r }

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -804,6 +804,44 @@ final class MangaViewModel {
         fetchEntries(for: day).filter { !$0.isRead }
     }
 
+    /// 曜日横断の未読エントリ。Library から起動する全未読キャッチアップ用。
+    /// fetchEntries(for:) と同じ可視性条件（追っかけ中・連載中・未削除・未非表示・未保留削除）
+    /// に未読フィルタを加えた上で、期日が古い順（nil は末尾、同順は曜日順）で並べる。
+    func allUnreadEntries() -> [MangaEntry] {
+        let _ = refreshCounter
+        let followingRaw = ReadingState.following.rawValue
+        let activeRaw = PublicationStatus.active.rawValue
+        let descriptor = FetchDescriptor<MangaEntry>(
+            predicate: #Predicate {
+                $0.readingStateRawValue == followingRaw
+                    && $0.publicationStatusRawValue == activeRaw
+                    && $0.deletedAt == nil
+            }
+        )
+        let results = modelContext.fetchLogged(descriptor)
+        let pendingIDs = Set(pendingDeleteEntries.map(\.id))
+        let currentHiddenIDs = hiddenIDs
+        let currentDeletedIDs = deletedIDs
+        var seenIDs = Set<UUID>()
+        let visible = results.filter { entry in
+            guard !currentHiddenIDs.contains(entry.id),
+                  !pendingIDs.contains(entry.id),
+                  !currentDeletedIDs.contains(entry.id),
+                  !entry.isRead else { return false }
+            return seenIDs.insert(entry.id).inserted
+        }
+        return visible.sorted { lhs, rhs in
+            switch (lhs.nextExpectedUpdate, rhs.nextExpectedUpdate) {
+            case let (l?, r?):
+                if l != r { return l < r }
+                return lhs.dayOfWeekRawValue < rhs.dayOfWeekRawValue
+            case (nil, _?): return false
+            case (_?, nil): return true
+            case (nil, nil): return lhs.dayOfWeekRawValue < rhs.dayOfWeekRawValue
+            }
+        }
+    }
+
     // 注意: アクティビティ・メモ集約は ActivityBuilder に移譲。
     // ここに recentActivity / allActivity / memoEntryCount などを置かないこと（N+1 fetch の温床になる）。
     // メモの更新は updateEntry() に統合済み。

--- a/MangaLauncher/Views/CatchUp/CatchUpView.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpView.swift
@@ -7,7 +7,8 @@ struct CatchUpView: View {
     @AppStorage(UserDefaultsKeys.browserMode) private var browserMode: String = "external"
 
     var viewModel: MangaViewModel
-    let day: DayOfWeek
+    /// 対象曜日。nil の場合は全曜日横断の未読をまとめてキャッチアップする（Library 経由の起動）。
+    let day: DayOfWeek?
     var publisher: String? = nil
 
     @State private var unreadItems: [MangaEntry] = []
@@ -64,7 +65,7 @@ struct CatchUpView: View {
             .toolbar {
                 ToolbarItem(placement: .principal) {
                     VStack(spacing: 2) {
-                        Text("\(day.displayName)のキャッチアップ")
+                        Text(day.map { "\($0.displayName)のキャッチアップ" } ?? "未読のキャッチアップ")
                             .font(theme.headlineFont)
                             .foregroundStyle(hasGradient ? .white : theme.onSurface)
                         if let publisher {
@@ -284,7 +285,7 @@ struct CatchUpView: View {
     }
 
     private func filteredUnreadEntries() -> [MangaEntry] {
-        let entries = viewModel.unreadEntries(for: day)
+        let entries = day.map { viewModel.unreadEntries(for: $0) } ?? viewModel.allUnreadEntries()
         if let publisher {
             return entries.filter { $0.publisher == publisher }
         }

--- a/MangaLauncher/Views/Library/LibraryView.swift
+++ b/MangaLauncher/Views/Library/LibraryView.swift
@@ -137,7 +137,7 @@ struct LibraryView: View {
 
     @ViewBuilder
     private var catchUpAllUnreadLink: some View {
-        let count = viewModel.allUnreadEntries().count
+        let count = viewModel.allUnreadCount()
         if count > 0 {
             Button {
                 showingCatchUp = true

--- a/MangaLauncher/Views/Library/LibraryView.swift
+++ b/MangaLauncher/Views/Library/LibraryView.swift
@@ -9,6 +9,7 @@ struct LibraryView: View {
     @State private var commentingEntry: MangaEntry?
     @State private var safariURL: URL?
     @State private var showingAddSheet = false
+    @State private var showingCatchUp = false
     @AppStorage(UserDefaultsKeys.browserMode) private var browserMode: String = "external"
     @AppStorage(UserDefaultsKeys.showHiddenSection) private var showHiddenSection: Bool = true
     @AppStorage(UserDefaultsKeys.recentActivityExpanded) private var recentActivityExpandedStorage: Bool = false
@@ -53,6 +54,11 @@ struct LibraryView: View {
                 SafariView(url: url).ignoresSafeArea()
             }
             #endif
+            .fullScreenCover(isPresented: $showingCatchUp, onDismiss: {
+                viewModel.notifyChange()
+            }) {
+                CatchUpView(viewModel: viewModel, day: nil)
+            }
             .onAppear {
                 recentActivityExpanded = recentActivityExpandedStorage
             }
@@ -85,6 +91,7 @@ struct LibraryView: View {
         } else {
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 24) {
+                    catchUpAllUnreadLink
                     timelineLink
                     hiddenSectionLink
                     recentlyDeletedLink
@@ -125,6 +132,42 @@ struct LibraryView: View {
             HiddenEntriesView(viewModel: viewModel)
         case .recentlyDeleted:
             RecentlyDeletedView(viewModel: viewModel)
+        }
+    }
+
+    @ViewBuilder
+    private var catchUpAllUnreadLink: some View {
+        let count = viewModel.allUnreadEntries().count
+        if count > 0 {
+            Button {
+                showingCatchUp = true
+            } label: {
+                HStack(spacing: 10) {
+                    Image(systemName: "bolt.fill")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(.white)
+                        .frame(width: 28, height: 28)
+                        .background(Color.orange, in: RoundedRectangle(cornerRadius: 6))
+                    Text("未読をキャッチアップ")
+                        .font(theme.subheadlineFont.weight(.semibold))
+                        .foregroundStyle(theme.onSurface)
+                    Spacer()
+                    Text("\(count)")
+                        .font(theme.captionFont)
+                        .foregroundStyle(theme.onSurfaceVariant)
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(theme.onSurfaceVariant)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .background(
+                    RoundedRectangle(cornerRadius: 12)
+                        .fill(theme.surfaceContainerHigh)
+                )
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal)
         }
     }
 

--- a/MangaLauncherTests/MangaEntryTests.swift
+++ b/MangaLauncherTests/MangaEntryTests.swift
@@ -259,6 +259,146 @@ struct MangaViewModelFindEntriesTests {
     }
 }
 
+@Suite("MangaViewModel.allUnreadEntries / allUnreadCount")
+struct MangaViewModelAllUnreadTests {
+
+    private func makeContainer() throws -> ModelContainer {
+        try ModelContainer(
+            for: MangaEntry.self, ReadingActivity.self, MangaComment.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+    }
+
+    /// 期日が古い順で並び、nil は末尾、同期日は曜日順 (Mon→Sun) で並ぶことを確認。
+    @Test("並び順: 期日 → 曜日 (Mon→Sun) → sortOrder")
+    @MainActor
+    func sortOrdering() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+
+        let now = Date()
+        let cal = Calendar.current
+        let plus1day = cal.date(byAdding: .day, value: 1, to: now)!
+        let plus2day = cal.date(byAdding: .day, value: 2, to: now)!
+
+        // すべて未読で取得対象になるよう、過去の lastReadDate を持たせず
+        // 次回更新を未来に設定 (isRead は false になる)
+        // 期日 nil (末尾)
+        let nilDue = MangaEntry(name: "no-date", dayOfWeek: .wednesday, sortOrder: 0)
+
+        // 期日が早い順に: A(plus1) < B(plus2 + Mon) < C(plus2 + Tue, sortOrder 0) < D(plus2 + Tue, sortOrder 1)
+        let a = MangaEntry(name: "A", dayOfWeek: .friday, sortOrder: 0)
+        a.nextExpectedUpdate = plus1day
+        let b = MangaEntry(name: "B", dayOfWeek: .monday, sortOrder: 0)
+        b.nextExpectedUpdate = plus2day
+        let c = MangaEntry(name: "C", dayOfWeek: .tuesday, sortOrder: 0)
+        c.nextExpectedUpdate = plus2day
+        let d = MangaEntry(name: "D", dayOfWeek: .tuesday, sortOrder: 1)
+        d.nextExpectedUpdate = plus2day
+
+        // わざと逆順に挿入して、内部のソートに依存することを確認
+        for entry in [nilDue, d, c, b, a] {
+            context.insert(entry)
+        }
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        let result = vm.allUnreadEntries()
+
+        #expect(result.map(\.name) == ["A", "B", "C", "D", "no-date"])
+    }
+
+    /// 日曜は Mon→Sun の最後尾になることを確認 (raw 値だと先頭になる落とし穴)。
+    @Test("曜日順: 日曜は最後尾 (Mon→Sun 規則)")
+    @MainActor
+    func sundayGoesLast() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+
+        let same = Date(timeIntervalSince1970: 2_000_000_000)
+        let sun = MangaEntry(name: "sun", dayOfWeek: .sunday, sortOrder: 0)
+        sun.nextExpectedUpdate = same
+        let mon = MangaEntry(name: "mon", dayOfWeek: .monday, sortOrder: 0)
+        mon.nextExpectedUpdate = same
+
+        context.insert(sun)
+        context.insert(mon)
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        let result = vm.allUnreadEntries()
+
+        #expect(result.map(\.name) == ["mon", "sun"])
+    }
+
+    /// 削除予定 (soft-delete) と非表示 (isHidden) が結果から除外されることを確認。
+    @Test("hidden / deleted は集計から除外")
+    @MainActor
+    func excludesHiddenAndDeleted() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+
+        let visible = MangaEntry(name: "visible", dayOfWeek: .monday)
+        let hidden = MangaEntry(name: "hidden", dayOfWeek: .monday)
+        hidden.isHidden = true
+        let deleted = MangaEntry(name: "deleted", dayOfWeek: .monday)
+        deleted.deletedAt = Date()
+
+        for entry in [visible, hidden, deleted] {
+            context.insert(entry)
+        }
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        vm.reloadHiddenIDs()
+        vm.reloadDeletedIDs()
+
+        let result = vm.allUnreadEntries()
+        #expect(result.map(\.name) == ["visible"])
+        #expect(vm.allUnreadCount() == 1)
+    }
+
+    /// 積読 (.backlog) や読了 (.archived) は対象外。
+    @Test("backlog / archived は対象外")
+    @MainActor
+    func excludesBacklogAndArchived() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+
+        let following = MangaEntry(name: "following", dayOfWeek: .monday)
+        let backlog = MangaEntry(name: "backlog", dayOfWeek: .monday)
+        backlog.readingState = .backlog
+        let archived = MangaEntry(name: "archived", dayOfWeek: .monday)
+        archived.readingState = .archived
+
+        for entry in [following, backlog, archived] {
+            context.insert(entry)
+        }
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        let result = vm.allUnreadEntries()
+        #expect(result.map(\.name) == ["following"])
+    }
+
+    /// allUnreadCount() と allUnreadEntries().count は常に一致する。
+    @Test("allUnreadCount と allUnreadEntries().count は一致")
+    @MainActor
+    func countAgreesWithEntriesCount() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+
+        for i in 0..<5 {
+            let entry = MangaEntry(name: "entry\(i)", dayOfWeek: .monday, sortOrder: i)
+            context.insert(entry)
+        }
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        #expect(vm.allUnreadCount() == vm.allUnreadEntries().count)
+    }
+}
+
 @Suite("MangaViewModel.runStartupMigrationsIfNeeded")
 struct MangaViewModelStartupTests {
 


### PR DESCRIPTION
## Summary

Library画面から **全曜日の未読をまとめて消化** できるキャッチアップ導線を追加します。

これまでは曜日タブごとに CatchUp を起動する必要があり、複数曜日に未読が散らばっているときは曜日を切り替えながら何度も起動する必要がありました。Library から起動できるようにすることで、未読の一気消化が1アクションで完結するようになります。

## UI

ライブラリ画面の上部に「未読をキャッチアップ」リンクを追加（未読 0 件のときは非表示）：

```
┌────────────────────────────────────┐
│ ⚡ 未読をキャッチアップ        7  > │  ← 新規追加
├────────────────────────────────────┤
│ 📊 タイムライン                  > │
├────────────────────────────────────┤
│ 👁 非表示                  12  > │
├────────────────────────────────────┤
│ 🗑 最近削除した項目         3  > │
└────────────────────────────────────┘
```

## 実装

3つのコミットに分割しています：

1. **`Add allUnreadEntries() for cross-day catch-up`**
   `MangaViewModel` に全曜日横断の未読フェッチを追加。期日が近い順、同期日や期日 nil 同士は曜日順で安定化。

2. **`Make CatchUpView day optional for cross-day mode`**
   `CatchUpView.day` を `DayOfWeek?` に変更。nil の場合は `allUnreadEntries()` を使い、タイトルも「未読のキャッチアップ」に切り替わる。既存の曜日タブからの起動は無変更で動作。

3. **`Add "未読をキャッチアップ" link to LibraryView`**
   ライブラリ画面に導線を追加。`fullScreenCover` で `CatchUpView(day: nil)` を起動。

## Test plan

- [ ] 複数曜日に未読がある状態で Library を開き、リンクに正しい合計件数が出る
- [ ] リンクタップで全未読がカードスタックに並ぶ（期日順）
- [ ] 既読/スキップ操作後、Library に戻ると件数が更新される
- [ ] 未読 0 件のときリンクが非表示
- [ ] 非表示・最近削除・保留中のエントリが含まれない
- [ ] 既存の曜日タブからの CatchUp 起動が壊れていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)