### PR TITLE
パーソナル評価（5段階星レーティング）機能を追加

### DIFF
--- a/MangaLauncher.xcodeproj/project.pbxproj
+++ b/MangaLauncher.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		AB50040000112233AA000001 /* BiometricAuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB50040000112233AA000002 /* BiometricAuthService.swift */; };
 		FB000001 /* PublisherIconService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB000010 /* PublisherIconService.swift */; };
 		AB50050000112233AA000001 /* SpecialEpisodeAlertModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB50050000112233AA000002 /* SpecialEpisodeAlertModifier.swift */; };
+		SR08BB6066FC9BC96538A142 /* StarRatingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = SR64676C69103849FA96D143 /* StarRatingView.swift */; };
 		AB50030000112233AA000003 /* MangaLifetimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB50030000112233AA000004 /* MangaLifetimeView.swift */; };
 		AB50030000112233AA000001 /* MangaLifetime.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB50030000112233AA000002 /* MangaLifetime.swift */; };
 		AB50020000112233AA000002 /* MangaEntryAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB50020000112233AA000001 /* MangaEntryAccessibility.swift */; };
@@ -195,6 +196,7 @@
 		AB50040000112233AA000002 /* BiometricAuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricAuthService.swift; sourceTree = "<group>"; };
 		FB000010 /* PublisherIconService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublisherIconService.swift; sourceTree = "<group>"; };
 		AB50050000112233AA000002 /* SpecialEpisodeAlertModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecialEpisodeAlertModifier.swift; sourceTree = "<group>"; };
+		SR64676C69103849FA96D143 /* StarRatingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarRatingView.swift; sourceTree = "<group>"; };
 		AB50030000112233AA000004 /* MangaLifetimeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaLifetimeView.swift; sourceTree = "<group>"; };
 		AB50030000112233AA000002 /* MangaLifetime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaLifetime.swift; sourceTree = "<group>"; };
 		AB50020000112233AA000001 /* MangaEntryAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaEntryAccessibility.swift; sourceTree = "<group>"; };
@@ -672,6 +674,7 @@
 				FB000010 /* PublisherIconService.swift */,
 				AB50050000112233AA000002 /* SpecialEpisodeAlertModifier.swift */,
 				AB5001FF00112233AA000004 /* NextUpdateBadgeView.swift */,
+				SR64676C69103849FA96D143 /* StarRatingView.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -867,6 +870,7 @@
 				AB50040000112233AA000003 /* HiddenEntriesView.swift in Sources */,
 				AB50040000112233AA000005 /* RecentlyDeletedView.swift in Sources */,
 				AB50050000112233AA000001 /* SpecialEpisodeAlertModifier.swift in Sources */,
+				SR08BB6066FC9BC96538A142 /* StarRatingView.swift in Sources */,
 				AB50030000112233AA000001 /* MangaLifetime.swift in Sources */,
 				AB50030000112233AA000003 /* MangaLifetimeView.swift in Sources */,
 				ECFEA8482F7F6E5700CE4DC0 /* MangaURLOpener.swift in Sources */,

--- a/MangaLauncher/Models/BackupData.swift
+++ b/MangaLauncher/Models/BackupData.swift
@@ -5,7 +5,7 @@ import UniformTypeIdentifiers
 struct BackupData: Codable {
     /// 現在のバックアップフォーマットバージョン。エクスポート時に書き込まれる。
     /// インポート時に backup.version > currentVersion なら拒否する。
-    static let currentVersion = 15
+    static let currentVersion = 16
 
     let version: Int
     let exportDate: Date
@@ -103,12 +103,14 @@ struct BackupData: Codable {
         let isHidden: Bool?
         // v13+
         let deletedAt: Date?
+        // v16+
+        let personalRating: Int?
         // Legacy fields (kept for backward-compat with v5 backups)
         let isOnHiatus: Bool?
         let isCompleted: Bool?
         let isBacklog: Bool?
 
-        init(id: UUID, name: String, url: String, dayOfWeekRawValue: Int, sortOrder: Int, iconColor: String, publisher: String, imageData: Data?, lastReadDate: Date? = nil, updateIntervalWeeks: Int = 1, nextExpectedUpdate: Date? = nil, isOneShot: Bool = false, publicationStatusRawValue: Int = 0, readingStateRawValue: Int = 0, memo: String = "", memoUpdatedAt: Date? = nil, currentEpisode: Int? = nil, episodeLabel: String? = nil, isHidden: Bool = false, deletedAt: Date? = nil) {
+        init(id: UUID, name: String, url: String, dayOfWeekRawValue: Int, sortOrder: Int, iconColor: String, publisher: String, imageData: Data?, lastReadDate: Date? = nil, updateIntervalWeeks: Int = 1, nextExpectedUpdate: Date? = nil, isOneShot: Bool = false, publicationStatusRawValue: Int = 0, readingStateRawValue: Int = 0, memo: String = "", memoUpdatedAt: Date? = nil, currentEpisode: Int? = nil, episodeLabel: String? = nil, isHidden: Bool = false, deletedAt: Date? = nil, personalRating: Int? = nil) {
             self.id = id
             self.name = name
             self.url = url
@@ -129,6 +131,7 @@ struct BackupData: Codable {
             self.episodeLabel = episodeLabel
             self.isHidden = isHidden
             self.deletedAt = deletedAt
+            self.personalRating = personalRating
             self.isOnHiatus = nil
             self.isCompleted = nil
             self.isBacklog = nil
@@ -156,6 +159,7 @@ struct BackupData: Codable {
             episodeLabel = try container.decodeIfPresent(String.self, forKey: .episodeLabel)
             isHidden = try container.decodeIfPresent(Bool.self, forKey: .isHidden)
             deletedAt = try container.decodeIfPresent(Date.self, forKey: .deletedAt)
+            personalRating = try container.decodeIfPresent(Int.self, forKey: .personalRating)
             isOnHiatus = try container.decodeIfPresent(Bool.self, forKey: .isOnHiatus)
             isCompleted = try container.decodeIfPresent(Bool.self, forKey: .isCompleted)
             isBacklog = try container.decodeIfPresent(Bool.self, forKey: .isBacklog)
@@ -186,7 +190,8 @@ struct BackupData: Codable {
                     memoUpdatedAt: $0.memoUpdatedAt,
                     currentEpisode: $0.currentEpisode,
                     episodeLabel: $0.episodeLabel,
-                    isHidden: $0.isHidden
+                    isHidden: $0.isHidden,
+                    personalRating: $0.personalRating
                 )
             },
             activities: activities.map {

--- a/MangaLauncher/Models/MangaEntry.swift
+++ b/MangaLauncher/Models/MangaEntry.swift
@@ -119,6 +119,8 @@ final class MangaEntry {
     var isHidden: Bool = false
     /// ソフトデリート日時（nil = 未削除）
     var deletedAt: Date?
+    /// パーソナル評価 (1〜5)。nil は未評価。
+    var personalRating: Int?
     /// フォーカス積読フラグ。最大3本まで同時にフォーカス可能。
     var isFocused: Bool = false
     /// フォーカス指定日時。フォーカス中積読セクションの並び順（降順 = 新しいフォーカスが先頭）に使う。

--- a/MangaLauncher/Shared/MangaEntryAccessibility.swift
+++ b/MangaLauncher/Shared/MangaEntryAccessibility.swift
@@ -11,6 +11,7 @@ extension MangaEntry {
         var parts = [name]
         if !publisher.isEmpty { parts.append(publisher) }
         if let text = episodeDisplayText { parts.append(text) }
+        if let rating = personalRating { parts.append("評価 \(rating)つ星") }
         if !isRead { parts.append("未読") }
         if showsNextUpdateBadge,
            let next = NextUpdateFormatter.format(nextExpectedUpdate, style: nextUpdateStyle) {

--- a/MangaLauncher/Shared/StarRatingView.swift
+++ b/MangaLauncher/Shared/StarRatingView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+/// 5段階の星評価を表示・操作するための再利用可能コンポーネント。
+///
+/// - Display-only: `StarRatingView(rating: entry.personalRating, size: 10)`
+/// - Interactive: `StarRatingView(rating: rating, size: 22) { newRating in ... }`
+struct StarRatingView: View {
+    let rating: Int?
+    var maxRating: Int = 5
+    var size: CGFloat = 14
+    /// nil の場合は表示専用（タップ不可）。
+    var onRate: ((Int?) -> Void)? = nil
+
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
+    var body: some View {
+        HStack(spacing: size > 16 ? 4 : 2) {
+            ForEach(1...maxRating, id: \.self) { star in
+                let isFilled = star <= (rating ?? 0)
+                Image(systemName: isFilled ? "star.fill" : "star")
+                    .font(.system(size: size))
+                    .foregroundStyle(isFilled ? .yellow : theme.onSurfaceVariant.opacity(0.3))
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        guard let onRate else { return }
+                        // 同じ星をタップで評価解除
+                        onRate(star == rating ? nil : star)
+                    }
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(ratingAccessibilityLabel)
+        .accessibilityValue(ratingAccessibilityValue)
+    }
+
+    private var ratingAccessibilityLabel: String {
+        "パーソナル評価"
+    }
+
+    private var ratingAccessibilityValue: String {
+        if let rating {
+            "\(rating)つ星"
+        } else {
+            "未評価"
+        }
+    }
+}

--- a/MangaLauncher/Shared/StarRatingView.swift
+++ b/MangaLauncher/Shared/StarRatingView.swift
@@ -11,6 +11,7 @@ struct StarRatingView: View {
     /// nil の場合は表示専用（タップ不可）。
     var onRate: ((Int?) -> Void)? = nil
 
+    private var isInteractive: Bool { onRate != nil }
     private var theme: ThemeStyle { ThemeManager.shared.style }
 
     var body: some View {
@@ -20,17 +21,38 @@ struct StarRatingView: View {
                 Image(systemName: isFilled ? "star.fill" : "star")
                     .font(.system(size: size))
                     .foregroundStyle(isFilled ? .yellow : theme.onSurfaceVariant.opacity(0.3))
-                    .contentShape(Rectangle())
-                    .onTapGesture {
-                        guard let onRate else { return }
-                        // 同じ星をタップで評価解除
-                        onRate(star == rating ? nil : star)
-                    }
             }
+        }
+        .contentShape(Rectangle())
+        .allowsHitTesting(isInteractive)
+        .onTapGesture { location in
+            guard let onRate else { return }
+            // タップ位置から星番号を算出
+            let spacing: CGFloat = size > 16 ? 4 : 2
+            let starWidth = size + spacing
+            let tappedStar = min(maxRating, max(1, Int(location.x / starWidth) + 1))
+            // 同じ星をタップで評価解除
+            onRate(tappedStar == rating ? nil : tappedStar)
         }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(ratingAccessibilityLabel)
         .accessibilityValue(ratingAccessibilityValue)
+        .if(isInteractive) { view in
+            view
+                .accessibilityAdjustableAction { direction in
+                    guard let onRate else { return }
+                    let current = rating ?? 0
+                    switch direction {
+                    case .increment:
+                        if current < maxRating { onRate(current + 1) }
+                    case .decrement:
+                        if current > 1 { onRate(current - 1) }
+                        else if current == 1 { onRate(nil) }
+                    @unknown default:
+                        break
+                    }
+                }
+        }
     }
 
     private var ratingAccessibilityLabel: String {

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -281,6 +281,8 @@ final class MangaViewModel {
     }
 
     /// パーソナル評価を設定する。nil で評価解除。
+    /// 現在は編集画面経由で updateEntry() から保存されるが、
+    /// 将来コンテキストメニュー等から直接評価変更する場合に使用する。
     func setPersonalRating(_ entry: MangaEntry, to rating: Int?) {
         if let r = rating {
             entry.personalRating = max(1, min(5, r))
@@ -416,7 +418,7 @@ final class MangaViewModel {
             }
             entry.currentEpisode = currentEpisode
             entry.episodeLabel = episodeLabel
-            entry.personalRating = personalRating
+            entry.personalRating = personalRating.map { max(1, min(5, $0)) }
             modelContext.insert(entry)
         }
         save()
@@ -475,7 +477,7 @@ final class MangaViewModel {
         }
         entry.currentEpisode = currentEpisode
         entry.episodeLabel = episodeLabel
-        entry.personalRating = personalRating
+        entry.personalRating = personalRating.map { max(1, min(5, $0)) }
 
         // 「保存時に既読にする」を同一トランザクション内で処理し、save() を1回に統合
         if markAsReadOnSave, entry.modelContext != nil {

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -197,6 +197,7 @@ final class MangaViewModel {
         if entry.lastReadDate != nil { s += 5 }
         if entry.isFocused { s += 5 }
         if entry.currentEpisode != nil { s += 3 }
+        if entry.personalRating != nil { s += 3 }
         if entry.imageData != nil { s += 2 }
         if entry.episodeLabel != nil { s += 1 }
         if entry.nextExpectedUpdate != nil { s += 1 }
@@ -275,6 +276,16 @@ final class MangaViewModel {
         if state != .backlog {
             entry.isFocused = false
             entry.focusedAt = nil
+        }
+        save()
+    }
+
+    /// パーソナル評価を設定する。nil で評価解除。
+    func setPersonalRating(_ entry: MangaEntry, to rating: Int?) {
+        if let r = rating {
+            entry.personalRating = max(1, min(5, r))
+        } else {
+            entry.personalRating = nil
         }
         save()
     }
@@ -378,7 +389,7 @@ final class MangaViewModel {
         save()
     }
 
-    func addEntry(name: String, url: String, days: Set<DayOfWeek>, iconColor: String, publisher: String = "", imageData: Data? = nil, updateIntervalWeeks: Int = 1, nextExpectedUpdate: Date? = nil, publicationStatus: PublicationStatus = .active, readingState: ReadingState = .following, isOneShot: Bool = false, memo: String = "", currentEpisode: Int? = nil, episodeLabel: String? = nil) {
+    func addEntry(name: String, url: String, days: Set<DayOfWeek>, iconColor: String, publisher: String = "", imageData: Data? = nil, updateIntervalWeeks: Int = 1, nextExpectedUpdate: Date? = nil, publicationStatus: PublicationStatus = .active, readingState: ReadingState = .following, isOneShot: Bool = false, memo: String = "", currentEpisode: Int? = nil, episodeLabel: String? = nil, personalRating: Int? = nil) {
         for day in days {
             // 同一URL + 同一曜日の重複登録を防止（状態問わず全エントリ対象）
             if allEntries().contains(where: { $0.dayOfWeek == day && $0.url == url }) { continue }
@@ -405,6 +416,7 @@ final class MangaViewModel {
             }
             entry.currentEpisode = currentEpisode
             entry.episodeLabel = episodeLabel
+            entry.personalRating = personalRating
             modelContext.insert(entry)
         }
         save()
@@ -426,6 +438,7 @@ final class MangaViewModel {
         memo: String,
         currentEpisode: Int? = nil,
         episodeLabel: String? = nil,
+        personalRating: Int? = nil,
         markAsReadOnSave: Bool = false
     ) {
         // URL または曜日が変更された場合、同一URL+曜日の重複を防止
@@ -462,6 +475,7 @@ final class MangaViewModel {
         }
         entry.currentEpisode = currentEpisode
         entry.episodeLabel = episodeLabel
+        entry.personalRating = personalRating
 
         // 「保存時に既読にする」を同一トランザクション内で処理し、save() を1回に統合
         if markAsReadOnSave, entry.modelContext != nil {
@@ -943,6 +957,7 @@ final class MangaViewModel {
             entry.currentEpisode = backupEntry.currentEpisode
             entry.episodeLabel = backupEntry.episodeLabel
             entry.isHidden = backupEntry.isHidden ?? false
+            entry.personalRating = backupEntry.personalRating
             // v6+ バックアップは publicationStatusRawValue / readingStateRawValue を authoritative とする。
             // 両方 nil のときだけ v5 以前の legacy Bool から導出する。
             // 通常 export 側は両方を必ず書くので片方 nil は現実にはほぼ起こらないが、

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -289,7 +289,17 @@ final class MangaViewModel {
         } else {
             entry.personalRating = nil
         }
-        save()
+        // entry が属するコンテキストで保存する（setHidden と同じパターン）
+        do {
+            if let ctx = entry.modelContext {
+                try ctx.save()
+            } else {
+                try modelContext.save()
+            }
+        } catch {
+            print("[MangaViewModel] setPersonalRating save failed: \(error)")
+        }
+        refreshCounter += 1
     }
 
     /// 非表示フラグの切り替え（refresh() は呼ばない）
@@ -959,7 +969,7 @@ final class MangaViewModel {
             entry.currentEpisode = backupEntry.currentEpisode
             entry.episodeLabel = backupEntry.episodeLabel
             entry.isHidden = backupEntry.isHidden ?? false
-            entry.personalRating = backupEntry.personalRating
+            entry.personalRating = backupEntry.personalRating.map { max(1, min(5, $0)) }
             // v6+ バックアップは publicationStatusRawValue / readingStateRawValue を authoritative とする。
             // 両方 nil のときだけ v5 以前の legacy Bool から導出する。
             // 通常 export 側は両方を必ず書くので片方 nil は現実にはほぼ起こらないが、

--- a/MangaLauncher/Views/CatchUp/CatchUpCardView.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpCardView.swift
@@ -10,11 +10,18 @@ struct CatchUpCardView: View {
 
     private var theme: ThemeStyle { ThemeManager.shared.style }
 
+    private var catchUpAccessibilityLabel: String {
+        var parts = [entry.name]
+        if !entry.publisher.isEmpty { parts.append(entry.publisher) }
+        if let rating = entry.personalRating { parts.append("評価 \(rating)つ星") }
+        return parts.joined(separator: "、")
+    }
+
     var body: some View {
         cardContent
             .contentShape(Rectangle())
             .accessibilityElement(children: .combine)
-            .accessibilityLabel("\(entry.name)\(entry.publisher.isEmpty ? "" : "、\(entry.publisher)")")
+            .accessibilityLabel(catchUpAccessibilityLabel)
             .accessibilityHint("タップでサイトを開く、長押しで編集")
             .onTapGesture {
                 onOpenURL(entry.url)

--- a/MangaLauncher/Views/CatchUp/CatchUpCardView.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpCardView.swift
@@ -69,6 +69,9 @@ struct CatchUpCardView: View {
                                 .foregroundStyle(theme.onSurfaceVariant)
                         }
                     }
+                    if entry.personalRating != nil {
+                        StarRatingView(rating: entry.personalRating, size: 12)
+                    }
                 }
                 .padding(.horizontal, theme.spacingMD)
                 .padding(.vertical, theme.spacingSM + 4)
@@ -95,6 +98,9 @@ struct CatchUpCardView: View {
                             .font(theme.subheadlineFont)
                             .foregroundStyle(hasGradientBackground ? .white.opacity(0.7) : theme.onSurfaceVariant)
                     }
+                }
+                if entry.personalRating != nil {
+                    StarRatingView(rating: entry.personalRating, size: 12)
                 }
             }
             .padding()
@@ -123,6 +129,9 @@ struct CatchUpCardView: View {
                                 .font(.system(size: 13, weight: .medium))
                                 .foregroundStyle(theme.onSurfaceVariant)
                         }
+                    }
+                    if entry.personalRating != nil {
+                        StarRatingView(rating: entry.personalRating, size: 12)
                     }
                 }
                 .padding(.horizontal, theme.spacingMD)

--- a/MangaLauncher/Views/Entry/EditEntryView.swift
+++ b/MangaLauncher/Views/Entry/EditEntryView.swift
@@ -36,6 +36,7 @@ struct EditEntryView: View {
     @State private var episodeText: String = ""
     @State private var episodeLabel: String = ""
     @State private var markAsReadOnSave: Bool = false
+    @State private var personalRating: Int?
     @State private var editingLink: MangaLink?
     @State private var showingAddLink = false
 
@@ -149,6 +150,7 @@ struct EditEntryView: View {
                 }
 
                 episodeSection
+                ratingSection
                 memoSection
 
                 if isEditing {
@@ -435,6 +437,23 @@ struct EditEntryView: View {
     }
 
     @ViewBuilder
+    private var ratingSection: some View {
+        Section {
+            HStack {
+                Text("パーソナル評価")
+                Spacer()
+                StarRatingView(rating: personalRating, size: 22) { newRating in
+                    personalRating = newRating
+                }
+            }
+        } header: {
+            Text("評価")
+        } footer: {
+            Text("作品への個人的な評価を5段階で記録できます。タップで評価、同じ星をタップで解除。")
+        }
+    }
+
+    @ViewBuilder
     private var memoSection: some View {
         Section {
             TextField("メモ（あらすじ・キャラ相関図など）", text: $memo, axis: .vertical)
@@ -576,6 +595,7 @@ struct EditEntryView: View {
             currentEpisode = entry.currentEpisode
             episodeText = entry.currentEpisode.map { String($0) } ?? ""
             episodeLabel = entry.episodeLabel ?? ""
+            personalRating = entry.personalRating
             didLoadEntry = true
         } else if entry == nil, !didLoadEntry {
             nextUpdateDate = nextUpdateCandidates.first ?? nextOccurrence(of: selectedDay)
@@ -625,6 +645,7 @@ struct EditEntryView: View {
                 memo: memo,
                 currentEpisode: currentEpisode,
                 episodeLabel: labelToSave,
+                personalRating: personalRating,
                 markAsReadOnSave: markAsReadOnSave
             )
         } else {
@@ -642,7 +663,8 @@ struct EditEntryView: View {
                 isOneShot: isOneShot,
                 memo: memo,
                 currentEpisode: currentEpisode,
-                episodeLabel: labelToSave
+                episodeLabel: labelToSave,
+                personalRating: personalRating
             )
         }
     }

--- a/MangaLauncher/Views/Library/LibraryCard.swift
+++ b/MangaLauncher/Views/Library/LibraryCard.swift
@@ -63,6 +63,10 @@ struct LibraryCard: View {
                     }
                     .frame(width: cardWidth, alignment: .leading)
                 }
+                if entry.personalRating != nil {
+                    StarRatingView(rating: entry.personalRating, size: 9)
+                        .frame(width: cardWidth, alignment: .leading)
+                }
             }
         }
         .buttonStyle(.plain)

--- a/MangaLauncher/Views/Library/LibrarySectionBuilder.swift
+++ b/MangaLauncher/Views/Library/LibrarySectionBuilder.swift
@@ -59,7 +59,11 @@ struct LibrarySectionBuilder {
     private func highRatedSection() -> LibrarySection? {
         let highRated = allEntries
             .filter { ($0.personalRating ?? 0) >= 4 }
-            .sorted { ($0.personalRating ?? 0) > ($1.personalRating ?? 0) }
+            .sorted {
+                let l = $0.personalRating ?? 0, r = $1.personalRating ?? 0
+                if l != r { return l > r }
+                return $0.name.localizedStandardCompare($1.name) == .orderedAscending
+            }
         guard !highRated.isEmpty else { return nil }
         return LibrarySection(title: "高評価", icon: "star.fill", iconColor: .yellow, entries: highRated)
     }

--- a/MangaLauncher/Views/Library/LibrarySectionBuilder.swift
+++ b/MangaLauncher/Views/Library/LibrarySectionBuilder.swift
@@ -11,6 +11,7 @@ struct LibrarySectionBuilder {
             recentSection(),
             unreadSection(),
             backlogSection(),
+            highRatedSection(),
         ].compactMap { $0 })
         sections.append(contentsOf: colorLabelSections())
         sections.append(contentsOf: [
@@ -52,6 +53,15 @@ struct LibrarySectionBuilder {
         let backlog = allEntries.filter { $0.readingState == .backlog }
         guard !backlog.isEmpty else { return nil }
         return LibrarySection(title: "積読", icon: "books.vertical", entries: backlog)
+    }
+
+    /// 高評価（4〜5つ星）
+    private func highRatedSection() -> LibrarySection? {
+        let highRated = allEntries
+            .filter { ($0.personalRating ?? 0) >= 4 }
+            .sorted { ($0.personalRating ?? 0) > ($1.personalRating ?? 0) }
+        guard !highRated.isEmpty else { return nil }
+        return LibrarySection(title: "高評価", icon: "star.fill", iconColor: .yellow, entries: highRated)
     }
 
     /// カラーラベル別（ラベル設定済みのもののみ）

--- a/MangaLauncher/Views/MangaCell/MangaGridCell.swift
+++ b/MangaLauncher/Views/MangaCell/MangaGridCell.swift
@@ -76,6 +76,9 @@ struct MangaGridCell: View {
                                     .foregroundStyle(theme.onSurfaceVariant)
                             }
                         }
+                        if entry.personalRating != nil {
+                            StarRatingView(rating: entry.personalRating, size: 8)
+                        }
                     }
                     Spacer(minLength: 0)
                 }

--- a/MangaLauncher/Views/MangaCell/MangaRowCell.swift
+++ b/MangaLauncher/Views/MangaCell/MangaRowCell.swift
@@ -76,6 +76,9 @@ struct MangaRowCell: View {
                                 .foregroundStyle(theme.onSurfaceVariant)
                         }
                     }
+                    if entry.personalRating != nil {
+                        StarRatingView(rating: entry.personalRating, size: 10)
+                    }
                 }
 
                 Spacer()

--- a/MangaLauncher/Views/Search/SearchFilterBars.swift
+++ b/MangaLauncher/Views/Search/SearchFilterBars.swift
@@ -9,6 +9,7 @@ struct SearchFilterBars: View {
     @Binding var showOneShotOnly: Bool
     @Binding var contentMode: SearchContentMode
     @Binding var selectedColors: Set<String>
+    @Binding var ratingFilter: Int?
 
     private let colorLabelStore = ColorLabelStore.shared
     private var theme: ThemeStyle { ThemeManager.shared.style }
@@ -93,6 +94,12 @@ struct SearchFilterBars: View {
                 ForEach(MangaColor.all) { mangaColor in
                     colorChip(for: mangaColor)
                 }
+
+                Spacer().frame(width: 4)
+
+                ForEach(1...5, id: \.self) { star in
+                    ratingChip(star: star)
+                }
             }
             .padding(.horizontal)
             .padding(.bottom, 8)
@@ -120,6 +127,36 @@ struct SearchFilterBars: View {
                 }
             }
             .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .background(
+                isSelected
+                    ? AnyShapeStyle(theme.primary.opacity(0.2))
+                    : AnyShapeStyle(theme.surfaceContainerHigh)
+            )
+            .overlay(
+                Capsule().strokeBorder(isSelected ? theme.primary : Color.clear, lineWidth: 1.5)
+            )
+            .foregroundStyle(theme.onSurface)
+            .clipShape(Capsule())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func ratingChip(star: Int) -> some View {
+        let isSelected = ratingFilter == star
+        return Button {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                ratingFilter = isSelected ? nil : star
+            }
+        } label: {
+            HStack(spacing: 2) {
+                Image(systemName: "star.fill")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.yellow)
+                Text("\(star)")
+                    .font(theme.captionFont)
+            }
+            .padding(.horizontal, 10)
             .padding(.vertical, 6)
             .background(
                 isSelected

--- a/MangaLauncher/Views/Search/SearchFilterBars.swift
+++ b/MangaLauncher/Views/Search/SearchFilterBars.swift
@@ -195,6 +195,7 @@ struct SearchFilterBars: View {
         publicationFilter = nil
         readingFilter = nil
         showOneShotOnly = false
+        ratingFilter = nil
     }
 }
 

--- a/MangaLauncher/Views/Search/SearchResultRow.swift
+++ b/MangaLauncher/Views/Search/SearchResultRow.swift
@@ -45,7 +45,7 @@ struct SearchResultRow: View {
                         if entry.personalRating != nil {
                             StarRatingView(rating: entry.personalRating, size: 9)
                         }
-                        if !hasAnyStatus(entry) && entry.personalRating == nil {
+                        if !hasAnyStatus(entry) {
                             dayBadge(entry.dayOfWeek.shortName)
                         }
                     }

--- a/MangaLauncher/Views/Search/SearchResultRow.swift
+++ b/MangaLauncher/Views/Search/SearchResultRow.swift
@@ -42,7 +42,10 @@ struct SearchResultRow: View {
                             }
                         }
                         MangaStatusBadgeView(entry: entry, fontSize: 9)
-                        if !hasAnyStatus(entry) {
+                        if entry.personalRating != nil {
+                            StarRatingView(rating: entry.personalRating, size: 9)
+                        }
+                        if !hasAnyStatus(entry) && entry.personalRating == nil {
                             dayBadge(entry.dayOfWeek.shortName)
                         }
                     }

--- a/MangaLauncher/Views/Search/SearchView.swift
+++ b/MangaLauncher/Views/Search/SearchView.swift
@@ -17,6 +17,7 @@ struct SearchView: View {
     @State private var selectedDay: DayOfWeek? = nil
     @State private var selectedPublisher: String? = nil
     @State private var selectedColors: Set<String> = []
+    @State private var ratingFilter: Int? = nil
     @State private var safariURL: URL?
     @State private var editingEntry: MangaEntry?
     @State private var commentingEntry: MangaEntry?
@@ -43,11 +44,12 @@ struct SearchView: View {
         let dayFiltered = applyDayFilter(to: allEntries)
         let publisherFiltered = applyPublisherFilter(to: dayFiltered)
         let colorFiltered = applyColorFilter(to: publisherFiltered)
+        let ratingFiltered = applyRatingFilter(to: colorFiltered)
 
         let trimmed = searchText.trimmingCharacters(in: .whitespaces)
 
         if contentMode == .memo {
-            let memoMatched = colorFiltered.filter {
+            let memoMatched = ratingFiltered.filter {
                 !$0.memo.isEmpty
                     && (trimmed.isEmpty || $0.memo.localizedCaseInsensitiveContains(trimmed))
             }
@@ -55,8 +57,8 @@ struct SearchView: View {
         }
 
         if contentMode == .comment {
-            let candidateIDs = Set(colorFiltered.map(\.id))
-            let entriesByID = Dictionary(colorFiltered.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+            let candidateIDs = Set(ratingFiltered.map(\.id))
+            let entriesByID = Dictionary(ratingFiltered.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
             let allComments = viewModel.allComments()
             let commentMatched: [(MangaComment, MangaEntry)] = allComments.compactMap { comment in
                 guard candidateIDs.contains(comment.mangaEntryID),
@@ -70,7 +72,7 @@ struct SearchView: View {
             return SearchResults(entries: [], memos: [], comments: commentMatched)
         }
 
-        let candidates = applyEntryFilters(to: colorFiltered)
+        let candidates = applyEntryFilters(to: ratingFiltered)
 
         guard !trimmed.isEmpty else {
             return SearchResults(entries: candidates, memos: [], comments: [])
@@ -122,6 +124,11 @@ struct SearchView: View {
         return entries.filter { selectedColors.contains($0.iconColor) }
     }
 
+    private func applyRatingFilter(to entries: [MangaEntry]) -> [MangaEntry] {
+        guard let rating = ratingFilter else { return entries }
+        return entries.filter { $0.personalRating == rating }
+    }
+
     private func applyDayFilter(to entries: [MangaEntry]) -> [MangaEntry] {
         guard let day = selectedDay else { return entries }
         return entries.filter { $0.dayOfWeek == day }
@@ -159,7 +166,8 @@ struct SearchView: View {
                         readingFilter: $readingFilter,
                         showOneShotOnly: $showOneShotOnly,
                         contentMode: $contentMode,
-                        selectedColors: $selectedColors
+                        selectedColors: $selectedColors,
+                        ratingFilter: $ratingFilter
                     )
                     if !cachedPublishers.isEmpty {
                         PublisherFilterView(
@@ -242,6 +250,7 @@ struct SearchView: View {
         }
         .onChange(of: selectedPublisher) { _, _ in refreshResults() }
         .onChange(of: selectedColors) { _, _ in refreshResults() }
+        .onChange(of: ratingFilter) { _, _ in refreshResults() }
         .onChange(of: viewModel.refreshCounter) { _, _ in
             refreshPublishers()
             refreshResults()
@@ -267,7 +276,7 @@ struct SearchView: View {
         let trimmed = searchText.trimmingCharacters(in: .whitespaces)
         let hasAnyFilter = publicationFilter != nil || readingFilter != nil
             || showOneShotOnly || selectedDay != nil || selectedPublisher != nil
-            || !selectedColors.isEmpty
+            || !selectedColors.isEmpty || ratingFilter != nil
 
         if trimmed.isEmpty && !hasAnyFilter && contentMode == .entries {
             ContentUnavailableView {


### PR DESCRIPTION
## Summary
- 各マンガに1〜5の星評価（パーソナル評価）を設定できる機能を追加
- 編集画面に「評価」セクションを追加（タップで星評価、同じ星をタップで解除）
- ホーム画面（グリッド/リスト）、ライブラリカード、キャッチアップカード、検索結果に星を表示
- 検索画面に星数フィルター（★1〜★5）チップを追加
- ライブラリに「高評価」セクション（4〜5つ星）を追加
- バックアップ形式をv16に更新し、評価データのエクスポート/インポートに対応
- アクセシビリティラベルに評価情報を追加

## 変更ファイル
- **Model**: `MangaEntry.personalRating: Int?` フィールド追加
- **BackupData**: v16化、`BackupEntry.personalRating` 追加
- **ViewModel**: `addEntry`/`updateEntry`/`setPersonalRating`/`dedupeScore`/`importBackupData` に対応
- **StarRatingView**: 新規 — 表示専用/インタラクティブ両対応の再利用可能コンポーネント
- **EditEntryView**: 評価セクション追加
- **セル/カード**: MangaGridCell, MangaRowCell, LibraryCard, CatchUpCardView, SearchResultRow に星表示
- **SearchView/SearchFilterBars**: 星フィルター追加
- **LibrarySectionBuilder**: 高評価セクション追加

## Test plan
- [ ] 編集画面で星評価を設定・変更・解除できること
- [ ] 新規登録時に星評価を設定して保存できること
- [ ] ホーム画面のグリッド/リスト表示で星が表示されること
- [ ] ライブラリの「高評価」セクションに4〜5つ星のマンガが表示されること
- [ ] 検索画面で星フィルターが正しく動作すること
- [ ] キャッチアップカードに星が表示されること
- [ ] バックアップのエクスポート/インポートで評価が保持されること
- [ ] 旧バージョン（v15以前）のバックアップをインポートしても問題ないこと
- [ ] 未評価のマンガでは星が表示されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)