### PR TITLE
EditEntryView にスクロールでキーボードを閉じる機能を追加

### DIFF
--- a/MangaLauncher/Views/Entry/EditEntryView.swift
+++ b/MangaLauncher/Views/Entry/EditEntryView.swift
@@ -165,6 +165,7 @@ struct EditEntryView: View {
                     deleteSection
                 }
             }
+            .scrollDismissesKeyboard(.interactively)
             .themedNavigationStyle()
             .navigationTitle(isEditing ? "編集" : "新規登録")
             #if os(iOS) || os(visionOS)


### PR DESCRIPTION
## Summary
- EditEntryView の Form に `.scrollDismissesKeyboard(.interactively)` を追加
- スクロール操作でキーボードが段階的に閉じるようになり、テキスト入力時のUXが向上

Closes #238

## Test plan
- [ ] 新規登録/編集画面でテキストフィールドにフォーカスした状態でスクロールするとキーボードが閉じること
- [ ] `.interactively` により、スクロール量に応じてキーボードが段階的に消えること

🤖 Generated with [Claude Code](https://claude.com/claude-code)