### PR TITLE
マジックナンバーを名前付き定数に抽出

### DIFF
--- a/MangaLauncher/Models/MangaEntry.swift
+++ b/MangaLauncher/Models/MangaEntry.swift
@@ -108,6 +108,7 @@ final class MangaEntry {
     /// ソフトデリート日時（nil = 未削除）
     var deletedAt: Date?
     /// パーソナル評価 (1〜5)。nil は未評価。
+    /// 有効範囲は `MangaEntry.ratingRange` で定義。
     var personalRating: Int?
     /// 最新話数。nil は未設定。積読の進捗表示に使用。
     var latestEpisode: Int?
@@ -127,6 +128,17 @@ final class MangaEntry {
     var isOnHiatus: Bool = false
     var isCompleted: Bool = false
     var isBacklog: Bool = false
+
+    // MARK: - Rating
+
+    /// パーソナル評価の有効範囲。
+    static let ratingRange = 1...5
+
+    /// 値を有効範囲にクランプして返す。nil はそのまま nil。
+    static func clampedRating(_ value: Int?) -> Int? {
+        guard let v = value else { return nil }
+        return max(ratingRange.lowerBound, min(ratingRange.upperBound, v))
+    }
 
     /// 読み切りのときに不整合な状態 (hiatus/finished、backlog) を矯正する。
     /// ViewModel の addEntry / updateEntry から呼ばれる。

--- a/MangaLauncher/ViewModels/MangaViewModel+Backup.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel+Backup.swift
@@ -67,7 +67,7 @@ extension MangaViewModel {
             entry.currentEpisode = backupEntry.currentEpisode
             entry.episodeLabel = backupEntry.episodeLabel
             entry.isHidden = backupEntry.isHidden ?? false
-            entry.personalRating = backupEntry.personalRating.map { max(1, min(5, $0)) }
+            entry.personalRating = MangaEntry.clampedRating(backupEntry.personalRating)
             entry.latestEpisode = backupEntry.latestEpisode.map { max(1, $0) }
             if backupEntry.publicationStatusRawValue != nil || backupEntry.readingStateRawValue != nil {
                 entry.publicationStatusRawValue = backupEntry.publicationStatusRawValue

--- a/MangaLauncher/ViewModels/MangaViewModel+CRUD.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel+CRUD.swift
@@ -37,7 +37,7 @@ extension MangaViewModel {
             }
             entry.currentEpisode = currentEpisode
             entry.episodeLabel = episodeLabel
-            entry.personalRating = personalRating.map { max(1, min(5, $0)) }
+            entry.personalRating = MangaEntry.clampedRating(personalRating)
             entry.latestEpisode = latestEpisode.map { max(1, $0) }
             modelContext.insert(entry)
         }
@@ -98,7 +98,7 @@ extension MangaViewModel {
         }
         entry.currentEpisode = currentEpisode
         entry.episodeLabel = episodeLabel
-        entry.personalRating = personalRating.map { max(1, min(5, $0)) }
+        entry.personalRating = MangaEntry.clampedRating(personalRating)
         entry.latestEpisode = latestEpisode.map { max(1, $0) }
 
         // 「保存時に既読にする」を同一トランザクション内で処理し、save() を1回に統合

--- a/MangaLauncher/ViewModels/MangaViewModel+ReadState.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel+ReadState.swift
@@ -27,11 +27,7 @@ extension MangaViewModel {
 
     /// パーソナル評価を設定する。nil で評価解除。
     func setPersonalRating(_ entry: MangaEntry, to rating: Int?) {
-        if let r = rating {
-            entry.personalRating = max(1, min(5, r))
-        } else {
-            entry.personalRating = nil
-        }
+        entry.personalRating = MangaEntry.clampedRating(rating)
         saveEntryChange(for: entry)
     }
 

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -265,9 +265,12 @@ final class MangaViewModel {
 
     // MARK: - Delete Timer (internal)
 
+    /// Undo 猶予時間（秒）。この間に「元に戻す」が押されなければ確定削除する。
+    static let undoGracePeriod: TimeInterval = 5.0
+
     func restartDeleteTimer() {
         deleteTimer?.invalidate()
-        deleteTimer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: false) { [weak self] _ in
+        deleteTimer = Timer.scheduledTimer(withTimeInterval: Self.undoGracePeriod, repeats: false) { [weak self] _ in
             Task { @MainActor in
                 self?.commitPendingDeletes()
             }
@@ -276,7 +279,7 @@ final class MangaViewModel {
 
     func restartCommentDeleteTimer() {
         commentDeleteTimer?.invalidate()
-        commentDeleteTimer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: false) { [weak self] _ in
+        commentDeleteTimer = Timer.scheduledTimer(withTimeInterval: Self.undoGracePeriod, repeats: false) { [weak self] _ in
             Task { @MainActor in
                 self?.commitPendingCommentDeletes()
             }


### PR DESCRIPTION
## Summary
- 評価クランプ `max(1, min(5, ...))` を `MangaEntry.clampedRating()` に集約（4箇所の重複を解消）
- 削除タイマーの `5.0` 秒を `MangaViewModel.undoGracePeriod` に定数化（2箇所の重複を解消）

## 変更ファイル
| ファイル | 変更内容 |
|---------|---------|
| `MangaEntry.swift` | `ratingRange` 定数 + `clampedRating()` メソッド追加 |
| `MangaViewModel+ReadState.swift` | `setPersonalRating` でクランプメソッド使用 |
| `MangaViewModel+CRUD.swift` | `addEntry` / `updateEntry` でクランプメソッド使用 |
| `MangaViewModel+Backup.swift` | `importBackupData` でクランプメソッド使用 |
| `MangaViewModel.swift` | `undoGracePeriod` 定数追加 + タイマーで参照 |

## Test plan
- [ ] 評価の設定・変更が 1〜5 の範囲で正常に動作する
- [ ] 評価を nil にリセットできる
- [ ] 削除操作後、Undo 猶予時間内に「元に戻す」が機能する
- [ ] バックアップインポート時に評価値が正しくクランプされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)