### PR TITLE
キャッチアップに「残りを全部既読にする」機能を追加

### DIFF
--- a/MangaLauncher/ViewModels/MangaViewModel+ReadState.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel+ReadState.swift
@@ -80,30 +80,43 @@ extension MangaViewModel {
     func markEntriesAsRead(_ entries: [MangaEntry]) {
         guard !entries.isEmpty else { return }
         let today = Calendar.current.startOfDay(for: Date())
+
+        // 今日の既存アクティビティを一括取得（N回 fetch → 1回に最適化）
+        let entryIDs = entries.map(\.id)
+        let existingDescriptor = FetchDescriptor<ReadingActivity>(
+            predicate: #Predicate { $0.date == today }
+        )
+        let existingActivityEntryIDs = Set(
+            modelContext.fetchLogged(existingDescriptor)
+                .filter { entryIDs.contains($0.mangaEntryID) }
+                .map(\.mangaEntryID)
+        )
+
         for entry in entries {
+            let ctx = entry.modelContext ?? modelContext
             entry.lastReadDate = Date()
             if !entry.isOneShot {
                 entry.advanceToNextUpdate()
             }
-            let entryID = entry.id
-            let existingDescriptor = FetchDescriptor<ReadingActivity>(
-                predicate: #Predicate { $0.date == today && $0.mangaEntryID == entryID }
-            )
-            let hasExisting = !modelContext.fetchLogged(existingDescriptor).isEmpty
-            if !hasExisting {
+            // 存在チェックと挿入を同じコンテキストで行う
+            if !existingActivityEntryIDs.contains(entry.id) {
                 let activity = ReadingActivity(
                     date: Date(),
                     mangaName: entry.name,
                     mangaEntryID: entry.id
                 )
-                (entry.modelContext ?? modelContext).insert(activity)
+                ctx.insert(activity)
             }
             if entry.isOneShot {
                 entry.readingState = .archived
             }
         }
-        // entry が複数コンテキストに跨る可能性に備え、先頭エントリのコンテキストを保存
-        if let entryCtx = entries.first?.modelContext, entryCtx !== modelContext {
+        // entry が複数コンテキストに跨る可能性に備え、全ユニークコンテキストを保存
+        var savedContexts = Set<ObjectIdentifier>()
+        for entry in entries {
+            guard let entryCtx = entry.modelContext, entryCtx !== modelContext else { continue }
+            let ctxID = ObjectIdentifier(entryCtx)
+            guard savedContexts.insert(ctxID).inserted else { continue }
             do {
                 try entryCtx.save()
             } catch {

--- a/MangaLauncher/ViewModels/MangaViewModel+ReadState.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel+ReadState.swift
@@ -75,6 +75,46 @@ extension MangaViewModel {
         saveEntryChange(for: entry)
     }
 
+    /// 複数エントリを一括既読にする。save() を1回にまとめてパフォーマンスを最適化。
+    /// CatchUp の「全部既読」で使用。
+    func markEntriesAsRead(_ entries: [MangaEntry]) {
+        guard !entries.isEmpty else { return }
+        let today = Calendar.current.startOfDay(for: Date())
+        for entry in entries {
+            entry.lastReadDate = Date()
+            if !entry.isOneShot {
+                entry.advanceToNextUpdate()
+            }
+            let entryID = entry.id
+            let existingDescriptor = FetchDescriptor<ReadingActivity>(
+                predicate: #Predicate { $0.date == today && $0.mangaEntryID == entryID }
+            )
+            let hasExisting = !modelContext.fetchLogged(existingDescriptor).isEmpty
+            if !hasExisting {
+                let activity = ReadingActivity(
+                    date: Date(),
+                    mangaName: entry.name,
+                    mangaEntryID: entry.id
+                )
+                (entry.modelContext ?? modelContext).insert(activity)
+            }
+            if entry.isOneShot {
+                entry.readingState = .archived
+            }
+        }
+        // entry が複数コンテキストに跨る可能性に備え、先頭エントリのコンテキストを保存
+        if let entryCtx = entries.first?.modelContext, entryCtx !== modelContext {
+            do {
+                try entryCtx.save()
+            } catch {
+                print("[MangaViewModel] markEntriesAsRead entryCtx save failed: \(error)")
+                lastError = .save(error)
+                return
+            }
+        }
+        save()
+    }
+
     func markAsUnread(_ entry: MangaEntry) {
         entry.lastReadDate = nil
         if entry.isOneShot {

--- a/MangaLauncher/Views/CatchUp/CatchUpView.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpView.swift
@@ -27,6 +27,7 @@ struct CatchUpView: View {
     @State private var milestoneAchievement: Int?
     @State private var backgroundGradient: ImageColorExtractor.GradientColors?
     @State private var gradientTask: Task<Void, Never>?
+    @State private var showMarkAllReadAlert = false
 
     private var theme: ThemeStyle { ThemeManager.shared.style }
     private var hasGradient: Bool { backgroundGradient != nil }
@@ -95,6 +96,16 @@ struct CatchUpView: View {
                         }
                     }
                 }
+                if !isCompleted && !unreadItems.isEmpty && remainingCount >= 2 {
+                    ToolbarItem(placement: .automatic) {
+                        Button {
+                            showMarkAllReadAlert = true
+                        } label: {
+                            Image(systemName: "checkmark.circle")
+                        }
+                        .accessibilityLabel("残りを全部既読にする")
+                    }
+                }
             }
         }
         .onAppear {
@@ -139,6 +150,14 @@ struct CatchUpView: View {
             }
         }
         #endif
+        .alert("残りを全部既読にする", isPresented: $showMarkAllReadAlert) {
+            Button("全部既読", role: .destructive) {
+                markAllRemainingAsRead()
+            }
+            Button("キャンセル", role: .cancel) {}
+        } message: {
+            Text("残り \(remainingCount) 件を既読にします。この操作は「元に戻す」で取り消せます。")
+        }
         .gesture(dismissDragGesture, including: isCompleted || unreadItems.isEmpty ? .all : .subviews)
         .preferredColorScheme(hasGradient ? .dark : theme.resolvedColorScheme(system: systemColorScheme))
     }
@@ -334,6 +353,19 @@ struct CatchUpView: View {
 
         currentIndex -= 1
         offset = .zero
+    }
+
+    /// 残りの未読エントリをすべて既読にする。
+    /// 各エントリを undoStack に積むので、完了後に undo で個別に戻せる。
+    private func markAllRemainingAsRead() {
+        guard currentIndex < unreadItems.count else { return }
+        for i in currentIndex..<unreadItems.count {
+            let entry = unreadItems[i]
+            undoStack.append((entry: entry, action: .read))
+            viewModel.markAsRead(entry)
+        }
+        offset = .zero
+        currentIndex = unreadItems.count
     }
 
     // MARK: - Completed View

--- a/MangaLauncher/Views/CatchUp/CatchUpView.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpView.swift
@@ -357,13 +357,14 @@ struct CatchUpView: View {
 
     /// 残りの未読エントリをすべて既読にする。
     /// 各エントリを undoStack に積むので、完了後に undo で個別に戻せる。
+    /// バッチ版 `markEntriesAsRead` を使い、save() を1回にまとめる。
     private func markAllRemainingAsRead() {
         guard currentIndex < unreadItems.count else { return }
-        for i in currentIndex..<unreadItems.count {
-            let entry = unreadItems[i]
+        let remaining = Array(unreadItems[currentIndex...])
+        for entry in remaining {
             undoStack.append((entry: entry, action: .read))
-            viewModel.markAsRead(entry)
         }
+        viewModel.markEntriesAsRead(remaining)
         offset = .zero
         currentIndex = unreadItems.count
     }


### PR DESCRIPTION
## Summary
- キャッチアップ画面のツールバーに「全部既読」ボタン（☑）を追加
- 残り2件以上のときに表示。タップで確認アラート → 一括既読
- 各エントリを undoStack に積むので、完了画面の「元に戻す」ボタンで個別に取り消し可能
- ストリーク / マイルストーン実績も通常通り判定される

## Test plan
- [ ] 未読が3件以上ある状態でキャッチアップを開き、ツールバーの☑ボタンが表示されること
- [ ] ボタンタップで確認アラートが出ること
- [ ] 「全部既読」を実行すると残り全件が既読になり、完了画面に遷移すること
- [ ] 完了画面で「元に戻す」ボタンが表示され、undo で1件ずつ既読解除できること
- [ ] 残り1件のときはボタンが非表示であること（通常のスワイプで十分）
- [ ] 曜日指定・掲載誌フィルター付きキャッチアップでも正常動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)