### PR TITLE
掲載誌の統合機能を追加

### DIFF
--- a/MangaLauncher.xcodeproj/project.pbxproj
+++ b/MangaLauncher.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		BC000603 /* AllPublishersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000630 /* AllPublishersView.swift */; };
 		BC000604 /* LibrarySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000640 /* LibrarySection.swift */; };
 		BC000605 /* LibrarySectionBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000650 /* LibrarySectionBuilder.swift */; };
+		BC000606 /* PublisherMergePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000660 /* PublisherMergePickerView.swift */; };
 		BC000701 /* SearchResultRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000710 /* SearchResultRow.swift */; };
 		BC000702 /* MemoMatchRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000720 /* MemoMatchRow.swift */; };
 		BC000703 /* CommentMatchRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000730 /* CommentMatchRow.swift */; };
@@ -254,6 +255,7 @@
 		BC000630 /* AllPublishersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllPublishersView.swift; sourceTree = "<group>"; };
 		BC000640 /* LibrarySection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibrarySection.swift; sourceTree = "<group>"; };
 		BC000650 /* LibrarySectionBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibrarySectionBuilder.swift; sourceTree = "<group>"; };
+		BC000660 /* PublisherMergePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublisherMergePickerView.swift; sourceTree = "<group>"; };
 		BC000710 /* SearchResultRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultRow.swift; sourceTree = "<group>"; };
 		BC000720 /* MemoMatchRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoMatchRow.swift; sourceTree = "<group>"; };
 		BC000730 /* CommentMatchRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentMatchRow.swift; sourceTree = "<group>"; };
@@ -485,6 +487,7 @@
 				BC000630 /* AllPublishersView.swift */,
 				BC000640 /* LibrarySection.swift */,
 				BC000650 /* LibrarySectionBuilder.swift */,
+				BC000660 /* PublisherMergePickerView.swift */,
 				AB2001FF00112233AA000007 /* Timeline */,
 			);
 			path = Library;
@@ -871,6 +874,7 @@
 				BC000603 /* AllPublishersView.swift in Sources */,
 				BC000604 /* LibrarySection.swift in Sources */,
 				BC000605 /* LibrarySectionBuilder.swift in Sources */,
+				BC000606 /* PublisherMergePickerView.swift in Sources */,
 				BC000101 /* CommentListView.swift in Sources */,
 				BC000301 /* ActivityItem.swift in Sources */,
 				AB2001FF00112233AA000001 /* TimelineItem.swift in Sources */,

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -422,20 +422,29 @@ final class MangaViewModel {
     }
 
     /// 掲載誌を統合する。`from` の名前を持つ全エントリの publisher を `to` に一括変更する。
+    /// soft-delete されたエントリも含めて変更するのは、restore したときに「古い publisher 名で蘇る」
+    /// ゴーストを作らないため（統合は user の所有データ全体に対する操作と捉える）。
     func mergePublisher(from oldName: String, to newName: String) {
         guard !oldName.isEmpty, !newName.isEmpty, oldName != newName else { return }
         let descriptor = FetchDescriptor<MangaEntry>(
-            predicate: #Predicate { $0.deletedAt == nil }
+            predicate: #Predicate { $0.publisher == oldName }
         )
         let entries = modelContext.fetchLogged(descriptor)
-        var updated = 0
-        for entry in entries where entry.publisher == oldName {
+        guard !entries.isEmpty else { return }
+        for entry in entries {
             entry.publisher = newName
-            updated += 1
         }
-        if updated > 0 {
-            save()
-        }
+        save()
+    }
+
+    /// `mergePublisher` の前置確認用。統合される件数（soft-delete 込み）を返す。
+    /// View 側の確認アラートで「○件を統合します」を表示するために使う。
+    func mergePublisherPreviewCount(for oldName: String) -> Int {
+        guard !oldName.isEmpty else { return 0 }
+        let descriptor = FetchDescriptor<MangaEntry>(
+            predicate: #Predicate { $0.publisher == oldName }
+        )
+        return modelContext.fetchLogged(descriptor).count
     }
 
     func deleteEntry(_ entry: MangaEntry) {

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -421,6 +421,23 @@ final class MangaViewModel {
         return publishers.sorted()
     }
 
+    /// 掲載誌を統合する。`from` の名前を持つ全エントリの publisher を `to` に一括変更する。
+    func mergePublisher(from oldName: String, to newName: String) {
+        guard !oldName.isEmpty, !newName.isEmpty, oldName != newName else { return }
+        let descriptor = FetchDescriptor<MangaEntry>(
+            predicate: #Predicate { $0.deletedAt == nil }
+        )
+        let entries = modelContext.fetchLogged(descriptor)
+        var updated = 0
+        for entry in entries where entry.publisher == oldName {
+            entry.publisher = newName
+            updated += 1
+        }
+        if updated > 0 {
+            save()
+        }
+    }
+
     func deleteEntry(_ entry: MangaEntry) {
         entry.deletedAt = Date()
         deletedIDs.insert(entry.id)

--- a/MangaLauncher/Views/Library/AllPublishersView.swift
+++ b/MangaLauncher/Views/Library/AllPublishersView.swift
@@ -11,6 +11,8 @@ struct AllPublishersView: View {
     private var theme: ThemeStyle { ThemeManager.shared.style }
 
     @State private var publisherCounts: [(publisher: String, count: Int)] = []
+    @State private var mergeSource: String = ""
+    @State private var showingMergeSheet = false
 
     var body: some View {
         ZStack {
@@ -37,6 +39,14 @@ struct AllPublishersView: View {
                         }
                     }
                     .listRowBackground(Color.clear)
+                    .contextMenu {
+                        Button {
+                            mergeSource = item.publisher
+                            showingMergeSheet = true
+                        } label: {
+                            Label("他の掲載誌に統合", systemImage: "arrow.triangle.merge")
+                        }
+                    }
                 }
             }
             .listStyle(.plain)
@@ -55,6 +65,13 @@ struct AllPublishersView: View {
                 editingEntry: $editingEntry,
                 commentingEntry: $commentingEntry,
                 onOpenURL: onOpenURL
+            )
+        }
+        .sheet(isPresented: $showingMergeSheet) {
+            PublisherMergePickerView(
+                source: mergeSource,
+                publishers: publisherCounts.map(\.publisher),
+                viewModel: viewModel
             )
         }
     }

--- a/MangaLauncher/Views/Library/PublisherMergePickerView.swift
+++ b/MangaLauncher/Views/Library/PublisherMergePickerView.swift
@@ -9,6 +9,8 @@ struct PublisherMergePickerView: View {
     let publishers: [String]
     var viewModel: MangaViewModel
 
+    @State private var pendingDestination: String?
+
     private var theme: ThemeStyle { ThemeManager.shared.style }
 
     /// source 以外の掲載誌リスト
@@ -42,8 +44,7 @@ struct PublisherMergePickerView: View {
                         } else {
                             ForEach(destinations, id: \.self) { dest in
                                 Button {
-                                    viewModel.mergePublisher(from: source, to: dest)
-                                    dismiss()
+                                    pendingDestination = dest
                                 } label: {
                                     HStack(spacing: 8) {
                                         Image(systemName: "magazine")
@@ -78,6 +79,25 @@ struct PublisherMergePickerView: View {
                         dismiss()
                     }
                 }
+            }
+            .alert(
+                "掲載誌を統合しますか？",
+                isPresented: Binding(
+                    get: { pendingDestination != nil },
+                    set: { if !$0 { pendingDestination = nil } }
+                ),
+                presenting: pendingDestination
+            ) { destination in
+                Button("統合する", role: .destructive) {
+                    viewModel.mergePublisher(from: source, to: destination)
+                    dismiss()
+                }
+                Button("キャンセル", role: .cancel) {
+                    pendingDestination = nil
+                }
+            } message: { destination in
+                let count = viewModel.mergePublisherPreviewCount(for: source)
+                Text("「\(source)」の \(count) 件を「\(destination)」に統合します。\n\nこの操作は元に戻せません。")
             }
         }
         .themedNavigationStyle()

--- a/MangaLauncher/Views/Library/PublisherMergePickerView.swift
+++ b/MangaLauncher/Views/Library/PublisherMergePickerView.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+
+/// 掲載誌の統合先を選ぶピッカー。
+/// source（移行元）以外の既存掲載誌を一覧表示し、タップで統合を実行する。
+struct PublisherMergePickerView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let source: String
+    let publishers: [String]
+    var viewModel: MangaViewModel
+
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
+    /// source 以外の掲載誌リスト
+    private var destinations: [String] {
+        publishers.filter { $0 != source }
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                if theme.usesCustomSurface {
+                    theme.surface.ignoresSafeArea()
+                }
+                List {
+                    Section {
+                        HStack(spacing: 8) {
+                            Image(systemName: "magazine")
+                                .foregroundStyle(theme.primary)
+                            Text(source)
+                                .font(theme.bodyFont.weight(.semibold))
+                                .foregroundStyle(theme.onSurface)
+                        }
+                    } header: {
+                        Text("統合元")
+                    }
+
+                    Section {
+                        if destinations.isEmpty {
+                            Text("他に掲載誌がありません")
+                                .foregroundStyle(theme.onSurfaceVariant)
+                        } else {
+                            ForEach(destinations, id: \.self) { dest in
+                                Button {
+                                    viewModel.mergePublisher(from: source, to: dest)
+                                    dismiss()
+                                } label: {
+                                    HStack(spacing: 8) {
+                                        Image(systemName: "magazine")
+                                            .foregroundStyle(theme.primary)
+                                        Text(dest)
+                                            .font(theme.bodyFont)
+                                            .foregroundStyle(theme.onSurface)
+                                        Spacer()
+                                        Image(systemName: "arrow.right")
+                                            .font(.caption)
+                                            .foregroundStyle(theme.onSurfaceVariant)
+                                    }
+                                }
+                            }
+                        }
+                    } header: {
+                        Text("統合先を選択")
+                    } footer: {
+                        Text("「\(source)」の全作品が選択した掲載誌に移動します")
+                    }
+                }
+                .listStyle(.insetGrouped)
+                .scrollContentBackground(.hidden)
+            }
+            .navigationTitle("掲載誌を統合")
+            #if os(iOS) || os(visionOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("キャンセル") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+        .themedNavigationStyle()
+    }
+}

--- a/MangaLauncherTests/MangaEntryTests.swift
+++ b/MangaLauncherTests/MangaEntryTests.swift
@@ -649,6 +649,127 @@ struct MangaViewModelFocusedBacklogTests {
     }
 }
 
+@Suite("MangaViewModel.mergePublisher")
+struct MangaViewModelMergePublisherTests {
+
+    private func makeContainer() throws -> ModelContainer {
+        try ModelContainer(
+            for: MangaEntry.self, ReadingActivity.self, MangaComment.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+    }
+
+    private func makeEntry(name: String, publisher: String, context: ModelContext) -> MangaEntry {
+        let e = MangaEntry(name: name, dayOfWeek: .monday, publisher: publisher)
+        context.insert(e)
+        return e
+    }
+
+    @Test("基本動作: 統合元の publisher を持つ全エントリが統合先に変更される")
+    @MainActor
+    func mergesMatchingEntries() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let a = makeEntry(name: "A", publisher: "ジャンプ＋", context: context)
+        let b = makeEntry(name: "B", publisher: "ジャンプ＋", context: context)
+        let c = makeEntry(name: "C", publisher: "ジャンププラス", context: context)
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        vm.mergePublisher(from: "ジャンプ＋", to: "ジャンププラス")
+
+        #expect(a.publisher == "ジャンププラス")
+        #expect(b.publisher == "ジャンププラス")
+        #expect(c.publisher == "ジャンププラス")
+    }
+
+    @Test("該当 publisher 以外のエントリは変更されない")
+    @MainActor
+    func leavesOtherPublishersUntouched() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let a = makeEntry(name: "A", publisher: "ジャンプ＋", context: context)
+        let b = makeEntry(name: "B", publisher: "サンデー", context: context)
+        let c = makeEntry(name: "C", publisher: "マガジン", context: context)
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        vm.mergePublisher(from: "ジャンプ＋", to: "ジャンププラス")
+
+        #expect(a.publisher == "ジャンププラス")
+        #expect(b.publisher == "サンデー")
+        #expect(c.publisher == "マガジン")
+    }
+
+    @Test("no-op: 同じ名前への統合は何もしない")
+    @MainActor
+    func sameNameIsNoOp() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let a = makeEntry(name: "A", publisher: "ジャンプ＋", context: context)
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        vm.mergePublisher(from: "ジャンプ＋", to: "ジャンプ＋")
+
+        #expect(a.publisher == "ジャンプ＋")
+    }
+
+    @Test("no-op: 空文字列の統合元/統合先は何もしない")
+    @MainActor
+    func emptyNamesAreNoOp() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let a = makeEntry(name: "A", publisher: "ジャンプ＋", context: context)
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        vm.mergePublisher(from: "", to: "ジャンププラス")
+        #expect(a.publisher == "ジャンプ＋")
+
+        vm.mergePublisher(from: "ジャンプ＋", to: "")
+        #expect(a.publisher == "ジャンプ＋")
+    }
+
+    @Test("soft-delete されたエントリも統合される (restore 時の整合性確保)")
+    @MainActor
+    func includesSoftDeletedEntries() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let visible = makeEntry(name: "visible", publisher: "ジャンプ＋", context: context)
+        let deleted = makeEntry(name: "deleted", publisher: "ジャンプ＋", context: context)
+        deleted.deletedAt = Date()
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        vm.mergePublisher(from: "ジャンプ＋", to: "ジャンププラス")
+
+        #expect(visible.publisher == "ジャンププラス")
+        #expect(deleted.publisher == "ジャンププラス")
+    }
+
+    @Test("preview count は soft-delete を含む該当件数を返す")
+    @MainActor
+    func previewCountIncludesSoftDeleted() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let v1 = makeEntry(name: "v1", publisher: "ジャンプ＋", context: context)
+        let v2 = makeEntry(name: "v2", publisher: "ジャンプ＋", context: context)
+        let d1 = makeEntry(name: "d1", publisher: "ジャンプ＋", context: context)
+        d1.deletedAt = Date()
+        let other = makeEntry(name: "other", publisher: "サンデー", context: context)
+        try context.save()
+        // 参照保持で warning 抑止
+        _ = (v1, v2, other)
+
+        let vm = MangaViewModel(modelContext: context)
+        #expect(vm.mergePublisherPreviewCount(for: "ジャンプ＋") == 3)
+        #expect(vm.mergePublisherPreviewCount(for: "サンデー") == 1)
+        #expect(vm.mergePublisherPreviewCount(for: "存在しない") == 0)
+        #expect(vm.mergePublisherPreviewCount(for: "") == 0)
+    }
+}
+
 @Suite("MangaViewModel.runStartupMigrationsIfNeeded")
 struct MangaViewModelStartupTests {
 


### PR DESCRIPTION
## Summary
- 掲載誌一覧（AllPublishersView）でコンテキストメニューから「他の掲載誌に統合」を選べるように
- 既存の掲載誌リストから統合先を選ぶだけで、全エントリの publisher が一括更新される
- 手入力不要で表記揺れの統合が手軽にできる

## Test plan
- [ ] 掲載誌一覧で掲載誌を長押し→「他の掲載誌に統合」が表示される
- [ ] 統合先ピッカーに統合元以外の掲載誌が表示される
- [ ] 統合先をタップ→統合元の全作品が統合先に移動する
- [ ] 統合後、掲載誌一覧が正しく更新される（統合元が消える）
- [ ] 掲載誌が1つしかない場合「他に掲載誌がありません」が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)