### PR TITLE
検索画面に掲載誌フィルタを追加

### DIFF
--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -389,13 +389,7 @@ final class MangaViewModel {
     }
 
     func publishers(for day: DayOfWeek) -> [String] {
-        let entries = fetchEntries(for: day)
-        let counts = Dictionary(grouping: entries.filter { !$0.publisher.isEmpty }, by: \.publisher)
-            .mapValues(\.count)
-        return counts.sorted { lhs, rhs in
-            if lhs.value != rhs.value { return lhs.value > rhs.value }
-            return lhs.key.localizedStandardCompare(rhs.key) == .orderedAscending
-        }.map(\.key)
+        PublisherIndex.counts(from: fetchEntries(for: day)).map(\.publisher)
     }
 
     func allEntries() -> [MangaEntry] {

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -390,7 +390,12 @@ final class MangaViewModel {
 
     func publishers(for day: DayOfWeek) -> [String] {
         let entries = fetchEntries(for: day)
-        return Set(entries.map(\.publisher)).filter { !$0.isEmpty }.sorted()
+        let counts = Dictionary(grouping: entries.filter { !$0.publisher.isEmpty }, by: \.publisher)
+            .mapValues(\.count)
+        return counts.sorted { lhs, rhs in
+            if lhs.value != rhs.value { return lhs.value > rhs.value }
+            return lhs.key.localizedStandardCompare(rhs.key) == .orderedAscending
+        }.map(\.key)
     }
 
     func allEntries() -> [MangaEntry] {

--- a/MangaLauncher/Views/Search/SearchView.swift
+++ b/MangaLauncher/Views/Search/SearchView.swift
@@ -133,7 +133,12 @@ struct SearchView: View {
 
     private func availablePublishers() -> [String] {
         let entries = applyDayFilter(to: viewModel.allEntries())
-        return Set(entries.map(\.publisher)).filter { !$0.isEmpty }.sorted()
+        let counts = Dictionary(grouping: entries.filter { !$0.publisher.isEmpty }, by: \.publisher)
+            .mapValues(\.count)
+        return counts.sorted { lhs, rhs in
+            if lhs.value != rhs.value { return lhs.value > rhs.value }
+            return lhs.key.localizedStandardCompare(rhs.key) == .orderedAscending
+        }.map(\.key)
     }
 
     // MARK: - Body

--- a/MangaLauncher/Views/Search/SearchView.swift
+++ b/MangaLauncher/Views/Search/SearchView.swift
@@ -15,6 +15,7 @@ struct SearchView: View {
     @State private var contentMode: SearchContentMode = .entries
 
     @State private var selectedDay: DayOfWeek? = nil
+    @State private var selectedPublisher: String? = nil
     @State private var selectedColors: Set<String> = []
     @State private var safariURL: URL?
     @State private var editingEntry: MangaEntry?
@@ -39,7 +40,8 @@ struct SearchView: View {
     private func computeSearchResults() -> SearchResults {
         let allEntries = viewModel.allEntries()
         let dayFiltered = applyDayFilter(to: allEntries)
-        let colorFiltered = applyColorFilter(to: dayFiltered)
+        let publisherFiltered = applyPublisherFilter(to: dayFiltered)
+        let colorFiltered = applyColorFilter(to: publisherFiltered)
 
         let trimmed = searchText.trimmingCharacters(in: .whitespaces)
 
@@ -124,6 +126,16 @@ struct SearchView: View {
         return entries.filter { $0.dayOfWeek == day }
     }
 
+    private func applyPublisherFilter(to entries: [MangaEntry]) -> [MangaEntry] {
+        guard let publisher = selectedPublisher else { return entries }
+        return entries.filter { $0.publisher == publisher }
+    }
+
+    private func availablePublishers() -> [String] {
+        let entries = applyDayFilter(to: viewModel.allEntries())
+        return Set(entries.map(\.publisher)).filter { !$0.isEmpty }.sorted()
+    }
+
     // MARK: - Body
 
     var body: some View {
@@ -142,6 +154,14 @@ struct SearchView: View {
                         contentMode: $contentMode,
                         selectedColors: $selectedColors
                     )
+                    let publishers = availablePublishers()
+                    if !publishers.isEmpty {
+                        PublisherFilterView(
+                            publishers: publishers,
+                            viewModel: viewModel,
+                            selectedPublisher: $selectedPublisher
+                        )
+                    }
                     content
                 }
             }
@@ -207,7 +227,14 @@ struct SearchView: View {
         .onChange(of: publicationFilter) { _, _ in refreshResults() }
         .onChange(of: readingFilter) { _, _ in refreshResults() }
         .onChange(of: showOneShotOnly) { _, _ in refreshResults() }
-        .onChange(of: selectedDay) { _, _ in refreshResults() }
+        .onChange(of: selectedDay) { _, _ in
+            // 曜日変更で publisher リストが変わるため、選択中の publisher が消える可能性がある
+            if let pub = selectedPublisher, !availablePublishers().contains(pub) {
+                selectedPublisher = nil
+            }
+            refreshResults()
+        }
+        .onChange(of: selectedPublisher) { _, _ in refreshResults() }
         .onChange(of: selectedColors) { _, _ in refreshResults() }
         .onChange(of: viewModel.refreshCounter) { _, _ in refreshResults() }
         .onMangaDataChange {
@@ -230,7 +257,8 @@ struct SearchView: View {
     private var emptyState: some View {
         let trimmed = searchText.trimmingCharacters(in: .whitespaces)
         let hasAnyFilter = publicationFilter != nil || readingFilter != nil
-            || showOneShotOnly || selectedDay != nil || !selectedColors.isEmpty
+            || showOneShotOnly || selectedDay != nil || selectedPublisher != nil
+            || !selectedColors.isEmpty
 
         if trimmed.isEmpty && !hasAnyFilter && contentMode == .entries {
             ContentUnavailableView {

--- a/MangaLauncher/Views/Search/SearchView.swift
+++ b/MangaLauncher/Views/Search/SearchView.swift
@@ -24,6 +24,7 @@ struct SearchView: View {
 
     @State private var searchTask: Task<Void, Never>?
     @State private var cachedResults = SearchResults()
+    @State private var cachedPublishers: [String] = []
 
     private var theme: ThemeStyle { ThemeManager.shared.style }
 
@@ -131,14 +132,15 @@ struct SearchView: View {
         return entries.filter { $0.publisher == publisher }
     }
 
-    private func availablePublishers() -> [String] {
-        let entries = applyDayFilter(to: viewModel.allEntries())
-        let counts = Dictionary(grouping: entries.filter { !$0.publisher.isEmpty }, by: \.publisher)
-            .mapValues(\.count)
-        return counts.sorted { lhs, rhs in
-            if lhs.value != rhs.value { return lhs.value > rhs.value }
-            return lhs.key.localizedStandardCompare(rhs.key) == .orderedAscending
-        }.map(\.key)
+    private func computePublishers() -> [String] {
+        PublisherIndex.counts(from: applyDayFilter(to: viewModel.allEntries())).map(\.publisher)
+    }
+
+    private func refreshPublishers() {
+        cachedPublishers = computePublishers()
+        if let pub = selectedPublisher, !cachedPublishers.contains(pub) {
+            selectedPublisher = nil
+        }
     }
 
     // MARK: - Body
@@ -159,10 +161,9 @@ struct SearchView: View {
                         contentMode: $contentMode,
                         selectedColors: $selectedColors
                     )
-                    let publishers = availablePublishers()
-                    if !publishers.isEmpty {
+                    if !cachedPublishers.isEmpty {
                         PublisherFilterView(
-                            publishers: publishers,
+                            publishers: cachedPublishers,
                             viewModel: viewModel,
                             selectedPublisher: $selectedPublisher
                         )
@@ -218,7 +219,10 @@ struct SearchView: View {
             }
             #endif
         }
-        .onAppear { refreshResults() }
+        .onAppear {
+            refreshPublishers()
+            refreshResults()
+        }
         .onDisappear { searchTask?.cancel() }
         .onChange(of: searchText) { _, _ in
             searchTask?.cancel()
@@ -233,15 +237,15 @@ struct SearchView: View {
         .onChange(of: readingFilter) { _, _ in refreshResults() }
         .onChange(of: showOneShotOnly) { _, _ in refreshResults() }
         .onChange(of: selectedDay) { _, _ in
-            // 曜日変更で publisher リストが変わるため、選択中の publisher が消える可能性がある
-            if let pub = selectedPublisher, !availablePublishers().contains(pub) {
-                selectedPublisher = nil
-            }
+            refreshPublishers()
             refreshResults()
         }
         .onChange(of: selectedPublisher) { _, _ in refreshResults() }
         .onChange(of: selectedColors) { _, _ in refreshResults() }
-        .onChange(of: viewModel.refreshCounter) { _, _ in refreshResults() }
+        .onChange(of: viewModel.refreshCounter) { _, _ in
+            refreshPublishers()
+            refreshResults()
+        }
         .onMangaDataChange {
             viewModel.refresh()
         }


### PR DESCRIPTION
## Summary
- 検索画面の `SearchFilterBars` 直下に、ホーム画面と同じ `PublisherFilterView` を追加
- 曜日フィルタと連動して publisher 一覧が更新され、選択中の publisher が消えた場合は nil に戻す
- entries / memo / comment いずれのコンテンツモードでも適用される位置で絞り込み
- **ホーム/検索 両方** の publisher chip 並び順を「件数 desc → 同数は localizedStandardCompare の昇順」に変更（既存の `PublisherIndex.counts(from:)` に集計ロジックを寄せて重複を解消）
- `cachedPublishers` を `@State` で保持し、body 内で毎回再計算しない

## Test plan
- [ ] 検索画面で publisher chip をタップして絞り込めること
- [ ] 曜日フィルタを切り替えると publisher 一覧が更新され、消えた選択は解除されること
- [ ] memo / comment モードでも publisher 絞り込みが効くこと
- [ ] 既存の連載状況 / 読書状態 / 読み切り / カラーフィルタの挙動が変わらないこと
- [ ] ホーム画面の publisher chip が件数の多い順で並ぶこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)