### PR TITLE
保存パターンの統一とrefreshCounter二重インクリメント修正

### DIFF
--- a/MangaLauncher/ViewModels/MangaViewModel+Links.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel+Links.swift
@@ -35,7 +35,6 @@ extension MangaViewModel {
     func deleteLink(_ link: MangaLink) {
         modelContext.delete(link)
         save()
-        refreshCounter += 1
     }
 
     func fetchLinks(for entry: MangaEntry) -> [MangaLink] {
@@ -62,6 +61,5 @@ extension MangaViewModel {
             link.sortOrder = index
         }
         save()
-        refreshCounter += 1
     }
 }

--- a/MangaLauncher/ViewModels/MangaViewModel+ReadState.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel+ReadState.swift
@@ -1,10 +1,5 @@
 import Foundation
-import SwiftUI
 import SwiftData
-import NotificationKit
-#if canImport(WidgetKit)
-import WidgetKit
-#endif
 
 // MARK: - Read State, Focused Backlog, Soft Delete
 
@@ -37,16 +32,7 @@ extension MangaViewModel {
         } else {
             entry.personalRating = nil
         }
-        do {
-            if let ctx = entry.modelContext {
-                try ctx.save()
-            } else {
-                try modelContext.save()
-            }
-        } catch {
-            print("[MangaViewModel] setPersonalRating save failed: \(error)")
-        }
-        refreshCounter += 1
+        saveEntryChange(for: entry)
     }
 
     /// 非表示フラグの切り替え
@@ -57,21 +43,7 @@ extension MangaViewModel {
         } else {
             hiddenIDs.remove(entry.id)
         }
-        do {
-            if let ctx = entry.modelContext {
-                try ctx.save()
-            } else {
-                try modelContext.save()
-            }
-        } catch {
-            print("[MangaViewModel] setHidden save failed: \(error)")
-        }
-        refreshCounter += 1
-        #if canImport(WidgetKit)
-        WidgetCenter.shared.reloadAllTimelines()
-        #endif
-        BadgeManager.updateBadge(unreadCount: unreadCount(for: .today))
-        rescheduleNotifications()
+        saveEntryChange(for: entry)
     }
 
     // MARK: Mark Read / Unread


### PR DESCRIPTION
## Summary
- `deleteLink` / `moveLinks` で `save()` 後に冗長な `refreshCounter += 1` をしていたのを削除（`save()` 内部で既にインクリメント済み）
- `setPersonalRating` / `setHidden` のインライン `ctx.save()` を `saveEntryChange(for:)` ヘルパーに統一し、`refresh()` 後の ModelContext 不整合にも安全に対応
- 不要になった import（SwiftUI / NotificationKit / WidgetKit）を ReadState.swift から削除

## Test plan
- [ ] リンクの削除・並び替えが正常に反映されること
- [ ] パーソナル評価の設定・解除が保存されること
- [ ] 非表示の切り替えでウィジェット・バッジ・通知が更新されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)