### PR TITLE
積読マンガの読書進捗表示機能を追加

### DIFF
--- a/MangaLauncher.xcodeproj/project.pbxproj
+++ b/MangaLauncher.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		FB000001 /* PublisherIconService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB000010 /* PublisherIconService.swift */; };
 		AB50050000112233AA000001 /* SpecialEpisodeAlertModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB50050000112233AA000002 /* SpecialEpisodeAlertModifier.swift */; };
 		SR08BB6066FC9BC96538A142 /* StarRatingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = SR64676C69103849FA96D143 /* StarRatingView.swift */; };
+		BP08BB6066FC9BC96538A142 /* BacklogProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BP64676C69103849FA96D143 /* BacklogProgressView.swift */; };
 		AB50030000112233AA000003 /* MangaLifetimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB50030000112233AA000004 /* MangaLifetimeView.swift */; };
 		AB50030000112233AA000001 /* MangaLifetime.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB50030000112233AA000002 /* MangaLifetime.swift */; };
 		AB50020000112233AA000002 /* MangaEntryAccessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB50020000112233AA000001 /* MangaEntryAccessibility.swift */; };
@@ -197,6 +198,7 @@
 		FB000010 /* PublisherIconService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublisherIconService.swift; sourceTree = "<group>"; };
 		AB50050000112233AA000002 /* SpecialEpisodeAlertModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecialEpisodeAlertModifier.swift; sourceTree = "<group>"; };
 		SR64676C69103849FA96D143 /* StarRatingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarRatingView.swift; sourceTree = "<group>"; };
+		BP64676C69103849FA96D143 /* BacklogProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BacklogProgressView.swift; sourceTree = "<group>"; };
 		AB50030000112233AA000004 /* MangaLifetimeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaLifetimeView.swift; sourceTree = "<group>"; };
 		AB50030000112233AA000002 /* MangaLifetime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaLifetime.swift; sourceTree = "<group>"; };
 		AB50020000112233AA000001 /* MangaEntryAccessibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaEntryAccessibility.swift; sourceTree = "<group>"; };
@@ -675,6 +677,7 @@
 				AB50050000112233AA000002 /* SpecialEpisodeAlertModifier.swift */,
 				AB5001FF00112233AA000004 /* NextUpdateBadgeView.swift */,
 				SR64676C69103849FA96D143 /* StarRatingView.swift */,
+				BP64676C69103849FA96D143 /* BacklogProgressView.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -871,6 +874,7 @@
 				AB50040000112233AA000005 /* RecentlyDeletedView.swift in Sources */,
 				AB50050000112233AA000001 /* SpecialEpisodeAlertModifier.swift in Sources */,
 				SR08BB6066FC9BC96538A142 /* StarRatingView.swift in Sources */,
+				BP08BB6066FC9BC96538A142 /* BacklogProgressView.swift in Sources */,
 				AB50030000112233AA000001 /* MangaLifetime.swift in Sources */,
 				AB50030000112233AA000003 /* MangaLifetimeView.swift in Sources */,
 				ECFEA8482F7F6E5700CE4DC0 /* MangaURLOpener.swift in Sources */,

--- a/MangaLauncher/Models/BackupData.swift
+++ b/MangaLauncher/Models/BackupData.swift
@@ -5,7 +5,7 @@ import UniformTypeIdentifiers
 struct BackupData: Codable {
     /// 現在のバックアップフォーマットバージョン。エクスポート時に書き込まれる。
     /// インポート時に backup.version > currentVersion なら拒否する。
-    static let currentVersion = 16
+    static let currentVersion = 17
 
     let version: Int
     let exportDate: Date
@@ -105,12 +105,14 @@ struct BackupData: Codable {
         let deletedAt: Date?
         // v16+
         let personalRating: Int?
+        // v17+
+        let latestEpisode: Int?
         // Legacy fields (kept for backward-compat with v5 backups)
         let isOnHiatus: Bool?
         let isCompleted: Bool?
         let isBacklog: Bool?
 
-        init(id: UUID, name: String, url: String, dayOfWeekRawValue: Int, sortOrder: Int, iconColor: String, publisher: String, imageData: Data?, lastReadDate: Date? = nil, updateIntervalWeeks: Int = 1, nextExpectedUpdate: Date? = nil, isOneShot: Bool = false, publicationStatusRawValue: Int = 0, readingStateRawValue: Int = 0, memo: String = "", memoUpdatedAt: Date? = nil, currentEpisode: Int? = nil, episodeLabel: String? = nil, isHidden: Bool = false, deletedAt: Date? = nil, personalRating: Int? = nil) {
+        init(id: UUID, name: String, url: String, dayOfWeekRawValue: Int, sortOrder: Int, iconColor: String, publisher: String, imageData: Data?, lastReadDate: Date? = nil, updateIntervalWeeks: Int = 1, nextExpectedUpdate: Date? = nil, isOneShot: Bool = false, publicationStatusRawValue: Int = 0, readingStateRawValue: Int = 0, memo: String = "", memoUpdatedAt: Date? = nil, currentEpisode: Int? = nil, episodeLabel: String? = nil, isHidden: Bool = false, deletedAt: Date? = nil, personalRating: Int? = nil, latestEpisode: Int? = nil) {
             self.id = id
             self.name = name
             self.url = url
@@ -132,6 +134,7 @@ struct BackupData: Codable {
             self.isHidden = isHidden
             self.deletedAt = deletedAt
             self.personalRating = personalRating
+            self.latestEpisode = latestEpisode
             self.isOnHiatus = nil
             self.isCompleted = nil
             self.isBacklog = nil
@@ -160,6 +163,7 @@ struct BackupData: Codable {
             isHidden = try container.decodeIfPresent(Bool.self, forKey: .isHidden)
             deletedAt = try container.decodeIfPresent(Date.self, forKey: .deletedAt)
             personalRating = try container.decodeIfPresent(Int.self, forKey: .personalRating)
+            latestEpisode = try container.decodeIfPresent(Int.self, forKey: .latestEpisode)
             isOnHiatus = try container.decodeIfPresent(Bool.self, forKey: .isOnHiatus)
             isCompleted = try container.decodeIfPresent(Bool.self, forKey: .isCompleted)
             isBacklog = try container.decodeIfPresent(Bool.self, forKey: .isBacklog)
@@ -191,7 +195,8 @@ struct BackupData: Codable {
                     currentEpisode: $0.currentEpisode,
                     episodeLabel: $0.episodeLabel,
                     isHidden: $0.isHidden,
-                    personalRating: $0.personalRating
+                    personalRating: $0.personalRating,
+                    latestEpisode: $0.latestEpisode
                 )
             },
             activities: activities.map {

--- a/MangaLauncher/Models/MangaEntry.swift
+++ b/MangaLauncher/Models/MangaEntry.swift
@@ -121,6 +121,8 @@ final class MangaEntry {
     var deletedAt: Date?
     /// パーソナル評価 (1〜5)。nil は未評価。
     var personalRating: Int?
+    /// 最新話数。nil は未設定。積読の進捗表示に使用。
+    var latestEpisode: Int?
     /// フォーカス積読フラグ。最大3本まで同時にフォーカス可能。
     var isFocused: Bool = false
     /// フォーカス指定日時。フォーカス中積読セクションの並び順（降順 = 新しいフォーカスが先頭）に使う。
@@ -273,6 +275,14 @@ final class MangaEntry {
         }
         normalizeOneShotInvariants()
         stateMigrationVersion = 1
+    }
+
+    /// 積読の進捗を表示すべきか
+    @Transient
+    var showsBacklogProgress: Bool {
+        readingState == .backlog
+            && currentEpisode != nil
+            && latestEpisode != nil
     }
 
     init(

--- a/MangaLauncher/Shared/BacklogProgressView.swift
+++ b/MangaLauncher/Shared/BacklogProgressView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+/// 積読マンガの読書進捗を表示する再利用可能コンポーネント。
+///
+/// `readingState == .backlog` かつ `currentEpisode` と `latestEpisode` の
+/// 両方が設定されている場合のみ表示される。
+///
+/// Usage: `BacklogProgressView(entry: entry, fontSize: 9)`
+struct BacklogProgressView: View {
+    let entry: MangaEntry
+    var fontSize: CGFloat = 10
+    var barHeight: CGFloat = 3
+
+    private var theme: ThemeStyle { ThemeManager.shared.style }
+
+    var body: some View {
+        if entry.showsBacklogProgress,
+           let current = entry.currentEpisode,
+           let latest = entry.latestEpisode {
+            let fraction = latest > 0 ? min(1.0, Double(current) / Double(latest)) : 0
+            VStack(alignment: .leading, spacing: 2) {
+                Text("\(current) / \(latest)話")
+                    .font(.system(size: fontSize, weight: .medium))
+                    .foregroundStyle(theme.onSurfaceVariant)
+
+                ProgressView(value: fraction)
+                    .tint(theme.primary)
+                    .frame(height: barHeight)
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("積読進捗 \(current)/\(latest)話")
+        }
+    }
+}

--- a/MangaLauncher/Shared/MangaEntryAccessibility.swift
+++ b/MangaLauncher/Shared/MangaEntryAccessibility.swift
@@ -11,6 +11,11 @@ extension MangaEntry {
         var parts = [name]
         if !publisher.isEmpty { parts.append(publisher) }
         if let text = episodeDisplayText { parts.append(text) }
+        if readingState == .backlog,
+           let current = currentEpisode,
+           let latest = latestEpisode {
+            parts.append("積読進捗 \(current)/\(latest)話")
+        }
         if let rating = personalRating { parts.append("評価 \(rating)つ星") }
         if !isRead { parts.append("未読") }
         if showsNextUpdateBadge,

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -198,6 +198,7 @@ final class MangaViewModel {
         if entry.isFocused { s += 5 }
         if entry.currentEpisode != nil { s += 3 }
         if entry.personalRating != nil { s += 3 }
+        if entry.latestEpisode != nil { s += 2 }
         if entry.imageData != nil { s += 2 }
         if entry.episodeLabel != nil { s += 1 }
         if entry.nextExpectedUpdate != nil { s += 1 }
@@ -401,7 +402,7 @@ final class MangaViewModel {
         save()
     }
 
-    func addEntry(name: String, url: String, days: Set<DayOfWeek>, iconColor: String, publisher: String = "", imageData: Data? = nil, updateIntervalWeeks: Int = 1, nextExpectedUpdate: Date? = nil, publicationStatus: PublicationStatus = .active, readingState: ReadingState = .following, isOneShot: Bool = false, memo: String = "", currentEpisode: Int? = nil, episodeLabel: String? = nil, personalRating: Int? = nil) {
+    func addEntry(name: String, url: String, days: Set<DayOfWeek>, iconColor: String, publisher: String = "", imageData: Data? = nil, updateIntervalWeeks: Int = 1, nextExpectedUpdate: Date? = nil, publicationStatus: PublicationStatus = .active, readingState: ReadingState = .following, isOneShot: Bool = false, memo: String = "", currentEpisode: Int? = nil, episodeLabel: String? = nil, personalRating: Int? = nil, latestEpisode: Int? = nil) {
         for day in days {
             // 同一URL + 同一曜日の重複登録を防止（状態問わず全エントリ対象）
             if allEntries().contains(where: { $0.dayOfWeek == day && $0.url == url }) { continue }
@@ -429,6 +430,7 @@ final class MangaViewModel {
             entry.currentEpisode = currentEpisode
             entry.episodeLabel = episodeLabel
             entry.personalRating = personalRating.map { max(1, min(5, $0)) }
+            entry.latestEpisode = latestEpisode.map { max(1, $0) }
             modelContext.insert(entry)
         }
         save()
@@ -451,6 +453,7 @@ final class MangaViewModel {
         currentEpisode: Int? = nil,
         episodeLabel: String? = nil,
         personalRating: Int? = nil,
+        latestEpisode: Int? = nil,
         markAsReadOnSave: Bool = false
     ) {
         // URL または曜日が変更された場合、同一URL+曜日の重複を防止
@@ -488,6 +491,7 @@ final class MangaViewModel {
         entry.currentEpisode = currentEpisode
         entry.episodeLabel = episodeLabel
         entry.personalRating = personalRating.map { max(1, min(5, $0)) }
+        entry.latestEpisode = latestEpisode.map { max(1, $0) }
 
         // 「保存時に既読にする」を同一トランザクション内で処理し、save() を1回に統合
         if markAsReadOnSave, entry.modelContext != nil {
@@ -970,6 +974,7 @@ final class MangaViewModel {
             entry.episodeLabel = backupEntry.episodeLabel
             entry.isHidden = backupEntry.isHidden ?? false
             entry.personalRating = backupEntry.personalRating.map { max(1, min(5, $0)) }
+            entry.latestEpisode = backupEntry.latestEpisode.map { max(1, $0) }
             // v6+ バックアップは publicationStatusRawValue / readingStateRawValue を authoritative とする。
             // 両方 nil のときだけ v5 以前の legacy Bool から導出する。
             // 通常 export 側は両方を必ず書くので片方 nil は現実にはほぼ起こらないが、

--- a/MangaLauncher/Views/Entry/EditEntryView.swift
+++ b/MangaLauncher/Views/Entry/EditEntryView.swift
@@ -37,6 +37,8 @@ struct EditEntryView: View {
     @State private var episodeLabel: String = ""
     @State private var markAsReadOnSave: Bool = false
     @State private var personalRating: Int?
+    @State private var latestEpisode: Int?
+    @State private var latestEpisodeText: String = ""
     @State private var editingLink: MangaLink?
     @State private var showingAddLink = false
 
@@ -417,6 +419,32 @@ struct EditEntryView: View {
                 }
             }
             HStack {
+                Text("最新話数")
+                Spacer()
+                TextField("未設定", text: $latestEpisodeText)
+                    #if os(iOS) || os(visionOS)
+                    .keyboardType(.numberPad)
+                    #endif
+                    .multilineTextAlignment(.trailing)
+                    .onChange(of: latestEpisodeText) { _, newValue in
+                        if newValue.isEmpty {
+                            latestEpisode = nil
+                        } else if let val = Int(newValue), val > 0 {
+                            latestEpisode = val
+                        }
+                    }
+                if latestEpisode != nil {
+                    Button {
+                        latestEpisode = nil
+                        latestEpisodeText = ""
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            HStack {
                 Text("ラベル")
                 Spacer()
                 TextField("おまけ、1.5話 など", text: $episodeLabel)
@@ -432,7 +460,7 @@ struct EditEntryView: View {
         } header: {
             Text("話数")
         } footer: {
-            Text("読んだ話数を記録します。「保存時に既読にする」をオンにすると、保存と同時に読書記録が作成されます。")
+            Text("読んだ話数を記録します。最新話数を設定すると積読の進捗が表示されます。「保存時に既読にする」をオンにすると、保存と同時に読書記録が作成されます。")
         }
     }
 
@@ -595,6 +623,8 @@ struct EditEntryView: View {
             currentEpisode = entry.currentEpisode
             episodeText = entry.currentEpisode.map { String($0) } ?? ""
             episodeLabel = entry.episodeLabel ?? ""
+            latestEpisode = entry.latestEpisode
+            latestEpisodeText = entry.latestEpisode.map { String($0) } ?? ""
             personalRating = entry.personalRating
             didLoadEntry = true
         } else if entry == nil, !didLoadEntry {
@@ -646,6 +676,7 @@ struct EditEntryView: View {
                 currentEpisode: currentEpisode,
                 episodeLabel: labelToSave,
                 personalRating: personalRating,
+                latestEpisode: latestEpisode,
                 markAsReadOnSave: markAsReadOnSave
             )
         } else {
@@ -664,7 +695,8 @@ struct EditEntryView: View {
                 memo: memo,
                 currentEpisode: currentEpisode,
                 episodeLabel: labelToSave,
-                personalRating: personalRating
+                personalRating: personalRating,
+                latestEpisode: latestEpisode
             )
         }
     }

--- a/MangaLauncher/Views/Library/LibraryCard.swift
+++ b/MangaLauncher/Views/Library/LibraryCard.swift
@@ -67,6 +67,10 @@ struct LibraryCard: View {
                     StarRatingView(rating: entry.personalRating, size: 9)
                         .frame(width: cardWidth, alignment: .leading)
                 }
+                if entry.showsBacklogProgress {
+                    BacklogProgressView(entry: entry, fontSize: 9, barHeight: 3)
+                        .frame(width: cardWidth, alignment: .leading)
+                }
             }
         }
         .buttonStyle(.plain)

--- a/MangaLauncher/Views/MangaCell/MangaGridCell.swift
+++ b/MangaLauncher/Views/MangaCell/MangaGridCell.swift
@@ -79,6 +79,9 @@ struct MangaGridCell: View {
                         if entry.personalRating != nil {
                             StarRatingView(rating: entry.personalRating, size: 8)
                         }
+                        if entry.showsBacklogProgress {
+                            BacklogProgressView(entry: entry, fontSize: 8, barHeight: 2)
+                        }
                     }
                     Spacer(minLength: 0)
                 }

--- a/MangaLauncher/Views/MangaCell/MangaRowCell.swift
+++ b/MangaLauncher/Views/MangaCell/MangaRowCell.swift
@@ -79,6 +79,10 @@ struct MangaRowCell: View {
                     if entry.personalRating != nil {
                         StarRatingView(rating: entry.personalRating, size: 10)
                     }
+                    if entry.showsBacklogProgress {
+                        BacklogProgressView(entry: entry, fontSize: 9, barHeight: 2)
+                            .frame(maxWidth: 120)
+                    }
                 }
 
                 Spacer()

--- a/MangaLauncher/Views/Search/SearchResultRow.swift
+++ b/MangaLauncher/Views/Search/SearchResultRow.swift
@@ -45,6 +45,10 @@ struct SearchResultRow: View {
                         if entry.personalRating != nil {
                             StarRatingView(rating: entry.personalRating, size: 9)
                         }
+                        if entry.showsBacklogProgress {
+                            BacklogProgressView(entry: entry, fontSize: 8, barHeight: 2)
+                                .frame(maxWidth: 80)
+                        }
                         if !hasAnyStatus(entry) {
                             dayBadge(entry.dayOfWeek.shortName)
                         }


### PR DESCRIPTION
## Summary
- `MangaEntry` に `latestEpisode: Int?` を追加し、積読マンガの進捗（例: 30 / 150話 + プログレスバー）を表示
- 編集画面に最新話数の入力欄を追加、ライブラリ・セル・検索結果すべてに進捗を表示
- バックアップ v17 対応、VoiceOver 対応

Closes #227

## Test plan
- [ ] 積読マンガの編集画面で話数と最新話数を設定し、進捗が表示されることを確認
- [ ] 積読以外のマンガでは進捗が表示されないことを確認
- [ ] 片方のみ設定（話数のみ / 最新話数のみ）では進捗が表示されないことを確認
- [ ] バックアップのエクスポート/インポートで latestEpisode が保持されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)