### PR TITLE
アイコンボタンに accessibilityLabel を追加

### DIFF
--- a/MangaLauncher/Views/CatchUp/CatchUpView.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpView.swift
@@ -94,6 +94,7 @@ struct CatchUpView: View {
                         } label: {
                             Image(systemName: "arrow.uturn.backward")
                         }
+                        .accessibilityLabel("元に戻す")
                     }
                 }
                 if !isCompleted && !unreadItems.isEmpty && remainingCount >= 2 {

--- a/MangaLauncher/Views/Common/SafariView.swift
+++ b/MangaLauncher/Views/Common/SafariView.swift
@@ -162,6 +162,7 @@ struct QuickViewBrowserScreen: View {
                     .background(.black.opacity(0.85))
                     .clipShape(Circle())
             }
+            .accessibilityLabel("閉じる")
 
             Spacer()
 
@@ -195,6 +196,7 @@ struct QuickViewBrowserScreen: View {
                 .background(.black.opacity(0.85))
                 .clipShape(Capsule())
             }
+            .accessibilityLabel("メニュー")
 
             Spacer()
 
@@ -206,6 +208,7 @@ struct QuickViewBrowserScreen: View {
                     .background(.black.opacity(0.85))
                     .clipShape(Circle())
             }
+            .accessibilityLabel("再読み込み")
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 6)

--- a/MangaLauncher/Views/Heatmap/ReadingHeatmapView.swift
+++ b/MangaLauncher/Views/Heatmap/ReadingHeatmapView.swift
@@ -370,6 +370,7 @@ private struct DayActivitySheet: View {
                 Image(systemName: "chevron.left")
                     .font(.body.weight(.semibold))
             }
+            .accessibilityLabel("前の日")
 
             Spacer()
 
@@ -389,6 +390,7 @@ private struct DayActivitySheet: View {
                 Image(systemName: "chevron.right")
                     .font(.body.weight(.semibold))
             }
+            .accessibilityLabel("次の日")
             .disabled(Calendar.current.isDateInToday(currentDate))
         }
         .padding(.horizontal)

--- a/MangaLauncher/Views/Home/ContentToolbar.swift
+++ b/MangaLauncher/Views/Home/ContentToolbar.swift
@@ -37,6 +37,7 @@ struct ContentToolbar: ToolbarContent {
                     }
                 }
             }
+            .accessibilityLabel("キャッチアップ、未読\(unreadCount)件")
             .disabled(unreadCount == 0 || edit.isEditing)
         }
         ToolbarItem(placement: .automatic) {
@@ -45,6 +46,7 @@ struct ContentToolbar: ToolbarContent {
             } label: {
                 Image(systemName: displayMode == .list ? "square.grid.2x2" : "list.bullet")
             }
+            .accessibilityLabel(displayMode == .list ? "グリッド表示に切り替え" : "リスト表示に切り替え")
             .disabled(showingWallpaperPicker)
         }
         ToolbarItem(placement: .automatic) {
@@ -53,6 +55,7 @@ struct ContentToolbar: ToolbarContent {
             } label: {
                 Image(systemName: "plus")
             }
+            .accessibilityLabel("マンガを追加")
             .disabled(edit.isEditing)
         }
     }


### PR DESCRIPTION
## Summary
- `ContentToolbar`: キャッチアップ・表示切替・追加ボタンに accessibilityLabel を追加
- `CatchUpView`: 「元に戻す」ボタンに accessibilityLabel を追加
- `SafariView`: 閉じる・メニュー・再読み込みボタンに accessibilityLabel を追加
- `ReadingHeatmapView`: 前の日・次の日ボタンに accessibilityLabel を追加

Closes #237

## Test plan
- [ ] VoiceOverを有効にして各画面のボタンが正しく読み上げられること
- [ ] ContentToolbarのキャッチアップボタンが未読件数を含めて読み上げること
- [ ] 表示切替ボタンが現在の状態に応じたラベルになること

🤖 Generated with [Claude Code](https://claude.com/claude-code)