### PR TITLE
コンテキストメニューに「リンクをコピー」を追加

### DIFF
--- a/MangaLauncher/Views/MangaCell/MangaContextMenu.swift
+++ b/MangaLauncher/Views/MangaCell/MangaContextMenu.swift
@@ -1,4 +1,7 @@
 import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#endif
 
 struct MangaContextMenu: View {
     let entry: MangaEntry
@@ -109,7 +112,11 @@ struct MangaContextMenu: View {
 
         #if canImport(UIKit)
         Button {
-            UIPasteboard.general.string = entry.url
+            if let url = URL(string: entry.url) {
+                UIPasteboard.general.url = url
+            } else {
+                UIPasteboard.general.string = entry.url
+            }
         } label: {
             Label("リンクをコピー", systemImage: "doc.on.doc")
         }

--- a/MangaLauncher/Views/MangaCell/MangaContextMenu.swift
+++ b/MangaLauncher/Views/MangaCell/MangaContextMenu.swift
@@ -107,6 +107,14 @@ struct MangaContextMenu: View {
             }
         }
 
+        #if canImport(UIKit)
+        Button {
+            UIPasteboard.general.string = entry.url
+        } label: {
+            Label("リンクをコピー", systemImage: "doc.on.doc")
+        }
+        #endif
+
         if let onShowLifetime {
             Button {
                 onShowLifetime()


### PR DESCRIPTION
## Summary
- マンガの長押しコンテキストメニューに「リンクをコピー」ボタンを追加
- `UIPasteboard.general.string` でURLをクリップボードにコピー
- `#if canImport(UIKit)` で iOS 環境のみ有効（visionOS等ではコンパイルから除外）

## 変更ファイル
- `MangaContextMenu.swift` — 関連リンクメニューの直後に配置

## Test plan
- [ ] マンガを長押し → コンテキストメニューに「リンクをコピー」が表示される
- [ ] タップするとクリップボードにURLがコピーされる
- [ ] 他アプリでペーストしてURLが正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)