### PR TITLE
ネットワーク通信の安全対策と force unwrap の排除

### DIFF
--- a/MangaLauncher/Shared/DataMigration.swift
+++ b/MangaLauncher/Shared/DataMigration.swift
@@ -8,7 +8,10 @@ enum DataMigration {
         guard SharedModelContainer.appGroupContainerURL != nil else { return }
 
         let fileManager = FileManager.default
-        let appSupportURL = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        guard let appSupportURL = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+            print("[DataMigration] Application Support directory not found")
+            return
+        }
 
         // SwiftData default store path
         let oldStoreURL = appSupportURL.appendingPathComponent("default.store")

--- a/MangaLauncher/Shared/SharedModelContainer.swift
+++ b/MangaLauncher/Shared/SharedModelContainer.swift
@@ -58,6 +58,23 @@ enum SharedModelContainer {
         return try ModelContainer(for: schema, configurations: [config])
     }
 
+    /// ストレージ破損・権限エラーなどで永続ストアが開けない場合の最終手段。
+    /// in-memory コンテナを返すのでデータは表示されないが、クラッシュは回避する。
+    static func createInMemory() -> ModelContainer {
+        let schema = Schema([MangaEntry.self, ReadingActivity.self, MangaComment.self, MangaLink.self, PublisherMetadata.self])
+        let config = ModelConfiguration(
+            "MangaLauncher",
+            schema: schema,
+            isStoredInMemoryOnly: true,
+            cloudKitDatabase: .none
+        )
+        do {
+            return try ModelContainer(for: schema, configurations: [config])
+        } catch {
+            fatalError("[SharedModelContainer] Even in-memory container failed: \(error)")
+        }
+    }
+
     static var storeURL: URL {
         let directory = appGroupContainerURL ?? fallbackURL
         return directory.appendingPathComponent("MangaLauncher.store")

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -789,7 +789,7 @@ final class MangaViewModel {
     }
 
     func purgeExpiredSoftDeletes() {
-        let cutoff = Calendar.current.date(byAdding: .day, value: -30, to: Date())!
+        guard let cutoff = Calendar.current.date(byAdding: .day, value: -30, to: Date()) else { return }
         let descriptor = FetchDescriptor<MangaEntry>(predicate: #Predicate { $0.deletedAt != nil && $0.deletedAt! < cutoff })
         guard let expired = try? modelContext.fetch(descriptor), !expired.isEmpty else { return }
         for entry in expired {

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -790,8 +790,10 @@ final class MangaViewModel {
 
     func purgeExpiredSoftDeletes() {
         guard let cutoff = Calendar.current.date(byAdding: .day, value: -30, to: Date()) else { return }
-        let descriptor = FetchDescriptor<MangaEntry>(predicate: #Predicate { $0.deletedAt != nil && $0.deletedAt! < cutoff })
-        guard let expired = try? modelContext.fetch(descriptor), !expired.isEmpty else { return }
+        let descriptor = FetchDescriptor<MangaEntry>(predicate: #Predicate { $0.deletedAt != nil })
+        guard let softDeleted = try? modelContext.fetch(descriptor) else { return }
+        let expired = softDeleted.filter { ($0.deletedAt ?? .distantFuture) < cutoff }
+        guard !expired.isEmpty else { return }
         for entry in expired {
             permanentlyDeleteWithoutSave(entry)
         }

--- a/MangaLauncher/ViewModels/ReadingStatsProvider.swift
+++ b/MangaLauncher/ViewModels/ReadingStatsProvider.swift
@@ -5,9 +5,10 @@ struct ReadingStatsProvider {
     let modelContext: ModelContext
 
     func fetchActivityCounts(days: Int = 84) -> [Date: Int] {
-        let startDate = Calendar.current.startOfDay(
-            for: Calendar.current.date(byAdding: .day, value: -days, to: Date())!
-        )
+        guard let baseDate = Calendar.current.date(byAdding: .day, value: -days, to: Date()) else {
+            return [:]
+        }
+        let startDate = Calendar.current.startOfDay(for: baseDate)
         let descriptor = FetchDescriptor<ReadingActivity>(
             predicate: #Predicate { $0.date >= startDate },
             sortBy: [SortDescriptor(\.date)]
@@ -36,12 +37,14 @@ struct ReadingStatsProvider {
         var checkDate = calendar.startOfDay(for: Date())
 
         if counts[checkDate] == nil {
-            checkDate = calendar.date(byAdding: .day, value: -1, to: checkDate)!
+            guard let prev = calendar.date(byAdding: .day, value: -1, to: checkDate) else { return 0 }
+            checkDate = prev
         }
 
         while counts[checkDate] != nil {
             streak += 1
-            checkDate = calendar.date(byAdding: .day, value: -1, to: checkDate)!
+            guard let prev = calendar.date(byAdding: .day, value: -1, to: checkDate) else { break }
+            checkDate = prev
         }
         return streak
     }
@@ -76,7 +79,9 @@ struct ReadingStatsProvider {
         let today = calendar.startOfDay(for: Date())
         let weekday = calendar.component(.weekday, from: today)
         let daysFromMonday = (weekday + 5) % 7
-        let monday = calendar.date(byAdding: .day, value: -daysFromMonday, to: today)!
+        guard let monday = calendar.date(byAdding: .day, value: -daysFromMonday, to: today) else {
+            return 0
+        }
         let descriptor = FetchDescriptor<ReadingActivity>(
             predicate: #Predicate { $0.date >= monday }
         )

--- a/MangaLauncher/Views/Entry/EditEntryView.swift
+++ b/MangaLauncher/Views/Entry/EditEntryView.swift
@@ -83,9 +83,9 @@ struct EditEntryView: View {
         let todayWeekday = calendar.component(.weekday, from: today) - 1
         let target = selectedDay.rawValue
         let daysToNext = (target - todayWeekday + 7) % 7
-        let firstDate = daysToNext == 0 ? today : calendar.date(byAdding: .day, value: daysToNext, to: today)!
-        return (0..<8).map { i in
-            calendar.date(byAdding: .day, value: i * 7, to: firstDate)!
+        let firstDate = daysToNext == 0 ? today : (calendar.date(byAdding: .day, value: daysToNext, to: today) ?? today)
+        return (0..<8).compactMap { i in
+            calendar.date(byAdding: .day, value: i * 7, to: firstDate)
         }
     }
 
@@ -96,7 +96,7 @@ struct EditEntryView: View {
         let target = day.rawValue
         let daysAhead = (target - todayWeekday + 7) % 7
         let next = daysAhead == 0 ? 7 : daysAhead // if today, go to next week
-        return calendar.date(byAdding: .day, value: next, to: today)!
+        return calendar.date(byAdding: .day, value: next, to: today) ?? today
     }
 
     private static let allowedSchemes: Set<String> = ["https", "http"]

--- a/MangaLauncher/Views/Heatmap/ReadingHeatmapView.swift
+++ b/MangaLauncher/Views/Heatmap/ReadingHeatmapView.swift
@@ -199,14 +199,19 @@ struct ReadingHeatmapView: View {
         // Find Monday of this week
         let weekday = calendar.component(.weekday, from: today) // 1=Sun, 2=Mon, ...
         let daysFromMonday = (weekday + 5) % 7 // Mon=0, Tue=1, ..., Sun=6
-        let thisMonday = calendar.date(byAdding: .day, value: -daysFromMonday, to: today)!
-        let startMonday = calendar.date(byAdding: .weekOfYear, value: -(weeks - 1), to: thisMonday)!
+        guard let thisMonday = calendar.date(byAdding: .day, value: -daysFromMonday, to: today),
+              let startMonday = calendar.date(byAdding: .weekOfYear, value: -(weeks - 1), to: thisMonday) else {
+            return []
+        }
 
         var grid: [[Date?]] = []
         for week in 0..<weeks {
             var column: [Date?] = []
             for day in 0..<7 {
-                let date = calendar.date(byAdding: .day, value: week * 7 + day, to: startMonday)!
+                guard let date = calendar.date(byAdding: .day, value: week * 7 + day, to: startMonday) else {
+                    column.append(nil)
+                    continue
+                }
                 if date <= today {
                     column.append(date)
                 } else {

--- a/MangaLauncher/Views/Library/Timeline/TimelineView.swift
+++ b/MangaLauncher/Views/Library/Timeline/TimelineView.swift
@@ -226,8 +226,8 @@ struct TimelineView: View {
 
     private func pageDates() -> [Date] {
         let calendar = Calendar.current
-        return (-Self.pageRadius...Self.pageRadius).map {
-            calendar.date(byAdding: .day, value: $0, to: pageAnchor)!
+        return (-Self.pageRadius...Self.pageRadius).compactMap {
+            calendar.date(byAdding: .day, value: $0, to: pageAnchor)
         }
     }
 

--- a/MangaShareExtension/ShareExtensionView.swift
+++ b/MangaShareExtension/ShareExtensionView.swift
@@ -53,9 +53,9 @@ struct ShareExtensionView: View {
         let todayWeekday = calendar.component(.weekday, from: today) - 1
         let target = selectedDay.rawValue
         let daysToNext = (target - todayWeekday + 7) % 7
-        let firstDate = daysToNext == 0 ? today : calendar.date(byAdding: .day, value: daysToNext, to: today)!
-        return (0..<8).map { i in
-            calendar.date(byAdding: .day, value: i * 7, to: firstDate)!
+        let firstDate = daysToNext == 0 ? today : (calendar.date(byAdding: .day, value: daysToNext, to: today) ?? today)
+        return (0..<8).compactMap { i in
+            calendar.date(byAdding: .day, value: i * 7, to: firstDate)
         }
     }
 
@@ -403,12 +403,17 @@ struct ShareExtensionView: View {
         let range = NSRange(html.startIndex..., in: html)
         let matches = regex.matches(in: html, range: range)
 
+        // 通信量を抑えるため、解決するリンク数を制限する
+        let maxResolveCount = 3
         var seen = Set<String>()
+        var resolvedCount = 0
         for match in matches {
+            guard resolvedCount < maxResolveCount else { break }
             guard let matchRange = Range(match.range, in: html) else { continue }
             let tcoURL = String(html[matchRange])
             guard !seen.contains(tcoURL) else { continue }
             seen.insert(tcoURL)
+            resolvedCount += 1
 
             let resolved = await URLResolver.resolveAll(tcoURL)
             let resolvedHost = URL(string: resolved)?.host ?? ""

--- a/MangaWidget/MangaWidget.swift
+++ b/MangaWidget/MangaWidget.swift
@@ -410,7 +410,8 @@ struct MangaLauncherWidget: Widget {
             do {
                 return try SharedModelContainer.createLocalOnly()
             } catch {
-                fatalError("[MangaWidget] ModelContainer creation failed completely: \(error)")
+                print("[MangaWidget] Local-only container also failed, using in-memory: \(error)")
+                return SharedModelContainer.createInMemory()
             }
         }
     }

--- a/MangaWidget/MangaWidget.swift
+++ b/MangaWidget/MangaWidget.swift
@@ -403,7 +403,16 @@ struct MangaLauncherWidget: Widget {
     let kind = "MangaWidget"
 
     private var container: ModelContainer {
-        try! SharedModelContainer.create()
+        do {
+            return try SharedModelContainer.create()
+        } catch {
+            print("[MangaWidget] CloudKit container failed, falling back to local-only: \(error)")
+            do {
+                return try SharedModelContainer.createLocalOnly()
+            } catch {
+                fatalError("[MangaWidget] ModelContainer creation failed completely: \(error)")
+            }
+        }
     }
 
     var body: some WidgetConfiguration {

--- a/Packages/OGPKit/Sources/OGPKit/OGPKit.swift
+++ b/Packages/OGPKit/Sources/OGPKit/OGPKit.swift
@@ -24,23 +24,35 @@ public enum URLResolver {
 
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
+        request.timeoutInterval = 10
 
         do {
             let (_, response) = try await URLSession.shared.data(for: request)
             if let finalURL = response.url {
                 return finalURL.absoluteString
             }
-        } catch {}
+        } catch {
+            print("[URLResolver] Failed to resolve \(urlString): \(error.localizedDescription)")
+        }
 
         return urlString
     }
 }
 
 public enum OGPFetcher {
+    /// HTML ページの取得タイムアウト (秒)
+    private static let htmlTimeout: TimeInterval = 15
+    /// OG 画像の取得タイムアウト (秒)
+    private static let imageTimeout: TimeInterval = 10
+    /// OG 画像の最大ダウンロードサイズ (5 MB)
+    private static let maxImageBytes = 5 * 1024 * 1024
+
     public static func fetch(from urlString: String) async -> OGPResult {
         guard let url = URL(string: urlString) else { return OGPResult() }
         do {
-            let (data, _) = try await URLSession.shared.data(from: url)
+            var htmlRequest = URLRequest(url: url)
+            htmlRequest.timeoutInterval = htmlTimeout
+            let (data, _) = try await URLSession.shared.data(for: htmlRequest)
             guard let html = String(data: data, encoding: .utf8) else { return OGPResult() }
 
             let siteName = extractMetaContent(from: html, property: "og:site_name")
@@ -54,14 +66,19 @@ public enum OGPFetcher {
                 } else {
                     resolvedURL = URL(string: imageURLString, relativeTo: url)?.absoluteString ?? imageURLString
                 }
-                if let imageURL = URL(string: resolvedURL),
-                   let (imgData, _) = try? await URLSession.shared.data(from: imageURL) {
-                    imageData = downsizedJPEGData(imgData, maxDimension: 600)
+                if let imageURL = URL(string: resolvedURL) {
+                    var imgRequest = URLRequest(url: imageURL)
+                    imgRequest.timeoutInterval = imageTimeout
+                    if let (imgData, _) = try? await URLSession.shared.data(for: imgRequest),
+                       imgData.count <= maxImageBytes {
+                        imageData = downsizedJPEGData(imgData, maxDimension: 600)
+                    }
                 }
             }
 
             return OGPResult(imageData: imageData, siteName: siteName, title: ogTitle)
         } catch {
+            print("[OGPFetcher] Failed to fetch from \(urlString): \(error.localizedDescription)")
             return OGPResult()
         }
     }

--- a/Packages/OGPKit/Sources/OGPKit/OGPKit.swift
+++ b/Packages/OGPKit/Sources/OGPKit/OGPKit.swift
@@ -67,12 +67,7 @@ public enum OGPFetcher {
                     resolvedURL = URL(string: imageURLString, relativeTo: url)?.absoluteString ?? imageURLString
                 }
                 if let imageURL = URL(string: resolvedURL) {
-                    var imgRequest = URLRequest(url: imageURL)
-                    imgRequest.timeoutInterval = imageTimeout
-                    if let (imgData, _) = try? await URLSession.shared.data(for: imgRequest),
-                       imgData.count <= maxImageBytes {
-                        imageData = downsizedJPEGData(imgData, maxDimension: 600)
-                    }
+                    imageData = try? await fetchImageWithLimit(from: imageURL)
                 }
             }
 
@@ -81,6 +76,35 @@ public enum OGPFetcher {
             print("[OGPFetcher] Failed to fetch from \(urlString): \(error.localizedDescription)")
             return OGPResult()
         }
+    }
+
+    /// 画像をストリーミング受信し、`maxImageBytes` を超えた時点でキャンセルする。
+    /// 通信量自体を抑えることでモバイルデータの浪費を防ぐ。
+    private static func fetchImageWithLimit(from url: URL) async throws -> Data? {
+        var request = URLRequest(url: url)
+        request.timeoutInterval = imageTimeout
+
+        let (bytes, response) = try await URLSession.shared.bytes(for: request)
+
+        // Content-Length が事前に分かる場合は早期に弾く
+        if let httpResponse = response as? HTTPURLResponse,
+           let contentLength = httpResponse.value(forHTTPHeaderField: "Content-Length"),
+           let length = Int(contentLength), length > maxImageBytes {
+            print("[OGPFetcher] Image too large (Content-Length: \(length) bytes), skipping")
+            return nil
+        }
+
+        var data = Data()
+        for try await byte in bytes {
+            data.append(byte)
+            if data.count > maxImageBytes {
+                print("[OGPFetcher] Image exceeded \(maxImageBytes) bytes during download, cancelling")
+                return nil
+            }
+        }
+
+        guard !data.isEmpty else { return nil }
+        return downsizedJPEGData(data, maxDimension: 600)
     }
 
     private static func extractMetaContent(from html: String, property: String) -> String? {


### PR DESCRIPTION
## Summary
- OGPKit にタイムアウト（HTML 15秒/画像 10秒）と画像サイズ上限（5MB）を設定し、モバイル通信の浪費を防止
- ShareExtension の t.co リンク解決ループに上限3件を設定し、無制限ネットワーク呼び出しを防止
- Widget の `try!` を CloudKit → ローカルフォールバックに変更しウィジェットクラッシュを防止
- プロジェクト全体の `calendar.date(byAdding:)!` 等の force unwrap を安全な nil ハンドリングに置換

## 変更ファイル (9件)
| カテゴリ | ファイル | 内容 |
|---|---|---|
| ネットワーク安全 | `OGPKit.swift` | タイムアウト・サイズ上限・エラーログ追加 |
| ネットワーク安全 | `ShareExtensionView.swift` | t.co ループ上限 + force unwrap 修正 |
| クラッシュ防止 | `MangaWidget.swift` | `try!` → do/catch + ローカルフォールバック |
| クラッシュ防止 | `DataMigration.swift` | `.first!` → `guard let` |
| クラッシュ防止 | `EditEntryView.swift` | `calendar.date!` → nil 合体 / compactMap |
| クラッシュ防止 | `ReadingStatsProvider.swift` | force unwrap × 4箇所修正 |
| クラッシュ防止 | `ReadingHeatmapView.swift` | force unwrap × 3箇所修正 |
| クラッシュ防止 | `TimelineView.swift` | `map` + force unwrap → `compactMap` |
| クラッシュ防止 | `MangaViewModel.swift` | `purgeExpiredSoftDeletes` の force unwrap 修正 |

## Test plan
- [ ] ビルド成功を確認（✅ 確認済み）
- [ ] Share Extension で X/Twitter のリンク共有が正常に動作すること
- [ ] OGP 画像取得が正常に動作すること（タイムアウト内に完了すること）
- [ ] ウィジェットが正常に表示されること
- [ ] ヒートマップ・タイムラインの日付表示が正常であること
- [ ] 編集画面の更新日候補が正常に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)