### PR TITLE
CloudSyncKitのエラーハンドリング改善とHomeStateのactor分離を強化

### DIFF
--- a/MangaLauncher/ViewModels/HomeState.swift
+++ b/MangaLauncher/ViewModels/HomeState.swift
@@ -23,6 +23,7 @@ final class HomeState {
 }
 
 @Observable
+@MainActor
 final class PagingState {
     /// 初期値を今日の曜日に合わせることで、onAppear での pageIndex 変更による
     /// 不要なタブアニメーションを防止する。
@@ -57,6 +58,7 @@ final class PagingState {
 }
 
 @Observable
+@MainActor
 final class EditState {
     var isGridEditMode = false
     #if os(iOS) || os(visionOS)
@@ -82,6 +84,7 @@ final class EditState {
 }
 
 @Observable
+@MainActor
 final class WallpaperState {
     static let shared = WallpaperState()
 
@@ -112,6 +115,7 @@ final class WallpaperState {
 }
 
 @Observable
+@MainActor
 final class SheetState {
     var showingAddSheet = false
     var showingCatchUp = false

--- a/Packages/CloudSyncKit/Sources/CloudSyncKit/CloudSyncKit.swift
+++ b/Packages/CloudSyncKit/Sources/CloudSyncKit/CloudSyncKit.swift
@@ -1,6 +1,8 @@
 import Foundation
-import CoreData
 import Observation
+#if canImport(CloudKit)
+import CloudKit
+#endif
 
 public enum CloudSyncStatus: Equatable {
     case idle
@@ -89,12 +91,10 @@ public final class CloudSyncMonitor {
                         syncStatus = .notAvailable
                     }
                 }
-            } catch {}
+            } catch {
+                print("[CloudSyncKit] Failed to check account status: \(error)")
+            }
         }
         #endif
     }
 }
-
-#if canImport(CloudKit)
-import CloudKit
-#endif


### PR DESCRIPTION
## Summary
- `CloudSyncKit`: 空の `catch {}` にエラーログ出力を追加し、CloudKit認証失敗を可視化
- `CloudSyncKit`: 未使用の `import CoreData` を削除、`import CloudKit` をファイル先頭に移動
- `HomeState`: `PagingState` / `EditState` / `WallpaperState` / `SheetState` に `@MainActor` を追加し、actor分離を親クラスと統一

Closes #239
Closes #241

## Test plan
- [ ] アプリ起動時にCloudKit認証エラーが発生した場合、コンソールにログが出力されること
- [ ] 各画面の操作（タブ切替、編集、壁紙、シート）が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)