### PR TITLE
ハードコードされたUserDefaultsキーを定数化

### DIFF
--- a/MangaLauncher/Shared/DesignSystem.swift
+++ b/MangaLauncher/Shared/DesignSystem.swift
@@ -269,12 +269,14 @@ extension ThemeStyle {
 final class ThemeManager {
     static let shared = ThemeManager()
 
+    private static let themeKey = "appTheme"
+
     var mode: ThemeMode {
-        didSet { UserDefaults.standard.set(mode.rawValue, forKey: "appTheme") }
+        didSet { UserDefaults.standard.set(mode.rawValue, forKey: Self.themeKey) }
     }
 
     private init() {
-        self.mode = ThemeMode(rawValue: UserDefaults.standard.string(forKey: "appTheme") ?? "classic") ?? .classic
+        self.mode = ThemeMode(rawValue: UserDefaults.standard.string(forKey: Self.themeKey) ?? "classic") ?? .classic
     }
 
     var style: ThemeStyle { mode.style }

--- a/Packages/WallpaperKit/Sources/WallpaperKit/WallpaperManager.swift
+++ b/Packages/WallpaperKit/Sources/WallpaperKit/WallpaperManager.swift
@@ -10,6 +10,9 @@ public enum WallpaperManager {
     private static let typeKey = "wallpaperType"
     private static let colorKey = "wallpaperColor"
     private static let customColorKey = "wallpaperCustomColor"
+    private static let cropScaleKey = "wallpaperCropScale"
+    private static let cropOffsetXKey = "wallpaperCropOffsetX"
+    private static let cropOffsetYKey = "wallpaperCropOffsetY"
     private static let imageFileName = "wallpaper.jpg"
     private static let originalImageFileName = "wallpaper_original.jpg"
 
@@ -29,18 +32,18 @@ public enum WallpaperManager {
     }
 
     public static var cropScale: CGFloat {
-        get { CGFloat(UserDefaults.standard.double(forKey: "wallpaperCropScale").nonZeroOrDefault(1.0)) }
-        set { UserDefaults.standard.set(Double(newValue), forKey: "wallpaperCropScale") }
+        get { CGFloat(UserDefaults.standard.double(forKey: cropScaleKey).nonZeroOrDefault(1.0)) }
+        set { UserDefaults.standard.set(Double(newValue), forKey: cropScaleKey) }
     }
 
     public static var cropOffsetX: CGFloat {
-        get { CGFloat(UserDefaults.standard.double(forKey: "wallpaperCropOffsetX")) }
-        set { UserDefaults.standard.set(Double(newValue), forKey: "wallpaperCropOffsetX") }
+        get { CGFloat(UserDefaults.standard.double(forKey: cropOffsetXKey)) }
+        set { UserDefaults.standard.set(Double(newValue), forKey: cropOffsetXKey) }
     }
 
     public static var cropOffsetY: CGFloat {
-        get { CGFloat(UserDefaults.standard.double(forKey: "wallpaperCropOffsetY")) }
-        set { UserDefaults.standard.set(Double(newValue), forKey: "wallpaperCropOffsetY") }
+        get { CGFloat(UserDefaults.standard.double(forKey: cropOffsetYKey)) }
+        set { UserDefaults.standard.set(Double(newValue), forKey: cropOffsetYKey) }
     }
 
     public static func saveImage(_ data: Data) {


### PR DESCRIPTION
## Summary
- `WallpaperManager`: `cropScale` / `cropOffsetX` / `cropOffsetY` のハードコードキーを `static let` に抽出
- `DesignSystem`: `"appTheme"` を `ThemeManager.themeKey` に抽出

Closes #240

## Test plan
- [ ] 壁紙設定（色・画像・クロップ）が正常に保存・読み込みされること
- [ ] テーマ切替（classic/ink/retro）が正常に保存・復元されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)