### PR TITLE
掲載誌アイコン機能 (PublisherMetadata)

### DIFF
--- a/MangaLauncher.xcodeproj/project.pbxproj
+++ b/MangaLauncher.xcodeproj/project.pbxproj
@@ -61,6 +61,9 @@
 		CD000001 /* MangaLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD000010 /* MangaLink.swift */; };
 		CD000002 /* MangaLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD000010 /* MangaLink.swift */; };
 		CD000003 /* MangaLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD000010 /* MangaLink.swift */; };
+		FA000001 /* PublisherMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA000010 /* PublisherMetadata.swift */; };
+		FA000002 /* PublisherMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA000010 /* PublisherMetadata.swift */; };
+		FA000003 /* PublisherMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA000010 /* PublisherMetadata.swift */; };
 		CD000101 /* EditLinkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD000110 /* EditLinkView.swift */; };
 		BC000101 /* CommentListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000110 /* CommentListView.swift */; };
 		BC000301 /* ActivityItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000310 /* ActivityItem.swift */; };
@@ -229,6 +232,7 @@
 		AA000010 /* ReadingActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingActivity.swift; sourceTree = "<group>"; };
 		BC000010 /* MangaComment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaComment.swift; sourceTree = "<group>"; };
 		CD000010 /* MangaLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaLink.swift; sourceTree = "<group>"; };
+		FA000010 /* PublisherMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublisherMetadata.swift; sourceTree = "<group>"; };
 		CE000010 /* LinkedText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedText.swift; sourceTree = "<group>"; };
 		CD000110 /* EditLinkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditLinkView.swift; sourceTree = "<group>"; };
 		BC000110 /* CommentListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentListView.swift; sourceTree = "<group>"; };
@@ -429,6 +433,7 @@
 				AA000010 /* ReadingActivity.swift */,
 				BC000010 /* MangaComment.swift */,
 				CD000010 /* MangaLink.swift */,
+				FA000010 /* PublisherMetadata.swift */,
 				BC000310 /* ActivityItem.swift */,
 				AB2001FF00112233AA000002 /* TimelineItem.swift */,
 				AB4001FF00112233AA000006 /* AppError.swift */,
@@ -807,6 +812,7 @@
 				AA000001 /* ReadingActivity.swift in Sources */,
 				BC000001 /* MangaComment.swift in Sources */,
 				CD000001 /* MangaLink.swift in Sources */,
+				FA000001 /* PublisherMetadata.swift in Sources */,
 				ECFEA84A2F7F6E5700CE4DC0 /* MangaURLOpener.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -826,6 +832,7 @@
 				AA000002 /* ReadingActivity.swift in Sources */,
 				BC000002 /* MangaComment.swift in Sources */,
 				CD000002 /* MangaLink.swift in Sources */,
+				FA000002 /* PublisherMetadata.swift in Sources */,
 				ECFEA8492F7F6E5700CE4DC0 /* MangaURLOpener.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -926,6 +933,7 @@
 				AA000003 /* ReadingActivity.swift in Sources */,
 				BC000003 /* MangaComment.swift in Sources */,
 				CD000003 /* MangaLink.swift in Sources */,
+				FA000003 /* PublisherMetadata.swift in Sources */,
 				CD000101 /* EditLinkView.swift in Sources */,
 				ECFEA8602F7F7E2000CE4DC0 /* DayPageView.swift in Sources */,
 				AA000004 /* ReadingHeatmapView.swift in Sources */,

--- a/MangaLauncher.xcodeproj/project.pbxproj
+++ b/MangaLauncher.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		BC000605 /* LibrarySectionBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000650 /* LibrarySectionBuilder.swift */; };
 		BC000606 /* PublisherMergePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000660 /* PublisherMergePickerView.swift */; };
 		FC000001 /* PublisherIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC000010 /* PublisherIconView.swift */; };
+		FD000001 /* PublisherIconEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD000010 /* PublisherIconEditorView.swift */; };
 		BC000701 /* SearchResultRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000710 /* SearchResultRow.swift */; };
 		BC000702 /* MemoMatchRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000720 /* MemoMatchRow.swift */; };
 		BC000703 /* CommentMatchRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000730 /* CommentMatchRow.swift */; };
@@ -264,6 +265,7 @@
 		BC000650 /* LibrarySectionBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibrarySectionBuilder.swift; sourceTree = "<group>"; };
 		BC000660 /* PublisherMergePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublisherMergePickerView.swift; sourceTree = "<group>"; };
 		FC000010 /* PublisherIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublisherIconView.swift; sourceTree = "<group>"; };
+		FD000010 /* PublisherIconEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublisherIconEditorView.swift; sourceTree = "<group>"; };
 		BC000710 /* SearchResultRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultRow.swift; sourceTree = "<group>"; };
 		BC000720 /* MemoMatchRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoMatchRow.swift; sourceTree = "<group>"; };
 		BC000730 /* CommentMatchRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentMatchRow.swift; sourceTree = "<group>"; };
@@ -498,6 +500,7 @@
 				BC000650 /* LibrarySectionBuilder.swift */,
 				BC000660 /* PublisherMergePickerView.swift */,
 				FC000010 /* PublisherIconView.swift */,
+				FD000010 /* PublisherIconEditorView.swift */,
 				AB2001FF00112233AA000007 /* Timeline */,
 			);
 			path = Library;
@@ -890,6 +893,7 @@
 				BC000605 /* LibrarySectionBuilder.swift in Sources */,
 				BC000606 /* PublisherMergePickerView.swift in Sources */,
 				FC000001 /* PublisherIconView.swift in Sources */,
+				FD000001 /* PublisherIconEditorView.swift in Sources */,
 				BC000101 /* CommentListView.swift in Sources */,
 				BC000301 /* ActivityItem.swift in Sources */,
 				AB2001FF00112233AA000001 /* TimelineItem.swift in Sources */,

--- a/MangaLauncher.xcodeproj/project.pbxproj
+++ b/MangaLauncher.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		AB50040000112233AA000003 /* HiddenEntriesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB50040000112233AA000004 /* HiddenEntriesView.swift */; };
 		AB50040000112233AA000005 /* RecentlyDeletedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB50040000112233AA000006 /* RecentlyDeletedView.swift */; };
 		AB50040000112233AA000001 /* BiometricAuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB50040000112233AA000002 /* BiometricAuthService.swift */; };
+		FB000001 /* PublisherIconService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB000010 /* PublisherIconService.swift */; };
 		AB50050000112233AA000001 /* SpecialEpisodeAlertModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB50050000112233AA000002 /* SpecialEpisodeAlertModifier.swift */; };
 		AB50030000112233AA000003 /* MangaLifetimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB50030000112233AA000004 /* MangaLifetimeView.swift */; };
 		AB50030000112233AA000001 /* MangaLifetime.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB50030000112233AA000002 /* MangaLifetime.swift */; };
@@ -189,6 +190,7 @@
 		AB50040000112233AA000004 /* HiddenEntriesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiddenEntriesView.swift; sourceTree = "<group>"; };
 		AB50040000112233AA000006 /* RecentlyDeletedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentlyDeletedView.swift; sourceTree = "<group>"; };
 		AB50040000112233AA000002 /* BiometricAuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricAuthService.swift; sourceTree = "<group>"; };
+		FB000010 /* PublisherIconService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublisherIconService.swift; sourceTree = "<group>"; };
 		AB50050000112233AA000002 /* SpecialEpisodeAlertModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecialEpisodeAlertModifier.swift; sourceTree = "<group>"; };
 		AB50030000112233AA000004 /* MangaLifetimeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaLifetimeView.swift; sourceTree = "<group>"; };
 		AB50030000112233AA000002 /* MangaLifetime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaLifetime.swift; sourceTree = "<group>"; };
@@ -658,6 +660,7 @@
 				AB5001FF00112233AA000002 /* NextUpdateFormatter.swift */,
 				AB50020000112233AA000001 /* MangaEntryAccessibility.swift */,
 				AB50040000112233AA000002 /* BiometricAuthService.swift */,
+				FB000010 /* PublisherIconService.swift */,
 				AB50050000112233AA000002 /* SpecialEpisodeAlertModifier.swift */,
 				AB5001FF00112233AA000004 /* NextUpdateBadgeView.swift */,
 			);
@@ -850,6 +853,7 @@
 				ECCD2FCE2F65596900BF3309 /* PublisherPickerView.swift in Sources */,
 				A1000002 /* MangaEntry.swift in Sources */,
 				AB50040000112233AA000001 /* BiometricAuthService.swift in Sources */,
+				FB000001 /* PublisherIconService.swift in Sources */,
 				AB50040000112233AA000003 /* HiddenEntriesView.swift in Sources */,
 				AB50040000112233AA000005 /* RecentlyDeletedView.swift in Sources */,
 				AB50050000112233AA000001 /* SpecialEpisodeAlertModifier.swift in Sources */,

--- a/MangaLauncher.xcodeproj/project.pbxproj
+++ b/MangaLauncher.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		BC000604 /* LibrarySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000640 /* LibrarySection.swift */; };
 		BC000605 /* LibrarySectionBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000650 /* LibrarySectionBuilder.swift */; };
 		BC000606 /* PublisherMergePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000660 /* PublisherMergePickerView.swift */; };
+		FC000001 /* PublisherIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC000010 /* PublisherIconView.swift */; };
 		BC000701 /* SearchResultRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000710 /* SearchResultRow.swift */; };
 		BC000702 /* MemoMatchRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000720 /* MemoMatchRow.swift */; };
 		BC000703 /* CommentMatchRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC000730 /* CommentMatchRow.swift */; };
@@ -262,6 +263,7 @@
 		BC000640 /* LibrarySection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibrarySection.swift; sourceTree = "<group>"; };
 		BC000650 /* LibrarySectionBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibrarySectionBuilder.swift; sourceTree = "<group>"; };
 		BC000660 /* PublisherMergePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublisherMergePickerView.swift; sourceTree = "<group>"; };
+		FC000010 /* PublisherIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublisherIconView.swift; sourceTree = "<group>"; };
 		BC000710 /* SearchResultRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultRow.swift; sourceTree = "<group>"; };
 		BC000720 /* MemoMatchRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoMatchRow.swift; sourceTree = "<group>"; };
 		BC000730 /* CommentMatchRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentMatchRow.swift; sourceTree = "<group>"; };
@@ -495,6 +497,7 @@
 				BC000640 /* LibrarySection.swift */,
 				BC000650 /* LibrarySectionBuilder.swift */,
 				BC000660 /* PublisherMergePickerView.swift */,
+				FC000010 /* PublisherIconView.swift */,
 				AB2001FF00112233AA000007 /* Timeline */,
 			);
 			path = Library;
@@ -886,6 +889,7 @@
 				BC000604 /* LibrarySection.swift in Sources */,
 				BC000605 /* LibrarySectionBuilder.swift in Sources */,
 				BC000606 /* PublisherMergePickerView.swift in Sources */,
+				FC000001 /* PublisherIconView.swift in Sources */,
 				BC000101 /* CommentListView.swift in Sources */,
 				BC000301 /* ActivityItem.swift in Sources */,
 				AB2001FF00112233AA000001 /* TimelineItem.swift in Sources */,

--- a/MangaLauncher/Models/BackupData.swift
+++ b/MangaLauncher/Models/BackupData.swift
@@ -9,6 +9,16 @@ struct BackupData: Codable {
     let activities: [BackupActivity]?
     let comments: [BackupComment]?
     let links: [BackupLink]?
+    /// v15+ 掲載誌アイコン等のメタデータ
+    let publisherMetadata: [BackupPublisherMetadata]?
+
+    struct BackupPublisherMetadata: Codable {
+        let id: UUID
+        let name: String
+        let iconData: Data?
+        let sourceURL: String?
+        let updatedAt: Date?
+    }
 
     struct BackupActivity: Codable {
         let id: UUID
@@ -148,9 +158,9 @@ struct BackupData: Codable {
         }
     }
 
-    static func from(_ entries: [MangaEntry], activities: [ReadingActivity] = [], comments: [MangaComment] = [], links: [MangaLink] = []) -> BackupData {
+    static func from(_ entries: [MangaEntry], activities: [ReadingActivity] = [], comments: [MangaComment] = [], links: [MangaLink] = [], publisherMetadata: [PublisherMetadata] = []) -> BackupData {
         BackupData(
-            version: 14,
+            version: 15,
             exportDate: Date(),
             entries: entries.map {
                 BackupEntry(
@@ -204,6 +214,15 @@ struct BackupData: Codable {
                     url: $0.url,
                     sortOrder: $0.sortOrder,
                     createdAt: $0.createdAt,
+                    updatedAt: $0.updatedAt
+                )
+            },
+            publisherMetadata: publisherMetadata.map {
+                BackupPublisherMetadata(
+                    id: $0.id,
+                    name: $0.name,
+                    iconData: $0.iconData,
+                    sourceURL: $0.sourceURL,
                     updatedAt: $0.updatedAt
                 )
             }

--- a/MangaLauncher/Models/PublisherMetadata.swift
+++ b/MangaLauncher/Models/PublisherMetadata.swift
@@ -1,0 +1,34 @@
+import Foundation
+import SwiftData
+
+/// 掲載誌名 (`MangaEntry.publisher`) に紐付くメタデータ。
+/// 別テーブルにすることで、既存 String カラムに触らず付随情報（アイコン等）を拡張できる。
+/// `name` をキーに `MangaEntry.publisher` と論理 join する。
+///
+/// CloudKit 同期対象。`@Attribute(.unique)` は使わない（既存モデルと統一、CloudKit との
+/// 組み合わせで race 時の挙動が不安定になるため）。重複は ViewModel 層で soft de-dup する。
+@Model
+final class PublisherMetadata: Identifiable {
+    var id: UUID = UUID()
+
+    /// 掲載誌名。`MangaEntry.publisher` と完全一致でジョインする。
+    var name: String = ""
+
+    /// アイコン画像（JPEG, 256x256, 1:1 にクロップ済みを期待）。
+    /// SQLite を太らせないため externalStorage で外部保存。
+    @Attribute(.externalStorage) var iconData: Data?
+
+    /// アイコン取得元の URL（ファビコンとして取得した場合の参照、再取得用）。
+    var sourceURL: String?
+
+    /// アイコン更新日時。重複 record の優先度判定にも使う。
+    var updatedAt: Date?
+
+    init(name: String, iconData: Data? = nil, sourceURL: String? = nil) {
+        self.id = UUID()
+        self.name = name
+        self.iconData = iconData
+        self.sourceURL = sourceURL
+        self.updatedAt = iconData == nil ? nil : Date()
+    }
+}

--- a/MangaLauncher/Shared/PublisherIconService.swift
+++ b/MangaLauncher/Shared/PublisherIconService.swift
@@ -1,0 +1,152 @@
+import Foundation
+import LinkPresentation
+#if canImport(UIKit)
+import UIKit
+#endif
+
+enum PublisherIconError: Error, LocalizedError {
+    case invalidURL
+    case noImage
+    case decodingFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL:     "URL の形式が不正です"
+        case .noImage:        "URL からアイコンを取得できませんでした"
+        case .decodingFailed: "取得した画像を変換できませんでした"
+        }
+    }
+}
+
+/// 掲載誌アイコンの取得・整形ユーティリティ。
+/// state を持たないので enum + static method。
+/// - 第一選択: LinkPresentation (LPMetadataProvider) でメタデータ取得
+/// - 失敗時フォールバック: `/favicon.ico` の直 fetch
+/// - 最終的に 256x256 / 1:1 / JPEG (q=0.85) に整形して返す
+///
+/// ネットワーク I/O は MainActor の外で実行する想定 (await が suspension で
+/// 自動的に actor を解放する)。
+enum PublisherIconService {
+
+    /// 取得結果。`data` は整形済み JPEG。
+    struct FetchResult {
+        let data: Data
+        let sourceURL: String
+    }
+
+    /// 第一選択: LinkPresentation。失敗時は /favicon.ico フォールバック。
+    static func fetchIcon(for urlString: String) async throws -> FetchResult {
+        guard let url = normalizedURL(from: urlString) else {
+            throw PublisherIconError.invalidURL
+        }
+
+        if let data = try? await fetchViaLinkPresentation(url: url) {
+            return FetchResult(data: data, sourceURL: url.absoluteString)
+        }
+        if let data = try await fetchFaviconFallback(origin: url) {
+            return FetchResult(data: data, sourceURL: url.absoluteString)
+        }
+        throw PublisherIconError.noImage
+    }
+
+    /// PhotosPicker から取得した raw 画像データを保存用に整形する。
+    /// 設定シートのプレビュー用にも使う。
+    static func prepareLocalIcon(from rawData: Data) -> Data? {
+        #if canImport(UIKit)
+        guard let image = UIImage(data: rawData) else { return nil }
+        return cropAndResize(image)
+        #else
+        return nil
+        #endif
+    }
+
+    // MARK: - LinkPresentation
+
+    private static func fetchViaLinkPresentation(url: URL) async throws -> Data? {
+        let provider = LPMetadataProvider()
+        provider.timeout = 6
+        let metadata = try await provider.startFetchingMetadata(for: url)
+        guard let imageProvider = metadata.iconProvider ?? metadata.imageProvider else {
+            return nil
+        }
+        let object = try await loadImage(from: imageProvider)
+        #if canImport(UIKit)
+        guard let uiImage = object as? UIImage else { return nil }
+        return cropAndResize(uiImage)
+        #else
+        return nil
+        #endif
+    }
+
+    /// `loadObject(ofClass:)` のコールバック版を async 化するブリッジ。
+    private static func loadImage(from provider: NSItemProvider) async throws -> NSItemProviderReading? {
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<NSItemProviderReading?, Error>) in
+            #if canImport(UIKit)
+            provider.loadObject(ofClass: UIImage.self) { object, error in
+                if let error { cont.resume(throwing: error); return }
+                cont.resume(returning: object)
+            }
+            #else
+            cont.resume(returning: nil)
+            #endif
+        }
+    }
+
+    // MARK: - /favicon.ico fallback
+
+    private static func fetchFaviconFallback(origin: URL) async throws -> Data? {
+        guard let scheme = origin.scheme, let host = origin.host,
+              var components = URLComponents(string: "\(scheme)://\(host)") else { return nil }
+        components.path = "/favicon.ico"
+        guard let icoURL = components.url else { return nil }
+
+        let (data, response) = try await URLSession.shared.data(from: icoURL)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            return nil
+        }
+        #if canImport(UIKit)
+        guard let uiImage = UIImage(data: data) else { return nil }
+        return cropAndResize(uiImage)
+        #else
+        return nil
+        #endif
+    }
+
+    // MARK: - Image transform
+
+    /// 中央正方形クロップ → target x target へリサイズ → JPEG q=0.85。
+    /// 表示は最大 96pt 程度なので 256 で 2.7x、十分な解像度。
+    /// internal 公開: 設定シートの PhotosPicker / プレビューでも同じ整形ロジックを使う。
+    #if canImport(UIKit)
+    static func cropAndResize(_ image: UIImage, target: CGFloat = 256) -> Data? {
+        let size = image.size
+        let edge = min(size.width, size.height)
+        guard edge > 0, let cg = image.cgImage else { return nil }
+        let scale = image.scale
+        let cropRect = CGRect(
+            x: (size.width  - edge) / 2 * scale,
+            y: (size.height - edge) / 2 * scale,
+            width:  edge * scale,
+            height: edge * scale
+        )
+        guard let cropped = cg.cropping(to: cropRect) else { return nil }
+        let croppedUI = UIImage(cgImage: cropped, scale: scale, orientation: image.imageOrientation)
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: target, height: target))
+        let resized = renderer.image { _ in
+            croppedUI.draw(in: CGRect(x: 0, y: 0, width: target, height: target))
+        }
+        return resized.jpegData(compressionQuality: 0.85)
+    }
+    #endif
+
+    // MARK: - URL normalization
+
+    private static func normalizedURL(from raw: String) -> URL? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        if trimmed.lowercased().hasPrefix("http") {
+            return URL(string: trimmed)
+        }
+        return URL(string: "https://\(trimmed)")
+    }
+}

--- a/MangaLauncher/Shared/SharedModelContainer.swift
+++ b/MangaLauncher/Shared/SharedModelContainer.swift
@@ -14,7 +14,7 @@ enum SharedModelContainer {
     /// アプリ更新直後など CloudKit の準備が間に合わない一時的な失敗を吸収する。
     /// 全試行失敗時は最後のエラーを throw する。
     static func create(maxAttempts: Int = 3) throws -> ModelContainer {
-        let schema = Schema([MangaEntry.self, ReadingActivity.self, MangaComment.self, MangaLink.self])
+        let schema = Schema([MangaEntry.self, ReadingActivity.self, MangaComment.self, MangaLink.self, PublisherMetadata.self])
         let config = ModelConfiguration(
             "MangaLauncher",
             schema: schema,
@@ -48,7 +48,7 @@ enum SharedModelContainer {
     /// データ連続性は保たれる。次回起動で CloudKit が回復していれば create() に
     /// 戻り、ローカル更新分も sync される (SwiftData が変更を検出して push)。
     static func createLocalOnly() throws -> ModelContainer {
-        let schema = Schema([MangaEntry.self, ReadingActivity.self, MangaComment.self, MangaLink.self])
+        let schema = Schema([MangaEntry.self, ReadingActivity.self, MangaComment.self, MangaLink.self, PublisherMetadata.self])
         let config = ModelConfiguration(
             "MangaLauncher",
             schema: schema,

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -527,10 +527,22 @@ final class MangaViewModel {
     }
 
     /// アイコンのみクリア（record 自体は残す: sourceURL を保持して再取得しやすくするため）。
+    /// CloudKit race で同名 record が複数できているケースでも確実に clear するため、
+    /// `publisherMetadata(for:)` で 1 件取るのではなく該当する全 record の iconData を nil にする。
+    /// （1 件だけ clear すると、cache の sort ロジックが残った record の iconData を拾って
+    /// 「削除したのに残る」現象になる）
     func clearPublisherIcon(name: String) {
-        guard let meta = publisherMetadata(for: name) else { return }
-        meta.iconData = nil
-        meta.updatedAt = Date()
+        guard !name.isEmpty else { return }
+        let descriptor = FetchDescriptor<PublisherMetadata>(
+            predicate: #Predicate { $0.name == name }
+        )
+        let records = modelContext.fetchLogged(descriptor)
+        guard !records.isEmpty else { return }
+        let now = Date()
+        for meta in records {
+            meta.iconData = nil
+            meta.updatedAt = now
+        }
         save()
     }
 

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -733,7 +733,10 @@ final class MangaViewModel {
         let comments = modelContext.fetchLogged(commentDescriptor).filter { activeEntryIDs.contains($0.mangaEntryID) }
         let linkDescriptor = FetchDescriptor<MangaLink>(sortBy: [SortDescriptor(\.sortOrder)])
         let links = modelContext.fetchLogged(linkDescriptor).filter { activeEntryIDs.contains($0.mangaEntryID) }
-        let backup = BackupData.from(entries, activities: activities, comments: comments, links: links)
+        // Publisher metadata は entry に紐付かない (name で join) ので、すべて含める
+        let metaDescriptor = FetchDescriptor<PublisherMetadata>(sortBy: [SortDescriptor(\.name)])
+        let publisherMetadata = modelContext.fetchLogged(metaDescriptor)
+        let backup = BackupData.from(entries, activities: activities, comments: comments, links: links, publisherMetadata: publisherMetadata)
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         return try? encoder.encode(backup)
@@ -836,6 +839,22 @@ final class MangaViewModel {
                 link.updatedAt = backupLink.updatedAt
                 modelContext.insert(link)
                 existingLinkIDs.insert(backupLink.id)
+                importedCount += 1
+            }
+        }
+        // v15+ 掲載誌アイコン等のメタデータ。同名既存があればスキップ (in-place update はしない)。
+        if let backupMetas = backup.publisherMetadata {
+            let existingNames = Set(modelContext.fetchLogged(FetchDescriptor<PublisherMetadata>()).map(\.name))
+            for backupMeta in backupMetas {
+                guard !existingNames.contains(backupMeta.name) else { continue }
+                let meta = PublisherMetadata(
+                    name: backupMeta.name,
+                    iconData: backupMeta.iconData,
+                    sourceURL: backupMeta.sourceURL
+                )
+                meta.id = backupMeta.id
+                meta.updatedAt = backupMeta.updatedAt
+                modelContext.insert(meta)
                 importedCount += 1
             }
         }

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -424,6 +424,7 @@ final class MangaViewModel {
     /// 掲載誌を統合する。`from` の名前を持つ全エントリの publisher を `to` に一括変更する。
     /// soft-delete されたエントリも含めて変更するのは、restore したときに「古い publisher 名で蘇る」
     /// ゴーストを作らないため（統合は user の所有データ全体に対する操作と捉える）。
+    /// 統合元の `PublisherMetadata`（アイコン情報）も削除する。統合先の metadata はそのまま維持。
     func mergePublisher(from oldName: String, to newName: String) {
         guard !oldName.isEmpty, !newName.isEmpty, oldName != newName else { return }
         let descriptor = FetchDescriptor<MangaEntry>(
@@ -434,6 +435,8 @@ final class MangaViewModel {
         for entry in entries {
             entry.publisher = newName
         }
+        // 統合元の metadata を削除（統合先のアイコンを維持）
+        deletePublisherMetadata(name: oldName)
         save()
     }
 
@@ -445,6 +448,71 @@ final class MangaViewModel {
             predicate: #Predicate { $0.publisher == oldName }
         )
         return modelContext.fetchLogged(descriptor).count
+    }
+
+    // MARK: - Publisher Metadata
+
+    /// 指定 publisher のアイコン Data を取得（表示パスから毎回呼ばれる前提、軽量）。
+    func publisherIcon(for name: String) -> Data? {
+        let _ = refreshCounter
+        guard !name.isEmpty else { return nil }
+        return publisherMetadata(for: name)?.iconData
+    }
+
+    /// 指定 publisher にアイコンが設定されているか。merge 確認文言の分岐などで使う。
+    func publisherHasIcon(name: String) -> Bool {
+        let _ = refreshCounter
+        guard !name.isEmpty else { return false }
+        return publisherMetadata(for: name)?.iconData != nil
+    }
+
+    /// 指定 publisher のメタデータレコード。重複時は iconData 持ち + 新しい updatedAt を優先。
+    /// CloudKit race で複数できる可能性に備えた soft de-dup。
+    private func publisherMetadata(for name: String) -> PublisherMetadata? {
+        let descriptor = FetchDescriptor<PublisherMetadata>(
+            predicate: #Predicate { $0.name == name }
+        )
+        let results = modelContext.fetchLogged(descriptor)
+        if results.count <= 1 { return results.first }
+        return results.sorted { lhs, rhs in
+            let lhsHas = lhs.iconData != nil
+            let rhsHas = rhs.iconData != nil
+            if lhsHas != rhsHas { return lhsHas }
+            return (lhs.updatedAt ?? .distantPast) > (rhs.updatedAt ?? .distantPast)
+        }.first
+    }
+
+    /// アイコンを保存。imageData は整形済み (PublisherIconService 経由) を期待。
+    /// 既存 record があれば update、なければ insert。
+    func setPublisherIcon(name: String, imageData: Data, sourceURL: String? = nil) {
+        guard !name.isEmpty else { return }
+        if let existing = publisherMetadata(for: name) {
+            existing.iconData = imageData
+            if let sourceURL { existing.sourceURL = sourceURL }
+            existing.updatedAt = Date()
+        } else {
+            let meta = PublisherMetadata(name: name, iconData: imageData, sourceURL: sourceURL)
+            modelContext.insert(meta)
+        }
+        save()
+    }
+
+    /// アイコンのみクリア（record 自体は残す: sourceURL を保持して再取得しやすくするため）。
+    func clearPublisherIcon(name: String) {
+        guard let meta = publisherMetadata(for: name) else { return }
+        meta.iconData = nil
+        meta.updatedAt = Date()
+        save()
+    }
+
+    /// メタデータレコードを完全削除（mergePublisher / deleteAllEntries 用、private）。
+    private func deletePublisherMetadata(name: String) {
+        let descriptor = FetchDescriptor<PublisherMetadata>(
+            predicate: #Predicate { $0.name == name }
+        )
+        for meta in modelContext.fetchLogged(descriptor) {
+            modelContext.delete(meta)
+        }
     }
 
     func deleteEntry(_ entry: MangaEntry) {
@@ -611,6 +679,10 @@ final class MangaViewModel {
         let commentDescriptor = FetchDescriptor<MangaComment>()
         for comment in modelContext.fetchLogged(commentDescriptor) {
             modelContext.delete(comment)
+        }
+        let metaDescriptor = FetchDescriptor<PublisherMetadata>()
+        for meta in modelContext.fetchLogged(metaDescriptor) {
+            modelContext.delete(meta)
         }
         UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.lastStreakShownDate)
         UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.shownMilestones)

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -472,20 +472,23 @@ final class MangaViewModel {
 
     /// publisher 名 → iconData の辞書を返す（キャッシュ済みならそれを返す）。
     /// `refreshCounter` が変わるとキャッシュは破棄される。
+    /// 同名重複時の優先順位は `publisherMetadata(for:)` と統一:
+    ///   1. iconData あり優先
+    ///   2. 同条件なら updatedAt の新しい方
+    /// 事前ソート + 先勝ち insert で実現する。
     private func loadAllPublisherIcons() -> [String: Data?] {
         invalidateCacheIfStale()
         if let cached = cachedPublisherIcons { return cached }
         let descriptor = FetchDescriptor<PublisherMetadata>()
         let records = modelContext.fetchLogged(descriptor)
-        // 同名重複時は iconData あり / 新しい updatedAt を優先 (publisherMetadata(for:) と同じロジック)
+        let sorted = records.sorted { lhs, rhs in
+            let lhsHas = lhs.iconData != nil
+            let rhsHas = rhs.iconData != nil
+            if lhsHas != rhsHas { return lhsHas }
+            return (lhs.updatedAt ?? .distantPast) > (rhs.updatedAt ?? .distantPast)
+        }
         var result: [String: Data?] = [:]
-        for record in records {
-            if let existing = result[record.name] {
-                let existingHas = existing != nil
-                let newHas = record.iconData != nil
-                if existingHas && !newHas { continue }
-                // どちらも同条件なら、updatedAt の新しい方を優先
-            }
+        for record in sorted where result[record.name] == nil {
             result[record.name] = record.iconData
         }
         cachedPublisherIcons = result

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -25,6 +25,10 @@ final class MangaViewModel {
     @ObservationIgnored private var cachedEntries: [MangaEntry]?
     @ObservationIgnored private var cachedComments: [MangaComment]?
     @ObservationIgnored private var cachedActivities: [ReadingActivity]?
+    /// publisher 名 → アイコン Data の辞書キャッシュ。一覧/chip でセル毎に
+    /// `publisherIcon(for:)` が呼ばれて N+1 fetch になるのを防ぐ。
+    /// nil 値は「設定無し」を表す（fetch 結果が nil でも 2 回目を走らせない）。
+    @ObservationIgnored private var cachedPublisherIcons: [String: Data?]?
 
     /// 直近の重大エラー（移行/インポート/同期）。View 側で alert 表示する用。
     var lastError: AppError?
@@ -453,17 +457,39 @@ final class MangaViewModel {
     // MARK: - Publisher Metadata
 
     /// 指定 publisher のアイコン Data を取得（表示パスから毎回呼ばれる前提、軽量）。
+    /// 初回呼び出しで全 PublisherMetadata を一括 fetch して `cachedPublisherIcons`
+    /// に辞書化する。同 render 内の複数 publisher 表示で N 回 fetch を避ける。
     func publisherIcon(for name: String) -> Data? {
-        let _ = refreshCounter
         guard !name.isEmpty else { return nil }
-        return publisherMetadata(for: name)?.iconData
+        return loadAllPublisherIcons()[name] ?? nil
     }
 
     /// 指定 publisher にアイコンが設定されているか。merge 確認文言の分岐などで使う。
     func publisherHasIcon(name: String) -> Bool {
-        let _ = refreshCounter
         guard !name.isEmpty else { return false }
-        return publisherMetadata(for: name)?.iconData != nil
+        return (loadAllPublisherIcons()[name] ?? nil) != nil
+    }
+
+    /// publisher 名 → iconData の辞書を返す（キャッシュ済みならそれを返す）。
+    /// `refreshCounter` が変わるとキャッシュは破棄される。
+    private func loadAllPublisherIcons() -> [String: Data?] {
+        invalidateCacheIfStale()
+        if let cached = cachedPublisherIcons { return cached }
+        let descriptor = FetchDescriptor<PublisherMetadata>()
+        let records = modelContext.fetchLogged(descriptor)
+        // 同名重複時は iconData あり / 新しい updatedAt を優先 (publisherMetadata(for:) と同じロジック)
+        var result: [String: Data?] = [:]
+        for record in records {
+            if let existing = result[record.name] {
+                let existingHas = existing != nil
+                let newHas = record.iconData != nil
+                if existingHas && !newHas { continue }
+                // どちらも同条件なら、updatedAt の新しい方を優先
+            }
+            result[record.name] = record.iconData
+        }
+        cachedPublisherIcons = result
+        return result
     }
 
     /// 指定 publisher のメタデータレコード。重複時は iconData 持ち + 新しい updatedAt を優先。
@@ -843,8 +869,10 @@ final class MangaViewModel {
             }
         }
         // v15+ 掲載誌アイコン等のメタデータ。同名既存があればスキップ (in-place update はしない)。
+        // backup 内に同名重複があるケース (CloudKit race 由来の重複を export したもの等) でも
+        // 二重 insert にならないよう、insert 後に existingNames へ追加する。
         if let backupMetas = backup.publisherMetadata {
-            let existingNames = Set(modelContext.fetchLogged(FetchDescriptor<PublisherMetadata>()).map(\.name))
+            var existingNames = Set(modelContext.fetchLogged(FetchDescriptor<PublisherMetadata>()).map(\.name))
             for backupMeta in backupMetas {
                 guard !existingNames.contains(backupMeta.name) else { continue }
                 let meta = PublisherMetadata(
@@ -855,6 +883,7 @@ final class MangaViewModel {
                 meta.id = backupMeta.id
                 meta.updatedAt = backupMeta.updatedAt
                 modelContext.insert(meta)
+                existingNames.insert(backupMeta.name)
                 importedCount += 1
             }
         }
@@ -1209,6 +1238,7 @@ final class MangaViewModel {
             cachedEntries = nil
             cachedComments = nil
             cachedActivities = nil
+            cachedPublisherIcons = nil
         }
     }
 

--- a/MangaLauncher/Views/CatchUp/CatchUpCardView.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpCardView.swift
@@ -3,6 +3,7 @@ import PlatformKit
 
 struct CatchUpCardView: View {
     let entry: MangaEntry
+    var viewModel: MangaViewModel
     @Binding var editingEntry: MangaEntry?
     let onOpenURL: (String) -> Void
     var hasGradientBackground: Bool = false
@@ -61,9 +62,12 @@ struct CatchUpCardView: View {
                         .multilineTextAlignment(.center)
 
                     if !entry.publisher.isEmpty {
-                        Text(entry.publisher)
-                            .font(.system(size: 13, weight: .medium))
-                            .foregroundStyle(theme.onSurfaceVariant)
+                        HStack(spacing: 4) {
+                            PublisherIconView(iconData: viewModel.publisherIcon(for: entry.publisher), size: 14)
+                            Text(entry.publisher)
+                                .font(.system(size: 13, weight: .medium))
+                                .foregroundStyle(theme.onSurfaceVariant)
+                        }
                     }
                 }
                 .padding(.horizontal, theme.spacingMD)
@@ -85,9 +89,12 @@ struct CatchUpCardView: View {
                     .multilineTextAlignment(.center)
 
                 if !entry.publisher.isEmpty {
-                    Text(entry.publisher)
-                        .font(theme.subheadlineFont)
-                        .foregroundStyle(hasGradientBackground ? .white.opacity(0.7) : theme.onSurfaceVariant)
+                    HStack(spacing: 4) {
+                        PublisherIconView(iconData: viewModel.publisherIcon(for: entry.publisher), size: 14)
+                        Text(entry.publisher)
+                            .font(theme.subheadlineFont)
+                            .foregroundStyle(hasGradientBackground ? .white.opacity(0.7) : theme.onSurfaceVariant)
+                    }
                 }
             }
             .padding()
@@ -110,9 +117,12 @@ struct CatchUpCardView: View {
                         .multilineTextAlignment(.center)
 
                     if !entry.publisher.isEmpty {
-                        Text(entry.publisher)
-                            .font(.system(size: 13, weight: .medium))
-                            .foregroundStyle(theme.onSurfaceVariant)
+                        HStack(spacing: 4) {
+                            PublisherIconView(iconData: viewModel.publisherIcon(for: entry.publisher), size: 14)
+                            Text(entry.publisher)
+                                .font(.system(size: 13, weight: .medium))
+                                .foregroundStyle(theme.onSurfaceVariant)
+                        }
                     }
                 }
                 .padding(.horizontal, theme.spacingMD)

--- a/MangaLauncher/Views/CatchUp/CatchUpView.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpView.swift
@@ -167,14 +167,14 @@ struct CatchUpView: View {
 
             ZStack {
                 if currentIndex + 1 < totalCount {
-                    CatchUpCardView(entry: unreadItems[currentIndex + 1], editingEntry: $editingEntry, onOpenURL: openMangaURL, hasGradientBackground: hasGradient)
+                    CatchUpCardView(entry: unreadItems[currentIndex + 1], viewModel: viewModel, editingEntry: $editingEntry, onOpenURL: openMangaURL, hasGradientBackground: hasGradient)
                         .id("\(unreadItems[currentIndex + 1].id)-\(reloadCount)")
                         .scaleEffect(0.95)
                         .opacity(0.5)
                         .allowsHitTesting(false)
                 }
 
-                CatchUpCardView(entry: unreadItems[currentIndex], editingEntry: $editingEntry, onOpenURL: openMangaURL, hasGradientBackground: hasGradient)
+                CatchUpCardView(entry: unreadItems[currentIndex], viewModel: viewModel, editingEntry: $editingEntry, onOpenURL: openMangaURL, hasGradientBackground: hasGradient)
                     .id("\(unreadItems[currentIndex].id)-\(reloadCount)")
                     .offset(offset)
                     .rotationEffect(.degrees(Double(offset.width) / 20))

--- a/MangaLauncher/Views/Entry/EditEntryView.swift
+++ b/MangaLauncher/Views/Entry/EditEntryView.swift
@@ -649,13 +649,13 @@ struct EditEntryView: View {
 }
 
 #Preview("New Entry") {
-    let container = try! ModelContainer(for: MangaEntry.self, configurations: ModelConfiguration(isStoredInMemoryOnly: true))
+    let container = try! ModelContainer(for: MangaEntry.self, PublisherMetadata.self, configurations: ModelConfiguration(isStoredInMemoryOnly: true))
     let viewModel = MangaViewModel(modelContext: container.mainContext)
     EditEntryView(viewModel: viewModel, day: .monday)
 }
 
 #Preview("Edit Entry") {
-    let container = try! ModelContainer(for: MangaEntry.self, configurations: ModelConfiguration(isStoredInMemoryOnly: true))
+    let container = try! ModelContainer(for: MangaEntry.self, PublisherMetadata.self, configurations: ModelConfiguration(isStoredInMemoryOnly: true))
     let viewModel = MangaViewModel(modelContext: container.mainContext)
     let entry = MangaEntry(name: "ジャンプ+", url: "https://shonenjumpplus.com", dayOfWeek: .monday, iconColor: "red")
     EditEntryView(viewModel: viewModel, entry: entry)

--- a/MangaLauncher/Views/Home/ContentView.swift
+++ b/MangaLauncher/Views/Home/ContentView.swift
@@ -173,7 +173,7 @@ struct ContentView: View {
             )
             let publishers = viewModel.publishers(for: viewModel.selectedDay)
             if !publishers.isEmpty {
-                PublisherFilterView(publishers: publishers, selectedPublisher: $homeState.selectedPublisher)
+                PublisherFilterView(publishers: publishers, viewModel: viewModel, selectedPublisher: $homeState.selectedPublisher)
             }
         }
         .background {

--- a/MangaLauncher/Views/Home/ContentView.swift
+++ b/MangaLauncher/Views/Home/ContentView.swift
@@ -209,7 +209,7 @@ struct ContentView: View {
 }
 
 #Preview {
-    let container = try! ModelContainer(for: MangaEntry.self, configurations: ModelConfiguration(isStoredInMemoryOnly: true))
+    let container = try! ModelContainer(for: MangaEntry.self, PublisherMetadata.self, configurations: ModelConfiguration(isStoredInMemoryOnly: true))
     ContentView(viewModel: MangaViewModel(modelContext: container.mainContext))
         .modelContainer(container)
 }

--- a/MangaLauncher/Views/Home/PublisherFilterView.swift
+++ b/MangaLauncher/Views/Home/PublisherFilterView.swift
@@ -6,8 +6,6 @@ struct PublisherFilterView: View {
     var viewModel: MangaViewModel
     @Binding var selectedPublisher: String?
 
-    private var theme: ThemeStyle { ThemeManager.shared.style }
-
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 8) {

--- a/MangaLauncher/Views/Home/PublisherFilterView.swift
+++ b/MangaLauncher/Views/Home/PublisherFilterView.swift
@@ -1,8 +1,12 @@
 import SwiftUI
+import PlatformKit
 
 struct PublisherFilterView: View {
     let publishers: [String]
+    var viewModel: MangaViewModel
     @Binding var selectedPublisher: String?
+
+    private var theme: ThemeStyle { ThemeManager.shared.style }
 
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
@@ -11,7 +15,11 @@ struct PublisherFilterView: View {
                     withAnimation { selectedPublisher = nil }
                 }
                 ForEach(publishers, id: \.self) { pub in
-                    FilterChip(label: pub, isSelected: selectedPublisher == pub) {
+                    PublisherFilterChip(
+                        publisher: pub,
+                        iconData: viewModel.publisherIcon(for: pub),
+                        isSelected: selectedPublisher == pub
+                    ) {
                         withAnimation { selectedPublisher = selectedPublisher == pub ? nil : pub }
                     }
                 }
@@ -19,5 +27,33 @@ struct PublisherFilterView: View {
             .padding(.horizontal)
             .padding(.vertical, 6)
         }
+    }
+}
+
+/// アイコン付きの publisher 専用 chip。アイコン未設定なら text のみ。
+private struct PublisherFilterChip: View {
+    let publisher: String
+    let iconData: Data?
+    let isSelected: Bool
+    let action: () -> Void
+
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 4) {
+                if iconData != nil {
+                    PublisherIconView(iconData: iconData, size: 14)
+                }
+                Text(publisher)
+                    .font(theme.captionFont)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .background(isSelected ? theme.primary : theme.surfaceContainerHigh)
+            .foregroundStyle(isSelected ? theme.onPrimary : theme.onSurfaceVariant)
+            .clipShape(theme.chipShape)
+        }
+        .buttonStyle(.plain)
     }
 }

--- a/MangaLauncher/Views/Library/AllPublishersView.swift
+++ b/MangaLauncher/Views/Library/AllPublishersView.swift
@@ -13,6 +13,7 @@ struct AllPublishersView: View {
     @State private var publisherCounts: [(publisher: String, count: Int)] = []
     @State private var mergeSource: String = ""
     @State private var showingMergeSheet = false
+    @State private var iconEditTarget: String?
 
     var body: some View {
         ZStack {
@@ -23,8 +24,11 @@ struct AllPublishersView: View {
                 ForEach(publisherCounts, id: \.publisher) { item in
                     NavigationLink(value: PublisherSelection(name: item.publisher)) {
                         HStack {
-                            Image(systemName: "magazine")
-                                .foregroundStyle(theme.primary)
+                            PublisherIconView(
+                                iconData: viewModel.publisherIcon(for: item.publisher),
+                                size: 28,
+                                showsFallback: true
+                            )
                             Text(item.publisher)
                                 .font(theme.bodyFont)
                                 .foregroundStyle(theme.onSurface)
@@ -40,6 +44,11 @@ struct AllPublishersView: View {
                     }
                     .listRowBackground(Color.clear)
                     .contextMenu {
+                        Button {
+                            iconEditTarget = item.publisher
+                        } label: {
+                            Label("掲載誌アイコンを設定", systemImage: "photo.badge.plus")
+                        }
                         Button {
                             mergeSource = item.publisher
                             showingMergeSheet = true
@@ -74,6 +83,12 @@ struct AllPublishersView: View {
                 viewModel: viewModel
             )
         }
+        .sheet(item: Binding(
+            get: { iconEditTarget.map { PublisherSelection(name: $0) } },
+            set: { iconEditTarget = $0?.name }
+        )) { selection in
+            PublisherIconEditorView(publisherName: selection.name, viewModel: viewModel)
+        }
     }
 
     private func refreshPublisherCounts() {
@@ -81,8 +96,9 @@ struct AllPublishersView: View {
     }
 }
 
-struct PublisherSelection: Hashable {
+struct PublisherSelection: Hashable, Identifiable {
     let name: String
+    var id: String { name }
 }
 
 /// 個別の掲載誌に紐付くマンガ一覧画面

--- a/MangaLauncher/Views/Library/HiddenEntriesView.swift
+++ b/MangaLauncher/Views/Library/HiddenEntriesView.swift
@@ -124,9 +124,12 @@ struct HiddenEntriesView: View {
                             .font(theme.bodyFont)
                             .foregroundStyle(theme.onSurface)
                         if !entry.publisher.isEmpty {
-                            Text(entry.publisher)
-                                .font(theme.captionFont)
-                                .foregroundStyle(theme.onSurfaceVariant)
+                            HStack(spacing: 4) {
+                                PublisherIconView(iconData: viewModel.publisherIcon(for: entry.publisher), size: 12)
+                                Text(entry.publisher)
+                                    .font(theme.captionFont)
+                                    .foregroundStyle(theme.onSurfaceVariant)
+                            }
                         }
                     }
                     Spacer()
@@ -178,9 +181,12 @@ struct HiddenEntriesView: View {
                                 .foregroundStyle(theme.onSurface)
                                 .lineLimit(2)
                             if !entry.publisher.isEmpty {
-                                Text(entry.publisher)
-                                    .font(.caption2)
-                                    .foregroundStyle(theme.onSurfaceVariant)
+                                HStack(spacing: 3) {
+                                    PublisherIconView(iconData: viewModel.publisherIcon(for: entry.publisher), size: 10)
+                                    Text(entry.publisher)
+                                        .font(.caption2)
+                                        .foregroundStyle(theme.onSurfaceVariant)
+                                }
                             }
                         }
                     }

--- a/MangaLauncher/Views/Library/LibraryCard.swift
+++ b/MangaLauncher/Views/Library/LibraryCard.swift
@@ -54,11 +54,14 @@ struct LibraryCard: View {
                     .frame(width: cardWidth, alignment: .leading)
 
                 if !entry.publisher.isEmpty {
-                    Text(entry.publisher)
-                        .font(theme.caption2Font)
-                        .foregroundStyle(theme.onSurfaceVariant)
-                        .lineLimit(1)
-                        .frame(width: cardWidth, alignment: .leading)
+                    HStack(spacing: 4) {
+                        PublisherIconView(iconData: viewModel.publisherIcon(for: entry.publisher), size: 12)
+                        Text(entry.publisher)
+                            .font(theme.caption2Font)
+                            .foregroundStyle(theme.onSurfaceVariant)
+                            .lineLimit(1)
+                    }
+                    .frame(width: cardWidth, alignment: .leading)
                 }
             }
         }

--- a/MangaLauncher/Views/Library/PublisherIconEditorView.swift
+++ b/MangaLauncher/Views/Library/PublisherIconEditorView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 import PhotosUI
-import PlatformKit
 
 /// 掲載誌アイコンの設定シート。
 /// カメラロール / URL ファビコン取得 の 2 経路を提供し、プレビューを確認してから保存する。
@@ -19,8 +18,6 @@ struct PublisherIconEditorView: View {
     @State private var errorMessage: String?
     /// 未保存のプレビュー画像。nil の場合は既存設定（または fallback）を表示。
     @State private var previewData: Data?
-
-    private var theme: ThemeStyle { ThemeManager.shared.style }
 
     private var displayedIconData: Data? {
         previewData ?? viewModel.publisherIcon(for: publisherName)

--- a/MangaLauncher/Views/Library/PublisherIconEditorView.swift
+++ b/MangaLauncher/Views/Library/PublisherIconEditorView.swift
@@ -1,0 +1,181 @@
+import SwiftUI
+import PhotosUI
+import PlatformKit
+
+/// 掲載誌アイコンの設定シート。
+/// カメラロール / URL ファビコン取得 の 2 経路を提供し、プレビューを確認してから保存する。
+struct PublisherIconEditorView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let publisherName: String
+    var viewModel: MangaViewModel
+
+    enum Mode: Hashable { case photo, url }
+
+    @State private var mode: Mode = .photo
+    @State private var selectedPhoto: PhotosPickerItem?
+    @State private var urlInput: String = ""
+    @State private var isFetching = false
+    @State private var errorMessage: String?
+    /// 未保存のプレビュー画像。nil の場合は既存設定（または fallback）を表示。
+    @State private var previewData: Data?
+
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
+    private var displayedIconData: Data? {
+        previewData ?? viewModel.publisherIcon(for: publisherName)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    HStack {
+                        Spacer()
+                        PublisherIconView(
+                            iconData: displayedIconData,
+                            size: 96,
+                            showsFallback: true
+                        )
+                        Spacer()
+                    }
+                    .listRowBackground(Color.clear)
+                } header: {
+                    Text("プレビュー")
+                }
+
+                Section {
+                    Picker("取得方法", selection: $mode) {
+                        Text("カメラロール").tag(Mode.photo)
+                        Text("URL から取得").tag(Mode.url)
+                    }
+                    .pickerStyle(.segmented)
+                }
+
+                switch mode {
+                case .photo:
+                    Section {
+                        PhotosPicker(selection: $selectedPhoto, matching: .images) {
+                            Label("写真を選ぶ", systemImage: "photo")
+                        }
+                    } footer: {
+                        Text("中央を正方形に切り抜いて保存します")
+                    }
+                case .url:
+                    Section {
+                        TextField("https://example.com", text: $urlInput)
+                            #if os(iOS)
+                            .textInputAutocapitalization(.never)
+                            .keyboardType(.URL)
+                            #endif
+                            .autocorrectionDisabled()
+                        Button {
+                            fetchFromURL()
+                        } label: {
+                            HStack {
+                                if isFetching {
+                                    ProgressView()
+                                    Text("取得中...")
+                                } else {
+                                    Label("ファビコンを取得", systemImage: "link")
+                                }
+                            }
+                        }
+                        .disabled(isFetching || urlInput.trimmingCharacters(in: .whitespaces).isEmpty)
+                    } footer: {
+                        Text("掲載誌の公式サイト URL からアイコン画像を取得します")
+                    }
+                }
+
+                if let errorMessage {
+                    Section {
+                        Text(errorMessage)
+                            .font(.caption)
+                            .foregroundStyle(.red)
+                    }
+                }
+
+                if viewModel.publisherHasIcon(name: publisherName) {
+                    Section {
+                        Button(role: .destructive) {
+                            viewModel.clearPublisherIcon(name: publisherName)
+                            previewData = nil
+                            dismiss()
+                        } label: {
+                            Label("現在のアイコンを削除", systemImage: "trash")
+                        }
+                    }
+                }
+            }
+            .navigationTitle(publisherName)
+            #if os(iOS) || os(visionOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("キャンセル") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("保存") {
+                        if let data = previewData {
+                            let source = (mode == .url) ? urlInput.trimmingCharacters(in: .whitespaces) : nil
+                            viewModel.setPublisherIcon(
+                                name: publisherName,
+                                imageData: data,
+                                sourceURL: source?.isEmpty == true ? nil : source
+                            )
+                        }
+                        dismiss()
+                    }
+                    .disabled(previewData == nil)
+                }
+            }
+        }
+        .onChange(of: selectedPhoto) { _, item in
+            Task { await loadPhoto(item) }
+        }
+    }
+
+    private func loadPhoto(_ item: PhotosPickerItem?) async {
+        guard let item else { return }
+        do {
+            guard let raw = try await item.loadTransferable(type: Data.self) else { return }
+            let prepared = PublisherIconService.prepareLocalIcon(from: raw)
+            await MainActor.run {
+                previewData = prepared
+                if prepared == nil {
+                    errorMessage = "選んだ画像を読み込めませんでした"
+                } else {
+                    errorMessage = nil
+                }
+            }
+        } catch {
+            await MainActor.run {
+                errorMessage = "写真の読み込みに失敗しました"
+            }
+        }
+    }
+
+    private func fetchFromURL() {
+        let trimmed = urlInput.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return }
+        isFetching = true
+        errorMessage = nil
+        Task {
+            do {
+                let result = try await PublisherIconService.fetchIcon(for: trimmed)
+                await MainActor.run {
+                    previewData = result.data
+                    isFetching = false
+                }
+            } catch {
+                await MainActor.run {
+                    let msg = (error as? PublisherIconError)?.errorDescription
+                        ?? "URL からアイコンを取得できませんでした"
+                    errorMessage = msg
+                    isFetching = false
+                }
+            }
+        }
+    }
+}

--- a/MangaLauncher/Views/Library/PublisherIconView.swift
+++ b/MangaLauncher/Views/Library/PublisherIconView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+import PlatformKit
+
+/// 掲載誌アイコンの共通表示コンポーネント。
+/// - 設定済み (`iconData != nil`): 画像を正方形で表示
+/// - 未設定 + `showsFallback == true`: 薄いグレーの "magazine" SF Symbol
+/// - 未設定 + `showsFallback == false`: EmptyView (テキスト前置き用、未設定時はスペースも消える)
+///
+/// `showsFallback` の使い分け:
+/// - AllPublishersView 等の「掲載誌の専用画面」では true (空白を埋めて視覚的に寂しさを軽減)
+/// - エントリ表示やフィルタ chip 等の「掲載誌が脇役の場所」では false (アイコンは意味を持つ要素として扱う)
+struct PublisherIconView: View {
+    let iconData: Data?
+    let size: CGFloat
+    var showsFallback: Bool = false
+
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
+    var body: some View {
+        if let iconData, let image = iconData.toSwiftUIImage() {
+            image
+                .resizable()
+                .scaledToFill()
+                .frame(width: size, height: size)
+                .clipShape(RoundedRectangle(cornerRadius: max(2, size * 0.18)))
+        } else if showsFallback {
+            Image(systemName: "magazine")
+                .font(.system(size: size * 0.7))
+                .foregroundStyle(theme.onSurfaceVariant.opacity(0.35))
+                .frame(width: size, height: size)
+        } else {
+            EmptyView()
+        }
+    }
+}

--- a/MangaLauncher/Views/Library/PublisherMergePickerView.swift
+++ b/MangaLauncher/Views/Library/PublisherMergePickerView.swift
@@ -27,8 +27,11 @@ struct PublisherMergePickerView: View {
                 List {
                     Section {
                         HStack(spacing: 8) {
-                            Image(systemName: "magazine")
-                                .foregroundStyle(theme.primary)
+                            PublisherIconView(
+                                iconData: viewModel.publisherIcon(for: source),
+                                size: 22,
+                                showsFallback: true
+                            )
                             Text(source)
                                 .font(theme.bodyFont.weight(.semibold))
                                 .foregroundStyle(theme.onSurface)
@@ -47,8 +50,11 @@ struct PublisherMergePickerView: View {
                                     pendingDestination = dest
                                 } label: {
                                     HStack(spacing: 8) {
-                                        Image(systemName: "magazine")
-                                            .foregroundStyle(theme.primary)
+                                        PublisherIconView(
+                                            iconData: viewModel.publisherIcon(for: dest),
+                                            size: 22,
+                                            showsFallback: true
+                                        )
                                         Text(dest)
                                             .font(theme.bodyFont)
                                             .foregroundStyle(theme.onSurface)
@@ -97,7 +103,10 @@ struct PublisherMergePickerView: View {
                 }
             } message: { destination in
                 let count = viewModel.mergePublisherPreviewCount(for: source)
-                Text("「\(source)」の \(count) 件を「\(destination)」に統合します。\n\nこの操作は元に戻せません。")
+                let iconNote = viewModel.publisherHasIcon(name: source)
+                    ? "\n\n「\(source)」のアイコンも削除されます。"
+                    : ""
+                Text("「\(source)」の \(count) 件を「\(destination)」に統合します。\n\nこの操作は元に戻せません。\(iconNote)")
             }
         }
         .themedNavigationStyle()

--- a/MangaLauncher/Views/Library/RecentlyDeletedView.swift
+++ b/MangaLauncher/Views/Library/RecentlyDeletedView.swift
@@ -157,9 +157,12 @@ struct RecentlyDeletedView: View {
                     }
                 }
                 if !entry.publisher.isEmpty {
-                    Text(entry.publisher)
-                        .font(theme.captionFont)
-                        .foregroundStyle(theme.onSurfaceVariant)
+                    HStack(spacing: 4) {
+                        PublisherIconView(iconData: viewModel.publisherIcon(for: entry.publisher), size: 12)
+                        Text(entry.publisher)
+                            .font(theme.captionFont)
+                            .foregroundStyle(theme.onSurfaceVariant)
+                    }
                 }
             }
             Spacer()

--- a/MangaLauncher/Views/MangaCell/MangaGridCell.swift
+++ b/MangaLauncher/Views/MangaCell/MangaGridCell.swift
@@ -69,9 +69,12 @@ struct MangaGridCell: View {
                             .foregroundStyle(theme.onSurface)
                             .lineLimit(2)
                         if !entry.publisher.isEmpty {
-                            Text(entry.publisher)
-                                .font(.caption2)
-                                .foregroundStyle(theme.onSurfaceVariant)
+                            HStack(spacing: 3) {
+                                PublisherIconView(iconData: viewModel.publisherIcon(for: entry.publisher), size: 10)
+                                Text(entry.publisher)
+                                    .font(.caption2)
+                                    .foregroundStyle(theme.onSurfaceVariant)
+                            }
                         }
                     }
                     Spacer(minLength: 0)

--- a/MangaLauncher/Views/MangaCell/MangaRowCell.swift
+++ b/MangaLauncher/Views/MangaCell/MangaRowCell.swift
@@ -69,9 +69,12 @@ struct MangaRowCell: View {
                         .font(theme.bodyFont)
                         .foregroundStyle(theme.onSurface)
                     if !entry.publisher.isEmpty {
-                        Text(entry.publisher)
-                            .font(theme.captionFont)
-                            .foregroundStyle(theme.onSurfaceVariant)
+                        HStack(spacing: 4) {
+                            PublisherIconView(iconData: viewModel.publisherIcon(for: entry.publisher), size: 12)
+                            Text(entry.publisher)
+                                .font(theme.captionFont)
+                                .foregroundStyle(theme.onSurfaceVariant)
+                        }
                     }
                 }
 

--- a/MangaLauncher/Views/Search/SearchResultRow.swift
+++ b/MangaLauncher/Views/Search/SearchResultRow.swift
@@ -34,9 +34,12 @@ struct SearchResultRow: View {
 
                     HStack(spacing: 6) {
                         if !entry.publisher.isEmpty {
-                            Text(entry.publisher)
-                                .font(theme.captionFont)
-                                .foregroundStyle(theme.onSurfaceVariant)
+                            HStack(spacing: 4) {
+                                PublisherIconView(iconData: viewModel.publisherIcon(for: entry.publisher), size: 12)
+                                Text(entry.publisher)
+                                    .font(theme.captionFont)
+                                    .foregroundStyle(theme.onSurfaceVariant)
+                            }
                         }
                         MangaStatusBadgeView(entry: entry, fontSize: 9)
                         if !hasAnyStatus(entry) {

--- a/MangaLauncherTests/MangaEntryTests.swift
+++ b/MangaLauncherTests/MangaEntryTests.swift
@@ -894,6 +894,32 @@ struct PublisherMetadataTests {
         #expect(vm.publisherIcon(for: "X") == Data([0x01]))
         #expect(vm.publisherHasIcon(name: "X") == true)
     }
+
+    /// CloudKit race で同名 record が複数できているケースで clearPublisherIcon が
+    /// 全 record の iconData を nil にすることを確認。1 件だけ clear する旧実装では、
+    /// 残った record の iconData が cache に拾われて「削除したのに残る」現象が起きていた。
+    @Test("clearPublisherIcon は重複 record すべてをクリアする")
+    @MainActor
+    func clearAllDuplicates() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let dup1 = PublisherMetadata(name: "X", iconData: Data([0x01]))
+        let dup2 = PublisherMetadata(name: "X", iconData: Data([0x02]))
+        context.insert(dup1)
+        context.insert(dup2)
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        vm.clearPublisherIcon(name: "X")
+
+        #expect(vm.publisherIcon(for: "X") == nil)
+        #expect(vm.publisherHasIcon(name: "X") == false)
+        // record 自体は残る (sourceURL の保持目的)
+        let descriptor = FetchDescriptor<PublisherMetadata>()
+        let remaining = context.fetchLogged(descriptor)
+        #expect(remaining.count == 2)
+        #expect(remaining.allSatisfy { $0.iconData == nil })
+    }
 }
 
 @Suite("BackupData with publisherMetadata (v15)")

--- a/MangaLauncherTests/MangaEntryTests.swift
+++ b/MangaLauncherTests/MangaEntryTests.swift
@@ -770,6 +770,191 @@ struct MangaViewModelMergePublisherTests {
     }
 }
 
+@Suite("MangaViewModel.publisherIcon CRUD")
+struct PublisherMetadataTests {
+
+    private func makeContainer() throws -> ModelContainer {
+        try ModelContainer(
+            for: MangaEntry.self, ReadingActivity.self, MangaComment.self,
+                 MangaLink.self, PublisherMetadata.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+    }
+
+    private let sampleData = Data([0xff, 0xd8, 0xff, 0xe0]) // dummy JPEG-ish bytes
+
+    @Test("set → get で同じ Data が返る")
+    @MainActor
+    func setAndGet() throws {
+        let container = try makeContainer()
+        let vm = MangaViewModel(modelContext: container.mainContext)
+
+        vm.setPublisherIcon(name: "ジャンプ＋", imageData: sampleData, sourceURL: "https://example.com")
+        #expect(vm.publisherIcon(for: "ジャンプ＋") == sampleData)
+        #expect(vm.publisherHasIcon(name: "ジャンプ＋") == true)
+    }
+
+    @Test("clear で nil に戻る (record は残る)")
+    @MainActor
+    func clearKeepsRecord() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let vm = MangaViewModel(modelContext: context)
+
+        vm.setPublisherIcon(name: "ジャンプ＋", imageData: sampleData)
+        vm.clearPublisherIcon(name: "ジャンプ＋")
+        #expect(vm.publisherIcon(for: "ジャンプ＋") == nil)
+        #expect(vm.publisherHasIcon(name: "ジャンプ＋") == false)
+        // record は残る (sourceURL の保持などに使うため)
+        let descriptor = FetchDescriptor<PublisherMetadata>()
+        #expect(context.fetchLogged(descriptor).count == 1)
+    }
+
+    @Test("set 2 回で update される (重複 record は作らない)")
+    @MainActor
+    func upsertSemantics() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let vm = MangaViewModel(modelContext: context)
+
+        vm.setPublisherIcon(name: "ジャンプ＋", imageData: Data([0x01]))
+        vm.setPublisherIcon(name: "ジャンプ＋", imageData: Data([0x02]))
+
+        let descriptor = FetchDescriptor<PublisherMetadata>()
+        let records = context.fetchLogged(descriptor)
+        #expect(records.count == 1)
+        #expect(records[0].iconData == Data([0x02]))
+    }
+
+    @Test("空 name は no-op")
+    @MainActor
+    func emptyNameNoOp() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let vm = MangaViewModel(modelContext: context)
+
+        vm.setPublisherIcon(name: "", imageData: sampleData)
+        #expect(vm.publisherIcon(for: "") == nil)
+        #expect(vm.publisherHasIcon(name: "") == false)
+        let descriptor = FetchDescriptor<PublisherMetadata>()
+        #expect(context.fetchLogged(descriptor).isEmpty)
+    }
+
+    @Test("mergePublisher で source の icon は消える / dest は維持")
+    @MainActor
+    func mergeDeletesSourceIcon() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        // entry を 1 つ作って publisher を src にしておく (mergePublisher は entry がないと no-op)
+        let entry = MangaEntry(name: "A", publisher: "src")
+        context.insert(entry)
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        vm.setPublisherIcon(name: "src", imageData: Data([0xAA]))
+        vm.setPublisherIcon(name: "dest", imageData: Data([0xBB]))
+
+        vm.mergePublisher(from: "src", to: "dest")
+
+        #expect(vm.publisherIcon(for: "src") == nil)
+        #expect(vm.publisherIcon(for: "dest") == Data([0xBB]))
+        // entry の publisher も移動している
+        #expect(entry.publisher == "dest")
+    }
+
+    @Test("deleteAllEntries で全 metadata 削除")
+    @MainActor
+    func deleteAllPurgesMetadata() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let vm = MangaViewModel(modelContext: context)
+
+        vm.setPublisherIcon(name: "A", imageData: Data([0x01]))
+        vm.setPublisherIcon(name: "B", imageData: Data([0x02]))
+        #expect(context.fetchLogged(FetchDescriptor<PublisherMetadata>()).count == 2)
+
+        vm.deleteAllEntries()
+        #expect(context.fetchLogged(FetchDescriptor<PublisherMetadata>()).isEmpty)
+    }
+
+    @Test("name 重複時は iconData ありを優先取得")
+    @MainActor
+    func duplicatePrefersIcon() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        // 直接 insert して race を再現 (ViewModel API 経由では重複しない)
+        let withIcon = PublisherMetadata(name: "X", iconData: Data([0x01]))
+        let withoutIcon = PublisherMetadata(name: "X", iconData: nil)
+        context.insert(withIcon)
+        context.insert(withoutIcon)
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        // iconData あり優先
+        #expect(vm.publisherIcon(for: "X") == Data([0x01]))
+        #expect(vm.publisherHasIcon(name: "X") == true)
+    }
+}
+
+@Suite("BackupData with publisherMetadata (v15)")
+struct PublisherMetadataBackupTests {
+
+    private func makeContainer() throws -> ModelContainer {
+        try ModelContainer(
+            for: MangaEntry.self, ReadingActivity.self, MangaComment.self,
+                 MangaLink.self, PublisherMetadata.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+    }
+
+    @Test("export → import ラウンドトリップ")
+    @MainActor
+    func roundTrip() throws {
+        let container1 = try makeContainer()
+        let context1 = container1.mainContext
+        let entry = MangaEntry(name: "A", publisher: "ジャンプ＋")
+        context1.insert(entry)
+        try context1.save()
+
+        let vm1 = MangaViewModel(modelContext: context1)
+        vm1.setPublisherIcon(name: "ジャンプ＋", imageData: Data([0xAB, 0xCD]),
+                             sourceURL: "https://shonenjumpplus.com")
+
+        guard let data = vm1.exportBackupData() else {
+            Issue.record("export returned nil")
+            return
+        }
+
+        let container2 = try makeContainer()
+        let context2 = container2.mainContext
+        let vm2 = MangaViewModel(modelContext: context2)
+        let imported = vm2.importBackupData(data)
+
+        // entry(1) + publisherMetadata(1) = 2
+        #expect(imported >= 2)
+        #expect(vm2.publisherIcon(for: "ジャンプ＋") == Data([0xAB, 0xCD]))
+    }
+
+    @Test("publisherMetadata なしの古い backup でも import できる (decodeIfPresent)")
+    @MainActor
+    func backwardCompatible() throws {
+        // publisherMetadata フィールドを持たない JSON を構築
+        let json = """
+        {
+            "version": 14,
+            "exportDate": "2026-01-01T00:00:00Z",
+            "entries": []
+        }
+        """.data(using: .utf8)!
+
+        let container = try makeContainer()
+        let vm = MangaViewModel(modelContext: container.mainContext)
+        let imported = vm.importBackupData(json)
+        #expect(imported == 0)
+        // クラッシュせず何も import されないことを確認できれば OK
+    }
+}
+
 @Suite("MangaViewModel.runStartupMigrationsIfNeeded")
 struct MangaViewModelStartupTests {
 


### PR DESCRIPTION
## Summary

掲載誌名 (`MangaEntry.publisher`) に **アイコン画像** を紐付けて、ライブラリ全体で視覚的識別を可能にする機能。

- **2 つの設定方法**: カメラロール / URL からファビコン自動取得 (LinkPresentation + フォールバック)
- **3 ヶ所に表示**: 掲載誌一覧 / マンガエントリ / Home の publisher フィルタチップ
- **既存パターン尊重**: `MangaEntry.publisher: String` には触らず、別テーブル `PublisherMetadata` に切り出し
- **CloudKit 互換**: 新規 entity 追加で SwiftData が自動マイグレーション

## アーキテクチャ

別テーブル方式 (`PublisherMetadata` @Model) を採用。`name` をキーに `MangaEntry.publisher` と論理 join。
- `@Attribute(.externalStorage)` で iconData を SQLite から外部化
- `@Attribute(.unique)` は使わず ViewModel 層で soft de-dup (CloudKit race 対策)
- ファビコン取得は `LPMetadataProvider` 第一選択 → `/favicon.ico` フォールバック
- 画像は中央正方形クロップ → 256x256 → JPEG q=0.85 (~8-20KB/件)

## コミット構成 (10 件)

| # | commit |
|---|---|
| 1 | `feat(model)` PublisherMetadata model + Schema 登録 |
| 2 | `feat(service)` PublisherIconService (LinkPresentation + favicon) |
| 3 | `feat(viewmodel)` 掲載誌アイコン CRUD + merge / deleteAll 連動 |
| 4 | `feat(ui)` PublisherIconView 共通コンポーネント |
| 5 | `feat(ui)` PublisherIconEditorView (PhotosPicker + URL fetch) |
| 6 | `feat(library)` AllPublishersView / PublisherMergePickerView 表示 |
| 7 | `feat(cells)` エントリ表示 7 ヶ所にアイコン埋め込み |
| 8 | `feat(home)` Home フィルタ chip にアイコン |
| 9 | `feat(backup)` Backup v15 拡張 (publisherMetadata 追加) |
| 10 | `test` 8 ケース追加 |

## 主要な設計判断

- **未設定時の fallback**: AllPublishersView (専用画面) のみ薄いグレー magazine SF Symbol、それ以外 (cells / chip) はテキストのみ
- **mergePublisher**: 統合元の metadata を削除、統合先のアイコンは維持。確認アラートで「統合元のアイコンも削除されます」を条件付き表示
- **clearPublisherIcon**: アイコンだけ nil 化し record は残す (sourceURL 保持で再取得しやすく)
- **orphan metadata**: publisher 名が誰にも使われなくなっても残す (再入力時の UX 保護)

## Test plan

- [x] xcodebuild build (iOS 実機向け) 成功
- [ ] 実機: AllPublishersView から長押し → 「掲載誌アイコンを設定」が出る
- [ ] 実機: カメラロールから写真選択 → プレビュー → 保存
- [ ] 実機: URL 入力 → 「ファビコンを取得」 → プレビュー → 保存
- [ ] 実機: 失敗時のエラーメッセージ表示
- [ ] 実機: 設定後、AllPublishersView / Home フィルタ / マンガカード / 検索結果すべてにアイコンが出る
- [ ] 実機: 「現在のアイコンを削除」で消える、record は残る (sourceURL は保持)
- [ ] 実機: 統合時に statementsource のアイコン削除メッセージが出る、統合先のアイコンは維持
- [ ] 実機: backup export → 別環境で import でアイコンが復元される
- [ ] 実機: 3 テーマ (Classic / Kinetic Ink / Retro) で表示が破綻しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)