### PR TITLE
Add focused backlog feature

### DIFF
--- a/MangaLauncher.xcodeproj/project.pbxproj
+++ b/MangaLauncher.xcodeproj/project.pbxproj
@@ -964,7 +964,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.4;
+				MARKETING_VERSION = 2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mh-mobile.MangaYoubi.MangaWidget";
 				PRODUCT_NAME = MangaWidgetExtension;
 				SDKROOT = iphoneos;
@@ -995,7 +995,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.4;
+				MARKETING_VERSION = 2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mh-mobile.MangaYoubi.dev.ShareExtension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1023,7 +1023,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.4;
+				MARKETING_VERSION = 2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mh-mobile.MangaYoubi.dev.MangaWidget";
 				PRODUCT_NAME = MangaWidgetExtension;
 				SDKROOT = iphoneos;
@@ -1187,7 +1187,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.4;
+				MARKETING_VERSION = 2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mh-mobile.MangaYoubi.dev";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1224,7 +1224,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.4;
+				MARKETING_VERSION = 2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mh-mobile.MangaYoubi";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1251,7 +1251,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.4;
+				MARKETING_VERSION = 2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mh-mobile.MangaYoubi.ShareExtension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1345,7 +1345,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.4;
+				MARKETING_VERSION = 2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mh-mobile.MangaYoubi.adhoc";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1376,7 +1376,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.4;
+				MARKETING_VERSION = 2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mh-mobile.MangaYoubi.adhoc.MangaWidget";
 				PRODUCT_NAME = MangaWidgetExtension;
 				SDKROOT = iphoneos;
@@ -1407,7 +1407,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.4;
+				MARKETING_VERSION = 2.5;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mh-mobile.MangaYoubi.adhoc.ShareExtension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/MangaLauncher/Models/MangaEntry.swift
+++ b/MangaLauncher/Models/MangaEntry.swift
@@ -119,6 +119,10 @@ final class MangaEntry {
     var isHidden: Bool = false
     /// ソフトデリート日時（nil = 未削除）
     var deletedAt: Date?
+    /// フォーカス積読フラグ。最大3本まで同時にフォーカス可能。
+    var isFocused: Bool = false
+    /// フォーカス指定日時。並び順と上限超過時の置き換え判定に使う。
+    var focusedAt: Date?
 
     /// 掲載状況の Int 値（PublicationStatus.rawValue）
     var publicationStatusRawValue: Int = 0

--- a/MangaLauncher/Models/MangaEntry.swift
+++ b/MangaLauncher/Models/MangaEntry.swift
@@ -121,7 +121,7 @@ final class MangaEntry {
     var deletedAt: Date?
     /// フォーカス積読フラグ。最大3本まで同時にフォーカス可能。
     var isFocused: Bool = false
-    /// フォーカス指定日時。並び順と上限超過時の置き換え判定に使う。
+    /// フォーカス指定日時。フォーカス中積読セクションの並び順（降順 = 新しいフォーカスが先頭）に使う。
     var focusedAt: Date?
 
     /// 掲載状況の Int 値（PublicationStatus.rawValue）

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -148,6 +148,12 @@ final class MangaViewModel {
     /// 読書状況の付け替え
     func setReadingState(_ entry: MangaEntry, to state: ReadingState) {
         entry.readingState = state
+        // フォーカス積読は readingState == .backlog 前提なので、
+        // 積読から外れた瞬間に自動でフォーカス解除する
+        if state != .backlog {
+            entry.isFocused = false
+            entry.focusedAt = nil
+        }
         save()
     }
 
@@ -323,6 +329,11 @@ final class MangaViewModel {
         entry.readingState = readingState
         // 読み切りの invariants (publicationStatus=.active, readingState != .backlog) を強制
         entry.normalizeOneShotInvariants()
+        // フォーカスは積読限定のフラグなので、積読から外れたら解除する
+        if entry.readingState != .backlog {
+            entry.isFocused = false
+            entry.focusedAt = nil
+        }
         entry.memo = memo
         if memoChanged {
             entry.memoUpdatedAt = memo.isEmpty ? nil : Date()
@@ -849,6 +860,49 @@ final class MangaViewModel {
     private static func weekdayOrderIndex(rawValue: Int) -> Int {
         // Sun(0) → 6, Mon(1) → 0, Tue(2) → 1, ..., Sat(6) → 5
         (rawValue + 6) % 7
+    }
+
+    // MARK: - Focused Backlog
+
+    /// 同時にフォーカス指定できる積読の上限本数。
+    static let maxFocusedBacklogCount = 3
+
+    /// フォーカス中の積読エントリ。`focusedAt` 降順（新しくフォーカスしたものが先頭）。
+    /// 集計ソースを `allEntries()` に揃えることで、ソフトデリート/hidden の整合性を担保する。
+    func focusedBacklogEntries() -> [MangaEntry] {
+        let _ = refreshCounter
+        return allEntries()
+            .filter { $0.isFocused && $0.readingState == .backlog }
+            .sorted { ($0.focusedAt ?? .distantPast) > ($1.focusedAt ?? .distantPast) }
+    }
+
+    func focusedBacklogCount() -> Int {
+        let _ = refreshCounter
+        return allEntries().lazy.filter { $0.isFocused && $0.readingState == .backlog }.count
+    }
+
+    /// 上限まで枠が空いているか。View 側で「フォーカスする」項目を出すか判定するのに使う。
+    func canFocus() -> Bool {
+        focusedBacklogCount() < Self.maxFocusedBacklogCount
+    }
+
+    /// 積読エントリーをフォーカス指定する。上限超過時は何もしない。
+    /// 積読でないエントリーには適用しない（呼び出し側で readingState をチェックする想定）。
+    func focus(_ entry: MangaEntry) {
+        guard entry.readingState == .backlog else { return }
+        guard !entry.isFocused else { return }
+        guard canFocus() else { return }
+        entry.isFocused = true
+        entry.focusedAt = Date()
+        save()
+    }
+
+    /// フォーカス指定を解除する。
+    func unfocus(_ entry: MangaEntry) {
+        guard entry.isFocused else { return }
+        entry.isFocused = false
+        entry.focusedAt = nil
+        save()
     }
 
     // 注意: アクティビティ・メモ集約は ActivityBuilder に移譲。

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -894,7 +894,7 @@ final class MangaViewModel {
         guard canFocus() else { return }
         entry.isFocused = true
         entry.focusedAt = Date()
-        save()
+        saveFocusChange(for: entry)
     }
 
     /// フォーカス指定を解除する。
@@ -902,6 +902,23 @@ final class MangaViewModel {
         guard entry.isFocused else { return }
         entry.isFocused = false
         entry.focusedAt = nil
+        saveFocusChange(for: entry)
+    }
+
+    /// フォーカス変更をエントリの所属する ModelContext で確実に保存する。
+    /// `refresh()` で `viewModel.modelContext` が差し替わった後でも、UI が保持している
+    /// `entry` は元のコンテキストに残っているケースがあるため、両方を save する
+    /// （`updateEntry` と同じパターン）。
+    private func saveFocusChange(for entry: MangaEntry) {
+        if let entryCtx = entry.modelContext, entryCtx !== modelContext {
+            do {
+                try entryCtx.save()
+            } catch {
+                print("[MangaViewModel] saveFocusChange entryCtx save failed: \(error)")
+                lastError = .save(error)
+                return
+            }
+        }
         save()
     }
 

--- a/MangaLauncher/Views/Library/LibraryView.swift
+++ b/MangaLauncher/Views/Library/LibraryView.swift
@@ -92,6 +92,7 @@ struct LibraryView: View {
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 24) {
                     catchUpAllUnreadLink
+                    focusedBacklogSection
                     timelineLink
                     hiddenSectionLink
                     recentlyDeletedLink
@@ -168,6 +169,40 @@ struct LibraryView: View {
             }
             .buttonStyle(.plain)
             .padding(.horizontal)
+        }
+    }
+
+    /// フォーカス中の積読セクション。最大 3 本のピン留め積読を最上部で常時表示する。
+    /// 0 本のときはセクションごと非表示。積読セクションには重複表示する仕様 (A 案)。
+    @ViewBuilder
+    private var focusedBacklogSection: some View {
+        let entries = viewModel.focusedBacklogEntries()
+        if !entries.isEmpty {
+            VStack(alignment: .leading, spacing: 8) {
+                SectionHeaderView(
+                    title: "フォーカス中の積読",
+                    icon: "pin.fill",
+                    iconColor: .pink,
+                    count: entries.count,
+                    badgeColor: .pink
+                )
+                .padding(.horizontal)
+
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(alignment: .top, spacing: 12) {
+                        ForEach(entries, id: \.id) { entry in
+                            LibraryCard(
+                                entry: entry,
+                                viewModel: viewModel,
+                                editingEntry: $editingEntry,
+                                commentingEntry: $commentingEntry,
+                                onOpenURL: { openMangaURL($0) }
+                            )
+                        }
+                    }
+                    .padding(.horizontal)
+                }
+            }
         }
     }
 

--- a/MangaLauncher/Views/Library/LibraryView.swift
+++ b/MangaLauncher/Views/Library/LibraryView.swift
@@ -172,8 +172,8 @@ struct LibraryView: View {
         }
     }
 
-    /// フォーカス中の積読セクション。最大 3 本のピン留め積読を最上部で常時表示する。
-    /// 0 本のときはセクションごと非表示。積読セクションには重複表示する仕様 (A 案)。
+    /// フォーカス中の積読セクション。最大 3 本のフォーカス指定された積読を最上部で常時表示する。
+    /// 0 本のときはセクションごと非表示。通常の積読セクションには重複表示する仕様 (A 案)。
     @ViewBuilder
     private var focusedBacklogSection: some View {
         let entries = viewModel.focusedBacklogEntries()

--- a/MangaLauncher/Views/MangaCell/MangaContextMenu.swift
+++ b/MangaLauncher/Views/MangaCell/MangaContextMenu.swift
@@ -52,6 +52,26 @@ struct MangaContextMenu: View {
             }
         }
 
+        // MARK: フォーカス積読
+        // 積読 (backlog) の中から最大 3 本だけ「今集中して消化する」と宣言する。
+        // ライブラリ最上部に常時表示されるので選択疲労が軽減される。
+        if entry.readingState == .backlog {
+            Button {
+                if entry.isFocused {
+                    viewModel.unfocus(entry)
+                } else {
+                    viewModel.focus(entry)
+                }
+            } label: {
+                if entry.isFocused {
+                    Label("フォーカスを外す", systemImage: "pin.slash")
+                } else {
+                    Label("フォーカスする", systemImage: "pin")
+                }
+            }
+            .disabled(!entry.isFocused && !viewModel.canFocus())
+        }
+
         Divider()
 
         // MARK: 日常操作

--- a/MangaLauncherTests/MangaEntryTests.swift
+++ b/MangaLauncherTests/MangaEntryTests.swift
@@ -562,6 +562,91 @@ struct MangaViewModelFocusedBacklogTests {
         #expect(vm.focusedBacklogEntries().map(\.name) == ["visible"])
         #expect(vm.focusedBacklogCount() == 1)
     }
+
+    /// 編集画面 (updateEntry) で readingState が積読から外れたら、フォーカスも自動解除される。
+    /// setReadingState だけでなく updateEntry 経由の遷移でも回帰しないことを担保。
+    @Test("updateEntry で .following に変えるとフォーカス自動解除")
+    @MainActor
+    func updateEntryToFollowingClearsFocus() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let a = makeBacklog(name: "A", context: context)
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        vm.focus(a)
+        #expect(a.isFocused == true)
+
+        vm.updateEntry(
+            a,
+            name: a.name,
+            url: a.url,
+            dayOfWeek: a.dayOfWeek,
+            iconColor: a.iconColor,
+            isOneShot: false,
+            publicationStatus: .active,
+            readingState: .following,
+            memo: a.memo
+        )
+        #expect(a.isFocused == false)
+        #expect(a.focusedAt == nil)
+        #expect(vm.focusedBacklogCount() == 0)
+    }
+
+    @Test("updateEntry で .archived に変えるとフォーカス自動解除")
+    @MainActor
+    func updateEntryToArchivedClearsFocus() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let a = makeBacklog(name: "A", context: context)
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        vm.focus(a)
+        #expect(a.isFocused == true)
+
+        vm.updateEntry(
+            a,
+            name: a.name,
+            url: a.url,
+            dayOfWeek: a.dayOfWeek,
+            iconColor: a.iconColor,
+            isOneShot: false,
+            publicationStatus: .active,
+            readingState: .archived,
+            memo: a.memo
+        )
+        #expect(a.isFocused == false)
+        #expect(a.focusedAt == nil)
+    }
+
+    @Test("updateEntry で .backlog のままならフォーカス維持")
+    @MainActor
+    func updateEntryStaysBacklogKeepsFocus() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let a = makeBacklog(name: "A", context: context)
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        vm.focus(a)
+        let originalFocusedAt = a.focusedAt
+
+        // メモだけ変更、readingState は .backlog のまま
+        vm.updateEntry(
+            a,
+            name: a.name,
+            url: a.url,
+            dayOfWeek: a.dayOfWeek,
+            iconColor: a.iconColor,
+            isOneShot: false,
+            publicationStatus: .active,
+            readingState: .backlog,
+            memo: "新しいメモ"
+        )
+        #expect(a.isFocused == true)
+        #expect(a.focusedAt == originalFocusedAt)
+    }
 }
 
 @Suite("MangaViewModel.runStartupMigrationsIfNeeded")

--- a/MangaLauncherTests/MangaEntryTests.swift
+++ b/MangaLauncherTests/MangaEntryTests.swift
@@ -399,6 +399,171 @@ struct MangaViewModelAllUnreadTests {
     }
 }
 
+@Suite("MangaViewModel.focusedBacklog")
+struct MangaViewModelFocusedBacklogTests {
+
+    private func makeContainer() throws -> ModelContainer {
+        try ModelContainer(
+            for: MangaEntry.self, ReadingActivity.self, MangaComment.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+    }
+
+    private func makeBacklog(name: String, context: ModelContext) -> MangaEntry {
+        let e = MangaEntry(name: name, dayOfWeek: .monday)
+        e.readingState = .backlog
+        context.insert(e)
+        return e
+    }
+
+    @Test("focus / unfocus の基本動作")
+    @MainActor
+    func basicFocusUnfocus() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let a = makeBacklog(name: "A", context: context)
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        vm.focus(a)
+        #expect(a.isFocused == true)
+        #expect(a.focusedAt != nil)
+        #expect(vm.focusedBacklogCount() == 1)
+
+        vm.unfocus(a)
+        #expect(a.isFocused == false)
+        #expect(a.focusedAt == nil)
+        #expect(vm.focusedBacklogCount() == 0)
+    }
+
+    @Test("上限 3 本: 4 本目は拒否される")
+    @MainActor
+    func enforcesMaxThree() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let entries = (0..<4).map { makeBacklog(name: "e\($0)", context: context) }
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        for entry in entries.prefix(3) {
+            vm.focus(entry)
+        }
+        #expect(vm.focusedBacklogCount() == 3)
+        #expect(vm.canFocus() == false)
+
+        // 4 本目は no-op
+        vm.focus(entries[3])
+        #expect(entries[3].isFocused == false)
+        #expect(vm.focusedBacklogCount() == 3)
+
+        // 1 本外したら再び枠が空く
+        vm.unfocus(entries[0])
+        #expect(vm.canFocus() == true)
+        vm.focus(entries[3])
+        #expect(entries[3].isFocused == true)
+        #expect(vm.focusedBacklogCount() == 3)
+    }
+
+    @Test("積読でないエントリーには focus() できない")
+    @MainActor
+    func rejectsNonBacklog() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let following = MangaEntry(name: "f", dayOfWeek: .monday)
+        following.readingState = .following
+        context.insert(following)
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        vm.focus(following)
+        #expect(following.isFocused == false)
+        #expect(vm.focusedBacklogCount() == 0)
+    }
+
+    @Test("setReadingState(.archived) でフォーカス自動解除")
+    @MainActor
+    func archivingClearsFocus() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let a = makeBacklog(name: "A", context: context)
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        vm.focus(a)
+        #expect(a.isFocused == true)
+
+        vm.setReadingState(a, to: .archived)
+        #expect(a.isFocused == false)
+        #expect(a.focusedAt == nil)
+        #expect(vm.focusedBacklogCount() == 0)
+    }
+
+    @Test("setReadingState(.following) でフォーカス自動解除")
+    @MainActor
+    func promotingToFollowingClearsFocus() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let a = makeBacklog(name: "A", context: context)
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        vm.focus(a)
+        #expect(a.isFocused == true)
+
+        vm.setReadingState(a, to: .following)
+        #expect(a.isFocused == false)
+        #expect(vm.focusedBacklogCount() == 0)
+    }
+
+    @Test("並び順: focusedAt 降順 (新しいフォーカスが先頭)")
+    @MainActor
+    func sortedByFocusedAtDesc() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let a = makeBacklog(name: "A", context: context)
+        let b = makeBacklog(name: "B", context: context)
+        let c = makeBacklog(name: "C", context: context)
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        vm.focus(a)
+        // focusedAt の差を出すため微小に待機（実機では Date() の解像度で十分だが、
+        // テストでは明示的に焼き付ける）
+        a.focusedAt = Date(timeIntervalSince1970: 1_000)
+        vm.focus(b)
+        b.focusedAt = Date(timeIntervalSince1970: 2_000)
+        vm.focus(c)
+        c.focusedAt = Date(timeIntervalSince1970: 3_000)
+
+        #expect(vm.focusedBacklogEntries().map(\.name) == ["C", "B", "A"])
+    }
+
+    @Test("hidden / deleted は集計から除外")
+    @MainActor
+    func excludesHiddenAndDeleted() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let visible = makeBacklog(name: "visible", context: context)
+        let hidden = makeBacklog(name: "hidden", context: context)
+        hidden.isHidden = true
+        let deleted = makeBacklog(name: "deleted", context: context)
+        // 直接 isFocused を立てて in-memory のソフトデリート/hidden が効くか確認
+        for entry in [visible, hidden, deleted] {
+            entry.isFocused = true
+            entry.focusedAt = Date()
+        }
+        deleted.deletedAt = Date()
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        vm.reloadHiddenIDs()
+        vm.reloadDeletedIDs()
+
+        #expect(vm.focusedBacklogEntries().map(\.name) == ["visible"])
+        #expect(vm.focusedBacklogCount() == 1)
+    }
+}
+
 @Suite("MangaViewModel.runStartupMigrationsIfNeeded")
 struct MangaViewModelStartupTests {
 


### PR DESCRIPTION
## Summary

積読 (`readingState == .backlog`) の中から最大 **3本まで** 「フォーカス中」として指定できる機能を追加します。ライブラリ最上部に常時表示することで選択疲労を解消し、長期積読の消化を促します。

- 「机の上の "今読みかけ" の本山」のメンタルモデル
- ピン留めではなく "フォーカス" という能動的なコミットメント
- 積読セクションには重複表示する（フォーカス中もフォーカスセクション + 積読セクションの両方に出る）

## 主な変更

| ファイル | 変更点 |
|---|---|
| `Models/MangaEntry.swift` | `isFocused: Bool`, `focusedAt: Date?` 追加（CloudKit 互換のためデフォルト値あり） |
| `ViewModels/MangaViewModel.swift` | `focus / unfocus / focusedBacklogEntries / focusedBacklogCount / canFocus` 追加 |
| `ViewModels/MangaViewModel.swift` | `setReadingState` / `updateEntry` で積読から外れた瞬間に自動フォーカス解除 |
| `Views/MangaCell/MangaContextMenu.swift` | 積読エントリーに「フォーカスする / 外す」項目（上限到達時は disabled） |
| `Views/Library/LibraryView.swift` | 「未読をキャッチアップ」直下にフォーカスセクション追加（pin.fill + ピンク） |
| `MangaLauncherTests/MangaEntryTests.swift` | 7 テスト追加 |

## 設計上の決定

- **上限 3 本**: 同時に追える物語の心理学的な限界に合わせる
- **自動解除**: フォーカスは積読限定のフラグなので、`.archived` / `.following` への遷移時に自動でクリア
- **重複表示 OK**: フォーカス中の作品は「フォーカス中の積読」セクションと通常の「積読」セクションの両方に出る（ユーザー指定）
- **集計ソース統一**: `focusedBacklogEntries()` は `allEntries()` 経由で取得し、ソフトデリート / hidden の整合性を担保

## Test plan

- [x] xcodebuild build (iOS 実機向け) 成功
- [x] iPhone 15 Pro 実機にインストール・起動確認
- [ ] 積読エントリーから「フォーカスする」でフォーカスセクションに表示される
- [ ] 上限 3 本到達時、4 本目のメニュー項目が disabled
- [ ] 「フォーカスを外す」で削除、0 本でセクション非表示
- [ ] 「読了にする」「追っかけ中にする」でフォーカス自動解除
- [ ] 積読セクションにフォーカス中も含めて表示される（重複表示）
- [ ] CloudKit 同期で他デバイスに `isFocused` / `focusedAt` が伝播する
- [ ] 3 テーマ（Classic / Kinetic Ink / Retro）で表示が破綻しない

## 同梱コミット

- `2800a52` Add focused backlog feature
- `2c31bbe` Bump marketing version to 2.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)