### PR TITLE
force unwrapとunsafeな配列アクセスを安全なパターンに修正

### DIFF
--- a/MangaLauncher/ViewModels/MangaViewModel+Publisher.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel+Publisher.swift
@@ -55,6 +55,8 @@ extension MangaViewModel {
     /// 指定 publisher にアイコンが設定されているか。
     func publisherHasIcon(name: String) -> Bool {
         guard !name.isEmpty else { return false }
+        // loadAllPublisherIcons() は [String: Data?] なので添字は Data?? を返す。
+        // ?? nil で Data? にフラット化し、実際に iconData がある場合のみ true にする。
         return (loadAllPublisherIcons()[name] ?? nil) != nil
     }
 

--- a/MangaLauncher/Views/Heatmap/MangaLifetimeView.swift
+++ b/MangaLauncher/Views/Heatmap/MangaLifetimeView.swift
@@ -217,11 +217,15 @@ struct MangaLifetimeView: View {
     private func monthBoundaries() -> [Date] {
         let calendar = Calendar.current
         var result: [Date] = []
-        var comps = calendar.dateComponents([.year, .month], from: domainStart)
-        comps.month = (comps.month ?? 0) + 1
-        while let date = calendar.date(from: comps), date < domainEnd {
-            result.append(date)
-            comps.month = (comps.month ?? 0) + 1
+        // domainStart の翌月1日を起点に、domainEnd まで1か月ずつ列挙
+        guard let firstOfNextMonth = calendar.date(byAdding: .month, value: 1,
+                                                    to: calendar.dateInterval(of: .month, for: domainStart)?.start ?? domainStart)
+        else { return result }
+        var cursor = firstOfNextMonth
+        while cursor < domainEnd {
+            result.append(cursor)
+            guard let next = calendar.date(byAdding: .month, value: 1, to: cursor) else { break }
+            cursor = next
         }
         return result
     }

--- a/MangaLauncher/Views/Heatmap/MangaLifetimeView.swift
+++ b/MangaLauncher/Views/Heatmap/MangaLifetimeView.swift
@@ -218,10 +218,10 @@ struct MangaLifetimeView: View {
         let calendar = Calendar.current
         var result: [Date] = []
         var comps = calendar.dateComponents([.year, .month], from: domainStart)
-        comps.month! += 1
+        comps.month = (comps.month ?? 0) + 1
         while let date = calendar.date(from: comps), date < domainEnd {
             result.append(date)
-            comps.month! += 1
+            comps.month = (comps.month ?? 0) + 1
         }
         return result
     }

--- a/MangaLauncher/Views/Heatmap/ReadingHeatmapView.swift
+++ b/MangaLauncher/Views/Heatmap/ReadingHeatmapView.swift
@@ -111,7 +111,7 @@ struct ReadingHeatmapView: View {
                         // Month labels
                         HStack(spacing: cellSpacing) {
                             ForEach(0..<weeks, id: \.self) { weekIndex in
-                                let date = grid[weekIndex][0]
+                                let date = grid[weekIndex].first ?? nil
                                 if let date, isFirstWeekOfMonth(date: date, weekIndex: weekIndex, grid: grid) {
                                     Text(monthLabel(for: date))
                                         .font(theme.caption2Font)
@@ -252,7 +252,7 @@ struct ReadingHeatmapView: View {
         let calendar = Calendar.current
         let month = calendar.component(.month, from: date)
         if weekIndex == 0 { return true }
-        guard let prevDate = grid[weekIndex - 1][0] else { return true }
+        guard let prevDate = grid[weekIndex - 1].first ?? nil else { return true }
         return calendar.component(.month, from: prevDate) != month
     }
 

--- a/MangaLauncher/Views/Heatmap/ReadingHeatmapView.swift
+++ b/MangaLauncher/Views/Heatmap/ReadingHeatmapView.swift
@@ -111,7 +111,7 @@ struct ReadingHeatmapView: View {
                         // Month labels
                         HStack(spacing: cellSpacing) {
                             ForEach(0..<weeks, id: \.self) { weekIndex in
-                                let date = grid[weekIndex].first ?? nil
+                                let date = grid[weekIndex].first.flatMap { $0 }
                                 if let date, isFirstWeekOfMonth(date: date, weekIndex: weekIndex, grid: grid) {
                                     Text(monthLabel(for: date))
                                         .font(theme.caption2Font)
@@ -252,7 +252,7 @@ struct ReadingHeatmapView: View {
         let calendar = Calendar.current
         let month = calendar.component(.month, from: date)
         if weekIndex == 0 { return true }
-        guard let prevDate = grid[weekIndex - 1].first ?? nil else { return true }
+        guard let prevDate = grid[weekIndex - 1].first.flatMap({ $0 }) else { return true }
         return calendar.component(.month, from: prevDate) != month
     }
 

--- a/MangaLauncher/Views/Library/AllPublishersView.swift
+++ b/MangaLauncher/Views/Library/AllPublishersView.swift
@@ -166,8 +166,9 @@ struct PublisherEntriesView: View {
         #if os(iOS) || os(visionOS)
         .navigationBarTitleDisplayMode(.inline)
         #endif
-        .if(specialEpisodeEntry != nil || !entries.isEmpty) { view in
-            view.specialEpisodeAlert(entry: specialEpisodeEntry ?? entries[0], viewModel: viewModel, isPresented: $showSpecialEpisodeAlert)
+        .if((specialEpisodeEntry ?? entries.first) != nil) { view in
+            // 条件により specialEpisodeEntry ?? entries.first は必ず non-nil
+            view.specialEpisodeAlert(entry: (specialEpisodeEntry ?? entries.first)!, viewModel: viewModel, isPresented: $showSpecialEpisodeAlert)
         }
     }
 }

--- a/MangaWidget/MangaWidget.swift
+++ b/MangaWidget/MangaWidget.swift
@@ -350,8 +350,13 @@ struct MangaWidgetEntryView: View {
 
     // MARK: - Grid Cell
 
+    private static func deepLink(for item: MangaWidgetItem) -> URL {
+        URL(string: "mangalauncher://open?id=\(item.id.uuidString)")
+            ?? URL(string: "mangalauncher://")!
+    }
+
     private func gridCell(item: MangaWidgetItem, size: CGFloat) -> some View {
-        Link(destination: URL(string: "mangalauncher://open?id=\(item.id.uuidString)")!) {
+        Link(destination: Self.deepLink(for: item)) {
             Group {
                 if let imageData = item.imageData, let image = imageData.toSwiftUIImage() {
                     image

--- a/MangaWidget/MangaWidget.swift
+++ b/MangaWidget/MangaWidget.swift
@@ -350,9 +350,10 @@ struct MangaWidgetEntryView: View {
 
     // MARK: - Grid Cell
 
+    private static let fallbackURL = URL(string: "mangalauncher://")!
+
     private static func deepLink(for item: MangaWidgetItem) -> URL {
-        URL(string: "mangalauncher://open?id=\(item.id.uuidString)")
-            ?? URL(string: "mangalauncher://")!
+        URL(string: "mangalauncher://open?id=\(item.id.uuidString)") ?? fallbackURL
     }
 
     private func gridCell(item: MangaWidgetItem, size: CGFloat) -> some View {


### PR DESCRIPTION
## Summary
- `MangaLifetimeView`: `comps.month!` の force unwrap を `(comps.month ?? 0) + 1` に変更
- `ReadingHeatmapView`: `grid[weekIndex][0]` を `.first ?? nil` に変更し、空配列でのクラッシュを防止
- `AllPublishersView`: `.if` の条件を force unwrap 対象の式と直接対応させ、安全性を明確化
- `MangaWidget`: deep link URL 生成を `static` メソッドに抽出し、フォールバック URL を追加
- `MangaViewModel+Publisher`: 二重 Optional の `?? nil` が必要な理由をコメントで説明

## Test plan
- [ ] ライフタイム画面で月境界ラベルが正しく表示されること
- [ ] ヒートマップの月ラベルが正しく表示されること
- [ ] 掲載誌詳細画面でエピソードアラートが正常動作すること
- [ ] ウィジェットのグリッドセルタップでアプリが正しく開くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)