### PR TITLE
起動時に重複 MangaEntry を自動統合する

### DIFF
--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -115,7 +115,13 @@ final class MangaViewModel {
 
         var toDelete: [MangaEntry] = []
         for (url, group) in groups where group.count >= 2 && !url.isEmpty {
-            let sorted = group.sorted { Self.dedupeScore(of: $0) > Self.dedupeScore(of: $1) }
+            // 同点時は UUID 文字列順で安定化させ、複数端末で kept が一致するようにする。
+            let sorted = group.sorted { lhs, rhs in
+                let l = Self.dedupeScore(of: lhs)
+                let r = Self.dedupeScore(of: rhs)
+                if l != r { return l > r }
+                return lhs.id.uuidString < rhs.id.uuidString
+            }
             toDelete.append(contentsOf: sorted.dropFirst())
         }
 

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -86,15 +86,22 @@ final class MangaViewModel {
         }
     }
 
-    /// 同じ URL を持つエントリが複数存在する場合に、情報量が最も多い 1 件を残して
+    /// 同じ URL × 同じ曜日 のエントリが複数存在する場合、情報量が最も多い 1 件を残して
     /// 残りを削除する。SwiftData + CloudKit では `@Attribute(.unique)` が使えず、
-    /// 端末間の同期不整合等で同 URL のレコードが複数残ることがある。
+    /// 端末間の同期不整合等で重複が残ることがある。
     ///
-    /// 注意: 重複エントリは UUID (`id`) が同一なケースが多い。`permanentlyDelete`
-    /// 経由だと `mangaEntryID == entry.id` で関連 ReadingActivity / Comment / Link
-    /// を引いてしまい、残す側のデータも消える危険がある。dedupe では
-    /// `modelContext.delete(entry)` を直接使って関連データはそのまま残す
-    /// (UUID が同じ kept エントリから引き続けるため孤児にならない)。
+    /// グルーピングキーは `(URL, dayOfWeek)` の複合キー。アプリ自身の重複防止
+    /// (`addEntry`) も `url + dayOfWeek` で判定しているため、それに揃える。
+    /// 同一 URL でも異なる曜日に登録されたエントリは正当な別物として扱う。
+    ///
+    /// 注意:
+    /// - 重複エントリは UUID (`id`) が同一なケースが多いが、別端末発番で UUID が
+    ///   異なるケースもあり得る。後者で関連 ReadingActivity / Comment / Link が
+    ///   孤児にならないよう、削除前に **losing 側の UUID を kept 側の UUID に
+    ///   付け替える** (re-point)。同 UUID のときは no-op になる。
+    /// - 削除後は `hiddenIDs` / `deletedIDs` キャッシュに stale な UUID が残る
+    ///   可能性があるので reload する(同 UUID の hidden/deleted が混ざっていた場合、
+    ///   kept エントリが誤って隠される事故を防ぐ)。
     private func dedupeEntriesIfNeeded() {
         let descriptor = FetchDescriptor<MangaEntry>(
             predicate: #Predicate { $0.deletedAt == nil }
@@ -109,12 +116,20 @@ final class MangaViewModel {
         }
         guard active.count >= 2 else { return }
 
-        let groups = Dictionary(grouping: active) { entry in
-            entry.url.trimmingCharacters(in: .whitespacesAndNewlines)
+        struct DedupeKey: Hashable {
+            let url: String
+            let day: Int
         }
 
-        var toDelete: [MangaEntry] = []
-        for (url, group) in groups where group.count >= 2 && !url.isEmpty {
+        let groups = Dictionary(grouping: active) { entry in
+            DedupeKey(
+                url: entry.url.trimmingCharacters(in: .whitespacesAndNewlines),
+                day: entry.dayOfWeekRawValue
+            )
+        }
+
+        var deletions: [(kept: MangaEntry, losers: [MangaEntry])] = []
+        for (key, group) in groups where group.count >= 2 && !key.url.isEmpty {
             // 同点時は UUID 文字列順で安定化させ、複数端末で kept が一致するようにする。
             let sorted = group.sorted { lhs, rhs in
                 let l = Self.dedupeScore(of: lhs)
@@ -122,21 +137,56 @@ final class MangaViewModel {
                 if l != r { return l > r }
                 return lhs.id.uuidString < rhs.id.uuidString
             }
-            toDelete.append(contentsOf: sorted.dropFirst())
+            guard let kept = sorted.first else { continue }
+            let losers = Array(sorted.dropFirst())
+            deletions.append((kept: kept, losers: losers))
         }
 
-        guard !toDelete.isEmpty else { return }
+        guard !deletions.isEmpty else { return }
 
-        print("[MangaViewModel] dedupe: removing \(toDelete.count) duplicate entries")
-        for entry in toDelete {
-            modelContext.delete(entry)
+        let totalToDelete = deletions.reduce(0) { $0 + $1.losers.count }
+        print("[MangaViewModel] dedupe: removing \(totalToDelete) duplicate entries across \(deletions.count) groups")
+        for (kept, losers) in deletions {
+            for loser in losers {
+                if loser.id != kept.id {
+                    repointRelatedReferences(from: loser.id, to: kept.id)
+                }
+                modelContext.delete(loser)
+            }
         }
         do {
             try modelContext.save()
+            // 削除した UUID と同じ UUID を kept が持つ場合に備えてキャッシュを再構築
+            reloadHiddenIDs()
+            reloadDeletedIDs()
             refreshCounter += 1
         } catch {
             print("[MangaViewModel] dedupe save failed: \(error)")
             lastError = .migration(error)
+        }
+    }
+
+    /// 重複統合で削除されるエントリの UUID を参照している
+    /// ReadingActivity / MangaComment / MangaLink を、残す方の UUID に付け替える。
+    /// 同 UUID のときは fetch しても 0 件なので何もしない。
+    private func repointRelatedReferences(from oldID: UUID, to newID: UUID) {
+        let activityDescriptor = FetchDescriptor<ReadingActivity>(
+            predicate: #Predicate { $0.mangaEntryID == oldID }
+        )
+        if let activities = try? modelContext.fetch(activityDescriptor) {
+            for a in activities { a.mangaEntryID = newID }
+        }
+        let commentDescriptor = FetchDescriptor<MangaComment>(
+            predicate: #Predicate { $0.mangaEntryID == oldID }
+        )
+        if let comments = try? modelContext.fetch(commentDescriptor) {
+            for c in comments { c.mangaEntryID = newID }
+        }
+        let linkDescriptor = FetchDescriptor<MangaLink>(
+            predicate: #Predicate { $0.mangaEntryID == oldID }
+        )
+        if let links = try? modelContext.fetch(linkDescriptor) {
+            for l in links { l.mangaEntryID = newID }
         }
     }
 

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -57,6 +57,7 @@ final class MangaViewModel {
         migrateLegacyStateIfNeeded()
         backfillMemoUpdatedAtIfNeeded()
         purgeExpiredSoftDeletes()
+        dedupeEntriesIfNeeded()
     }
 
     /// 旧 Bool 状態（isOnHiatus / isCompleted / isBacklog）を
@@ -83,6 +84,67 @@ final class MangaViewModel {
             print("[MangaViewModel] state migration save failed: \(error)")
             lastError = .migration(error)
         }
+    }
+
+    /// 同じ URL を持つエントリが複数存在する場合に、情報量が最も多い 1 件を残して
+    /// 残りを削除する。SwiftData + CloudKit では `@Attribute(.unique)` が使えず、
+    /// 端末間の同期不整合等で同 URL のレコードが複数残ることがある。
+    ///
+    /// 注意: 重複エントリは UUID (`id`) が同一なケースが多い。`permanentlyDelete`
+    /// 経由だと `mangaEntryID == entry.id` で関連 ReadingActivity / Comment / Link
+    /// を引いてしまい、残す側のデータも消える危険がある。dedupe では
+    /// `modelContext.delete(entry)` を直接使って関連データはそのまま残す
+    /// (UUID が同じ kept エントリから引き続けるため孤児にならない)。
+    private func dedupeEntriesIfNeeded() {
+        let descriptor = FetchDescriptor<MangaEntry>(
+            predicate: #Predicate { $0.deletedAt == nil }
+        )
+        let active: [MangaEntry]
+        do {
+            active = try modelContext.fetch(descriptor)
+        } catch {
+            print("[MangaViewModel] dedupe fetch failed: \(error)")
+            lastError = .migration(error)
+            return
+        }
+        guard active.count >= 2 else { return }
+
+        let groups = Dictionary(grouping: active) { entry in
+            entry.url.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        var toDelete: [MangaEntry] = []
+        for (url, group) in groups where group.count >= 2 && !url.isEmpty {
+            let sorted = group.sorted { Self.dedupeScore(of: $0) > Self.dedupeScore(of: $1) }
+            toDelete.append(contentsOf: sorted.dropFirst())
+        }
+
+        guard !toDelete.isEmpty else { return }
+
+        print("[MangaViewModel] dedupe: removing \(toDelete.count) duplicate entries")
+        for entry in toDelete {
+            modelContext.delete(entry)
+        }
+        do {
+            try modelContext.save()
+            refreshCounter += 1
+        } catch {
+            print("[MangaViewModel] dedupe save failed: \(error)")
+            lastError = .migration(error)
+        }
+    }
+
+    /// 重複グループ内で残す 1 件を決めるためのスコア。値が大きいほど情報量が多い。
+    private static func dedupeScore(of entry: MangaEntry) -> Int {
+        var s = 0
+        if !entry.memo.isEmpty { s += 10 }
+        if entry.lastReadDate != nil { s += 5 }
+        if entry.isFocused { s += 5 }
+        if entry.currentEpisode != nil { s += 3 }
+        if entry.imageData != nil { s += 2 }
+        if entry.episodeLabel != nil { s += 1 }
+        if entry.nextExpectedUpdate != nil { s += 1 }
+        return s
     }
 
     /// memoUpdatedAt 追加前に書かれたメモには nil が入っているので、

--- a/MangaLauncherTests/MangaEntryTests.swift
+++ b/MangaLauncherTests/MangaEntryTests.swift
@@ -384,6 +384,62 @@ struct MangaViewModelDedupeTests {
         #expect(firstCount == 1)
         #expect(secondCount == 1)
     }
+
+    @Test("dedupe 後も kept エントリの ReadingActivity は保持される")
+    @MainActor
+    func dedupePreservesReadingActivity() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let url = "https://example.com/keep-activity"
+        let sharedID = UUID()
+
+        // 同 URL × 同 UUID の重複(実環境で観測されたパターン)
+        context.insert(MangaEntry(id: sharedID, name: "A", url: url))
+        context.insert(MangaEntry(id: sharedID, name: "A", url: url))
+        // 共有 mangaEntryID の Activity を 3 件
+        context.insert(ReadingActivity(date: Date(timeIntervalSince1970: 1_700_000_000), mangaName: "A", mangaEntryID: sharedID))
+        context.insert(ReadingActivity(date: Date(timeIntervalSince1970: 1_700_086_400), mangaName: "A", mangaEntryID: sharedID))
+        context.insert(ReadingActivity(date: Date(timeIntervalSince1970: 1_700_172_800), mangaName: "A", mangaEntryID: sharedID))
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        vm.runStartupMigrationsIfNeeded()
+
+        // エントリは 1 件に統合される
+        let entries = try activeEntries(context)
+        #expect(entries.count == 1)
+
+        // ReadingActivity は 1 件も削除されない(草が消えない)
+        let allActivities = try context.fetch(FetchDescriptor<ReadingActivity>())
+        #expect(allActivities.count == 3)
+
+        // kept エントリと Activity の mangaEntryID が一致する(参照が孤児にならない)
+        if let kept = entries.first {
+            #expect(allActivities.allSatisfy { $0.mangaEntryID == kept.id })
+        }
+    }
+
+    @Test("score 同点時は UUID 文字列の昇順で kept が決まる(端末間で安定)")
+    @MainActor
+    func dedupeBreaksTiesByUUID() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let url = "https://example.com/tie"
+
+        // どちらも score=0 の同条件エントリ。UUID 順で勝者が決まることを確認。
+        let smallerUUID = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+        let largerUUID = UUID(uuidString: "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF")!
+        context.insert(MangaEntry(id: largerUUID, name: "loser", url: url))
+        context.insert(MangaEntry(id: smallerUUID, name: "winner", url: url))
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        vm.runStartupMigrationsIfNeeded()
+
+        let remaining = try activeEntries(context)
+        #expect(remaining.count == 1)
+        #expect(remaining.first?.id == smallerUUID)
+    }
 }
 
 @Suite("MangaViewModel.allUnreadEntries / allUnreadCount")

--- a/MangaLauncherTests/MangaEntryTests.swift
+++ b/MangaLauncherTests/MangaEntryTests.swift
@@ -259,6 +259,133 @@ struct MangaViewModelFindEntriesTests {
     }
 }
 
+@Suite("MangaViewModel dedupe-on-startup")
+struct MangaViewModelDedupeTests {
+
+    private func makeContainer() throws -> ModelContainer {
+        try ModelContainer(
+            for: MangaEntry.self, ReadingActivity.self, MangaComment.self,
+            configurations: ModelConfiguration(isStoredInMemoryOnly: true)
+        )
+    }
+
+    private func activeEntries(_ context: ModelContext) throws -> [MangaEntry] {
+        let descriptor = FetchDescriptor<MangaEntry>(
+            predicate: #Predicate { $0.deletedAt == nil }
+        )
+        return try context.fetch(descriptor)
+    }
+
+    @Test("同 URL の重複は最も情報量が多い 1 件を残して削除される")
+    @MainActor
+    func dedupeKeepsHighestScore() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let url = "https://example.com/title/1"
+
+        let plain = MangaEntry(name: "A", url: url)
+        let withMemo = MangaEntry(name: "A", url: url)
+        withMemo.memo = "高スコアにしたいエントリ"
+        let withProgress = MangaEntry(name: "A", url: url)
+        withProgress.currentEpisode = 5
+        context.insert(plain)
+        context.insert(withMemo)
+        context.insert(withProgress)
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        vm.runStartupMigrationsIfNeeded()
+
+        let remaining = try activeEntries(context)
+        #expect(remaining.count == 1)
+        #expect(remaining.first?.memo == "高スコアにしたいエントリ")
+    }
+
+    @Test("URL が異なるエントリは保持される")
+    @MainActor
+    func dedupeKeepsDistinctURLs() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        context.insert(MangaEntry(name: "A", url: "https://example.com/a"))
+        context.insert(MangaEntry(name: "B", url: "https://example.com/b"))
+        context.insert(MangaEntry(name: "C", url: "https://example.com/c"))
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        vm.runStartupMigrationsIfNeeded()
+
+        let remaining = try activeEntries(context)
+        #expect(remaining.count == 3)
+    }
+
+    @Test("URL が空のエントリは別エントリとして扱う(誤統合しない)")
+    @MainActor
+    func dedupeIgnoresEmptyURL() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        context.insert(MangaEntry(name: "noUrl1", url: ""))
+        context.insert(MangaEntry(name: "noUrl2", url: ""))
+        context.insert(MangaEntry(name: "noUrl3", url: "   "))
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        vm.runStartupMigrationsIfNeeded()
+
+        let remaining = try activeEntries(context)
+        #expect(remaining.count == 3)
+    }
+
+    @Test("削除済み (deletedAt != nil) エントリは dedupe 対象外")
+    @MainActor
+    func dedupeSkipsSoftDeleted() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let url = "https://example.com/x"
+
+        let kept = MangaEntry(name: "kept", url: url)
+        let deleted = MangaEntry(name: "deleted", url: url)
+        deleted.deletedAt = Date()
+        context.insert(kept)
+        context.insert(deleted)
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        vm.runStartupMigrationsIfNeeded()
+
+        let active = try activeEntries(context)
+        #expect(active.count == 1)
+        #expect(active.first?.name == "kept")
+
+        let allDescriptor = FetchDescriptor<MangaEntry>()
+        let all = try context.fetch(allDescriptor)
+        #expect(all.count == 2)
+    }
+
+    @Test("dedupe は冪等(2 回呼んでも結果が変わらない)")
+    @MainActor
+    func dedupeIsIdempotent() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let url = "https://example.com/idem"
+        context.insert(MangaEntry(name: "A", url: url))
+        context.insert(MangaEntry(name: "A", url: url))
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        vm.runStartupMigrationsIfNeeded()
+        let firstCount = try activeEntries(context).count
+
+        // 同じ ViewModel インスタンスは didRunStartupMigrations フラグで再実行されないため、
+        // 別インスタンスで再実行しても結果が変わらないことを確認。
+        let vm2 = MangaViewModel(modelContext: context)
+        vm2.runStartupMigrationsIfNeeded()
+        let secondCount = try activeEntries(context).count
+
+        #expect(firstCount == 1)
+        #expect(secondCount == 1)
+    }
+}
+
 @Suite("MangaViewModel.allUnreadEntries / allUnreadCount")
 struct MangaViewModelAllUnreadTests {
 

--- a/MangaLauncherTests/MangaEntryTests.swift
+++ b/MangaLauncherTests/MangaEntryTests.swift
@@ -419,6 +419,66 @@ struct MangaViewModelDedupeTests {
         }
     }
 
+    @Test("同 URL × 異なる曜日 は別物として保持される(マルチ曜日登録の保護)")
+    @MainActor
+    func dedupeKeepsSameURLAcrossDifferentDays() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let url = "https://example.com/multi-day"
+
+        // 同じ URL を月・火・水に登録した状態(addEntry の days: 引数の正常系)
+        let monday = MangaEntry(name: "A", url: url, dayOfWeek: .monday)
+        let tuesday = MangaEntry(name: "A", url: url, dayOfWeek: .tuesday)
+        let wednesday = MangaEntry(name: "A", url: url, dayOfWeek: .wednesday)
+        context.insert(monday)
+        context.insert(tuesday)
+        context.insert(wednesday)
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        vm.runStartupMigrationsIfNeeded()
+
+        let remaining = try activeEntries(context)
+        #expect(remaining.count == 3)
+        let days = Set(remaining.map(\.dayOfWeek))
+        #expect(days == Set([.monday, .tuesday, .wednesday]))
+    }
+
+    @Test("UUID が異なる重複でも関連 ReadingActivity が孤児化しない(re-point される)")
+    @MainActor
+    func dedupeRepointsRelatedRowsAcrossDifferentUUIDs() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let url = "https://example.com/cross-device-dup"
+
+        // 別端末で発番された前提で UUID が異なる重複(同 URL × 同曜日)
+        let losingID = UUID()
+        let winningID = UUID()
+        let loser = MangaEntry(id: losingID, name: "A", url: url)
+        let winner = MangaEntry(id: winningID, name: "A", url: url)
+        winner.memo = "高スコア側"  // kept が確定するように
+        context.insert(loser)
+        context.insert(winner)
+
+        // losingID 側に紐付いた Activity を作る
+        context.insert(ReadingActivity(date: Date(timeIntervalSince1970: 1_700_000_000), mangaName: "A", mangaEntryID: losingID))
+        context.insert(ReadingActivity(date: Date(timeIntervalSince1970: 1_700_086_400), mangaName: "A", mangaEntryID: losingID))
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        vm.runStartupMigrationsIfNeeded()
+
+        // エントリは winner 1 件のみ
+        let entries = try activeEntries(context)
+        #expect(entries.count == 1)
+        #expect(entries.first?.id == winningID)
+
+        // Activity は削除されず、mangaEntryID が winning 側に付け替えられている
+        let activities = try context.fetch(FetchDescriptor<ReadingActivity>())
+        #expect(activities.count == 2)
+        #expect(activities.allSatisfy { $0.mangaEntryID == winningID })
+    }
+
     @Test("score 同点時は UUID 文字列の昇順で kept が決まる(端末間で安定)")
     @MainActor
     func dedupeBreaksTiesByUUID() throws {

--- a/MangaLauncherTests/MangaEntryTests.swift
+++ b/MangaLauncherTests/MangaEntryTests.swift
@@ -264,7 +264,7 @@ struct MangaViewModelDedupeTests {
 
     private func makeContainer() throws -> ModelContainer {
         try ModelContainer(
-            for: MangaEntry.self, ReadingActivity.self, MangaComment.self,
+            for: MangaEntry.self, ReadingActivity.self, MangaComment.self, MangaLink.self,
             configurations: ModelConfiguration(isStoredInMemoryOnly: true)
         )
     }
@@ -477,6 +477,109 @@ struct MangaViewModelDedupeTests {
         let activities = try context.fetch(FetchDescriptor<ReadingActivity>())
         #expect(activities.count == 2)
         #expect(activities.allSatisfy { $0.mangaEntryID == winningID })
+    }
+
+    @Test("UUID が異なる重複で MangaComment / MangaLink も re-point される")
+    @MainActor
+    func dedupeRepointsCommentsAndLinks() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let url = "https://example.com/comments-and-links"
+
+        let losingID = UUID()
+        let winningID = UUID()
+        let loser = MangaEntry(id: losingID, name: "A", url: url)
+        let winner = MangaEntry(id: winningID, name: "A", url: url)
+        winner.memo = "高スコア側"
+        context.insert(loser)
+        context.insert(winner)
+
+        // losingID に紐付いた Comment / Link を作る
+        context.insert(MangaComment(mangaEntryID: losingID, content: "comment-1"))
+        context.insert(MangaComment(mangaEntryID: losingID, content: "comment-2"))
+        context.insert(MangaLink(mangaEntryID: losingID, url: "https://example.com/related-1"))
+        context.insert(MangaLink(mangaEntryID: losingID, url: "https://example.com/related-2"))
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        vm.runStartupMigrationsIfNeeded()
+
+        let comments = try context.fetch(FetchDescriptor<MangaComment>())
+        #expect(comments.count == 2)
+        #expect(comments.allSatisfy { $0.mangaEntryID == winningID })
+
+        let links = try context.fetch(FetchDescriptor<MangaLink>())
+        #expect(links.count == 2)
+        #expect(links.allSatisfy { $0.mangaEntryID == winningID })
+    }
+
+    @Test("dedupe 後に hiddenIDs キャッシュが reload され、kept が誤って隠れない")
+    @MainActor
+    func dedupeReloadsHiddenIDs() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let url = "https://example.com/hidden-cache"
+        let sharedID = UUID()
+
+        // 同 UUID × 同 URL の重複。loser は isHidden=true、kept は isHidden=false。
+        // 重複 UUID では hiddenIDs がそのままだと kept まで隠されてしまう。
+        let kept = MangaEntry(id: sharedID, name: "kept", url: url)
+        kept.memo = "高スコア側"
+        kept.isHidden = false
+        let loser = MangaEntry(id: sharedID, name: "loser", url: url)
+        loser.isHidden = true
+        context.insert(kept)
+        context.insert(loser)
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        // init で reloadHiddenIDs が走り、hiddenIDs に sharedID が入る(loser 由来)
+        #expect(vm.hiddenIDs.contains(sharedID))
+
+        vm.runStartupMigrationsIfNeeded()
+
+        // 削除後は loser 不在 → reload で hiddenIDs から外れる
+        #expect(!vm.hiddenIDs.contains(sharedID))
+        // fetchEntries が kept を返す(hidden 扱いされない)
+        let entries = vm.fetchEntries(for: kept.dayOfWeek)
+        #expect(entries.contains { $0.name == "kept" })
+    }
+
+    @Test("dedupe 後に deletedIDs キャッシュも reload される")
+    @MainActor
+    func dedupeReloadsDeletedIDs() throws {
+        let container = try makeContainer()
+        let context = container.mainContext
+        let url = "https://example.com/deleted-cache"
+        let sharedID = UUID()
+
+        // soft-deleted な loser と active な kept(同 UUID)。
+        // ※ dedupe は active のみ対象なので loser は dedupe で消えないが、
+        //   deletedIDs キャッシュに sharedID が入っている状態で kept が
+        //   `fetchEntries` 等で誤って弾かれないかを確認する。
+        let kept = MangaEntry(id: sharedID, name: "kept-active", url: url)
+        kept.memo = "高スコア側"
+        let other = MangaEntry(id: sharedID, name: "loser-active", url: url)
+        let softDeleted = MangaEntry(id: sharedID, name: "soft-deleted", url: url + "/other")
+        softDeleted.deletedAt = Date()
+        context.insert(kept)
+        context.insert(other)
+        context.insert(softDeleted)
+        try context.save()
+
+        let vm = MangaViewModel(modelContext: context)
+        // init で deletedIDs に sharedID(soft-deleted 由来)が入る
+        #expect(vm.deletedIDs.contains(sharedID))
+
+        vm.runStartupMigrationsIfNeeded()
+
+        // dedupe 後も soft-deleted 1 件は残る → deletedIDs に sharedID が引き続き入る
+        // (これは reload の正しい挙動。reload しないと stale だが偶々合うケースもあるので
+        //  ここは「reload が走った結果として正しい状態になっている」ことを検証)
+        let allDescriptor = FetchDescriptor<MangaEntry>(predicate: #Predicate { $0.deletedAt != nil })
+        let stillDeleted = try context.fetch(allDescriptor)
+        #expect(!stillDeleted.isEmpty)
+        #expect(vm.deletedIDs.contains(sharedID))
     }
 
     @Test("score 同点時は UUID 文字列の昇順で kept が決まる(端末間で安定)")


### PR DESCRIPTION
## Summary

- CloudKit 同期下では `@Attribute(.unique)` が使えず、端末間の同期不整合や復元等で同 URL のレコードが複数残るケースがある(実環境で 91 件中 62 件重複していた)。
- アプリ起動時(`runStartupMigrationsIfNeeded()`)で同 URL の重複を検出し、最も情報量が多い 1 件を残して残りを永久削除する処理を追加。
- 既存の `migrateLegacyStateIfNeeded` / `backfillMemoUpdatedAtIfNeeded` / `purgeExpiredSoftDeletes` と同じフローに乗せて、CloudKit 同期前のローカル DB 上書きを避ける既存 guard を共有する。

## 実装上の注意点

- 重複エントリは **UUID (`id`) も同一**なケースが多い。`permanentlyDelete` 経由だと `mangaEntryID == entry.id` で関連 ReadingActivity / Comment / Link を引いて、kept エントリのデータも巻き添えで消える危険がある。dedupe では `modelContext.delete(entry)` を直接呼んで関連データはそのまま残し、UUID が同じ kept エントリから引き続けられるようにしている。
- スコア(残す 1 件を決める基準): メモ +10 / lastReadDate +5 / isFocused +5 / currentEpisode +3 / imageData +2 / episodeLabel +1 / nextExpectedUpdate +1。
- URL が空文字または空白のみのエントリは別扱いにして誤統合しない。

## Test plan

- [ ] `MangaViewModelDedupeTests`: 同 URL の重複が高スコア 1 件に集約される
- [ ] 異 URL は保持される
- [ ] URL 空のエントリは統合されない
- [ ] `deletedAt != nil` (soft delete) は触らない
- [ ] dedupe が冪等
- [ ] 実機で複数端末 → 重複多数の状態 → 起動時にクリーンアップされることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)