### PR TITLE
ホーム画面クイックアクションを追加

### DIFF
--- a/MangaLauncher.xcodeproj/project.pbxproj
+++ b/MangaLauncher.xcodeproj/project.pbxproj
@@ -154,6 +154,7 @@
 		ECFEA8962F7F93AF00CE4DC0 /* ModelContextExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC44DD5EE5561C4C4F99C248 /* ModelContextExtensions.swift */; };
 		ECFEA89E2F7F96D200CE4DC0 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = ECFEA89D2F7F96D200CE4DC0 /* Localizable.xcstrings */; };
 		F8659628D6F745CA942803EB /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E7D977DE254FB1F216740BE6 /* Foundation.framework */; };
+		4B241C862AFC25CC38194ED7 /* QuickActionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F15C114B4AB9EACE665D7382 /* QuickActionService.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -313,6 +314,7 @@
 		ECFEA89D2F7F96D200CE4DC0 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		EEC07D90615785B81C2E71C8 /* ImageCropView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImageCropView.swift; sourceTree = "<group>"; };
 		EEEF347AB79EE547A4014C35 /* MangaLauncher.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = MangaLauncher.entitlements; sourceTree = "<group>"; };
+		F15C114B4AB9EACE665D7382 /* QuickActionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickActionService.swift; sourceTree = "<group>"; };
 		F75AA6830F31ABE5BD81DE01 /* MangaLauncherDebug.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = MangaLauncherDebug.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -654,6 +656,7 @@
 				9C7FA9735199D021E15CEED8 /* SharedModelContainer.swift */,
 				1CF568E5CBBFA07B55373C73 /* DataMigration.swift */,
 				ECFEA8202F7E8B9D00CE4DC0 /* UserDefaultsKeys.swift */,
+				F15C114B4AB9EACE665D7382 /* QuickActionService.swift */,
 				ECD61F7CE55EE24A44A02F14 /* AnimationTiming.swift */,
 				EC38F4ED01AE0D411DA0C66B /* DesignSystem.swift */,
 				05365AD0D66B41D8C20EDF49 /* ImageColorExtractor.swift */,
@@ -854,6 +857,7 @@
 				ECFEA8522F7F756A00CE4DC0 /* FilterChip.swift in Sources */,
 				ECFEA82A2F7E91A800CE4DC0 /* MangaGridCell.swift in Sources */,
 				ECFEA8302F7E970700CE4DC0 /* ReadingStatsProvider.swift in Sources */,
+				4B241C862AFC25CC38194ED7 /* QuickActionService.swift in Sources */,
 				A1000001 /* MangaLauncherApp.swift in Sources */,
 				ECFEA85C2F7F7C5200CE4DC0 /* PublisherFilterView.swift in Sources */,
 				ECCD2FCE2F65596900BF3309 /* PublisherPickerView.swift in Sources */,

--- a/MangaLauncher/MangaLauncherApp.swift
+++ b/MangaLauncher/MangaLauncherApp.swift
@@ -75,6 +75,7 @@ struct MangaLauncherApp: App {
     let container: ModelContainer
     @Environment(\.scenePhase) private var scenePhase
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+    @AppStorage(UserDefaultsKeys.hasSeenOnboarding) private var hasSeenOnboarding = false
     @State private var intentPrefill: IntentPrefill?
     @State private var syncMonitor = CloudSyncMonitor()
     /// アプリ全体で共有する単一の MangaViewModel。
@@ -152,13 +153,19 @@ struct MangaLauncherApp: App {
                         QuickActionService.handlePendingIfNeeded()
                         NotificationCenter.default.post(name: .mangaDataDidChange, object: nil)
                         updateBadge()
-                        QuickActionService.updateShortcutItems(
-                            unreadCount: viewModel.unreadCount(for: .today)
-                        )
+                        // updateBadge で最新の unreadCount が確定した後に登録する。
+                        // オンボーディング未完了時はタブが表示されないため登録しない。
+                        if hasSeenOnboarding {
+                            QuickActionService.updateShortcutItems(
+                                unreadCount: viewModel.unreadCount(for: .today)
+                            )
+                        }
                     } else if newPhase == .background {
-                        QuickActionService.updateShortcutItems(
-                            unreadCount: viewModel.unreadCount(for: .today)
-                        )
+                        if hasSeenOnboarding {
+                            QuickActionService.updateShortcutItems(
+                                unreadCount: viewModel.unreadCount(for: .today)
+                            )
+                        }
                     }
                 }
         }

--- a/MangaLauncher/MangaLauncherApp.swift
+++ b/MangaLauncher/MangaLauncherApp.swift
@@ -17,6 +17,34 @@ extension Notification.Name {
     // .switchToDay / .openCatchUp は ControlIntents.swift (widget extension とも共有) で定義
 }
 
+class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(
+        _ application: UIApplication,
+        configurationForConnecting connectingSceneSession: UISceneSession,
+        options: UIScene.ConnectionOptions
+    ) -> UISceneConfiguration {
+        // コールドスタート時のクイックアクション処理
+        if let shortcutItem = options.shortcutItem {
+            QuickActionService.savePending(shortcutItem)
+        }
+        let config = UISceneConfiguration(name: nil, sessionRole: connectingSceneSession.role)
+        config.delegateClass = SceneDelegate.self
+        return config
+    }
+}
+
+class SceneDelegate: NSObject, UIWindowSceneDelegate {
+    /// ウォームスタート（バックグラウンド復帰）時のクイックアクション処理
+    func windowScene(
+        _ windowScene: UIWindowScene,
+        performActionFor shortcutItem: UIApplicationShortcutItem,
+        completionHandler: @escaping (Bool) -> Void
+    ) {
+        QuickActionService.handle(shortcutItem)
+        completionHandler(true)
+    }
+}
+
 class NotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
         let identifier = response.notification.request.identifier
@@ -46,6 +74,7 @@ struct IntentPrefill: Identifiable {
 struct MangaLauncherApp: App {
     let container: ModelContainer
     @Environment(\.scenePhase) private var scenePhase
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @State private var intentPrefill: IntentPrefill?
     @State private var syncMonitor = CloudSyncMonitor()
     /// アプリ全体で共有する単一の MangaViewModel。
@@ -120,8 +149,16 @@ struct MangaLauncherApp: App {
                         checkPendingIntent()
                         checkPendingOpenDay()
                         checkPendingOpenCatchUp()
+                        QuickActionService.handlePendingIfNeeded()
                         NotificationCenter.default.post(name: .mangaDataDidChange, object: nil)
                         updateBadge()
+                        QuickActionService.updateShortcutItems(
+                            unreadCount: viewModel.unreadCount(for: .today)
+                        )
+                    } else if newPhase == .background {
+                        QuickActionService.updateShortcutItems(
+                            unreadCount: viewModel.unreadCount(for: .today)
+                        )
                     }
                 }
         }

--- a/MangaLauncher/Shared/QuickActionService.swift
+++ b/MangaLauncher/Shared/QuickActionService.swift
@@ -1,0 +1,90 @@
+import UIKit
+
+/// ホーム画面アイコン長押し時のクイックアクション (UIApplicationShortcutItem) を管理する。
+/// アクション実行時は既存の NotificationCenter パターンで各画面に伝達する。
+enum QuickActionService {
+
+    // MARK: - Action Types
+
+    enum ActionType: String, CaseIterable {
+        case openToday = "com.mangalauncher.openToday"
+        case catchUp   = "com.mangalauncher.catchUp"
+        case addEntry  = "com.mangalauncher.addEntry"
+        case search    = "com.mangalauncher.search"
+    }
+
+    // MARK: - Pending (Cold Start)
+
+    /// コールドスタート時はまだ View ツリーが構築されていないため、
+    /// shortcutItem を保持して scenePhase == .active 後に処理する。
+    private(set) static var pendingShortcutType: String?
+
+    static func savePending(_ shortcutItem: UIApplicationShortcutItem) {
+        pendingShortcutType = shortcutItem.type
+    }
+
+    /// 保留中のクイックアクションがあれば処理して消化する。
+    static func handlePendingIfNeeded() {
+        guard let type = pendingShortcutType else { return }
+        pendingShortcutType = nil
+        let item = UIApplicationShortcutItem(type: type, localizedTitle: "")
+        handle(item)
+    }
+
+    // MARK: - Register Dynamic Shortcuts
+
+    /// 動的ショートカットを登録する。active / background 遷移時に呼び出す。
+    static func updateShortcutItems(unreadCount: Int) {
+        let items: [UIApplicationShortcutItem] = [
+            UIApplicationShortcutItem(
+                type: ActionType.openToday.rawValue,
+                localizedTitle: "今日のマンガ",
+                localizedSubtitle: nil,
+                icon: UIApplicationShortcutIcon(systemImageName: "book.fill")
+            ),
+            UIApplicationShortcutItem(
+                type: ActionType.catchUp.rawValue,
+                localizedTitle: "キャッチアップ",
+                localizedSubtitle: unreadCount > 0 ? "未読 \(unreadCount) 件" : nil,
+                icon: UIApplicationShortcutIcon(systemImageName: "bolt.fill")
+            ),
+            UIApplicationShortcutItem(
+                type: ActionType.addEntry.rawValue,
+                localizedTitle: "作品を追加",
+                localizedSubtitle: nil,
+                icon: UIApplicationShortcutIcon(systemImageName: "plus")
+            ),
+            UIApplicationShortcutItem(
+                type: ActionType.search.rawValue,
+                localizedTitle: "検索",
+                localizedSubtitle: nil,
+                icon: UIApplicationShortcutIcon(systemImageName: "magnifyingglass")
+            ),
+        ]
+        UIApplication.shared.shortcutItems = items
+    }
+
+    // MARK: - Handle Action
+
+    /// クイックアクションを処理し、対応する通知を post する。
+    static func handle(_ shortcutItem: UIApplicationShortcutItem) {
+        guard let actionType = ActionType(rawValue: shortcutItem.type) else { return }
+
+        switch actionType {
+        case .openToday:
+            NotificationCenter.default.post(name: .switchToDay, object: DayOfWeek.today.rawValue)
+
+        case .catchUp:
+            let todayRaw = DayOfWeek.today.rawValue
+            NotificationCenter.default.post(name: .switchToDay, object: todayRaw)
+            NotificationCenter.default.post(name: .openCatchUp, object: nil)
+
+        case .addEntry:
+            NotificationCenter.default.post(name: .switchToDay, object: DayOfWeek.today.rawValue)
+            NotificationCenter.default.post(name: .openAddSheet, object: nil)
+
+        case .search:
+            NotificationCenter.default.post(name: .switchToSearch, object: nil)
+        }
+    }
+}

--- a/MangaLauncher/Shared/UserDefaultsKeys.swift
+++ b/MangaLauncher/Shared/UserDefaultsKeys.swift
@@ -33,4 +33,8 @@ extension Notification.Name {
     static let switchToDay = Notification.Name("switchToDay")
     /// キャッチアップ画面の起動リクエスト。
     static let openCatchUp = Notification.Name("openCatchUp")
+    /// ホームタブの新規登録シート表示リクエスト。
+    static let openAddSheet = Notification.Name("openAddSheet")
+    /// 検索タブへの切替リクエスト。
+    static let switchToSearch = Notification.Name("switchToSearch")
 }

--- a/MangaLauncher/Views/Home/ContentView.swift
+++ b/MangaLauncher/Views/Home/ContentView.swift
@@ -44,6 +44,9 @@ struct ContentView: View {
             .onReceive(NotificationCenter.default.publisher(for: .openCatchUp)) { _ in
                 homeState.sheets.showingCatchUp = true
             }
+            .onReceive(NotificationCenter.default.publisher(for: .openAddSheet)) { _ in
+                homeState.sheets.showingAddSheet = true
+            }
     }
 
     // MARK: - Main Content

--- a/MangaLauncher/Views/RootTabView.swift
+++ b/MangaLauncher/Views/RootTabView.swift
@@ -44,6 +44,12 @@ struct RootTabView: View {
         .onReceive(NotificationCenter.default.publisher(for: .openCatchUp)) { _ in
             selectedTab = .home
         }
+        .onReceive(NotificationCenter.default.publisher(for: .openAddSheet)) { _ in
+            selectedTab = .home
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .switchToSearch)) { _ in
+            selectedTab = .search
+        }
         // どのタブから削除してもトーストが表示されるように全体 overlay で保持
         .overlay(alignment: .bottom) {
             if !viewModel.pendingDeleteEntries.isEmpty {


### PR DESCRIPTION
## Summary
- アプリアイコン長押しで4つのクイックアクション (UIApplicationShortcutItem) を追加
  - **今日のマンガ** (`book.fill`): ホームタブの今日の曜日に遷移
  - **キャッチアップ** (`bolt.fill`): 未読まとめ読みを開始（未読数をサブタイトルに動的表示）
  - **作品を追加** (`plus`): 新規登録シートを表示
  - **検索** (`magnifyingglass`): 検索タブに遷移
- `UIApplicationDelegateAdaptor` + `SceneDelegate` で実装。コールドスタート時は pending に保持し active 後に処理
- 動的ショートカットは active / background 遷移時に更新し、キャッチアップの未読数を反映

## Test plan
- [ ] コールドスタート（アプリ終了状態）から各クイックアクションで正しい画面に遷移すること
- [ ] ウォームスタート（バックグラウンド復帰）から各クイックアクションで正しい画面に遷移すること
- [ ] 「今日のマンガ」→ ホームタブ今日の曜日に遷移
- [ ] 「キャッチアップ」→ CatchUpView が表示され、未読数がサブタイトルに正しく表示
- [ ] 「作品を追加」→ 新規登録シートが表示
- [ ] 「検索」→ 検索タブに遷移
- [ ] 既存のコントロールセンターウィジェット・通知タップ・ディープリンクが正常動作すること（回帰テスト）

🤖 Generated with [Claude Code](https://claude.com/claude-code)