### PR TITLE
不要なフェッチ・計算の削減とforce unwrapの安全化

### DIFF
--- a/MangaLauncher/ViewModels/MangaViewModel+CRUD.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel+CRUD.swift
@@ -161,11 +161,12 @@ extension MangaViewModel {
 
     func incrementEpisode(_ entry: MangaEntry) {
         let newEpisode = (entry.currentEpisode ?? 0) + 1
+        let now = Date()
         entry.currentEpisode = newEpisode
         entry.episodeLabel = nil
-        entry.lastReadDate = Date()
+        entry.lastReadDate = now
         let activity = ReadingActivity(
-            date: Date(),
+            date: now,
             mangaName: entry.name,
             mangaEntryID: entry.id,
             episodeNumber: newEpisode

--- a/MangaLauncher/ViewModels/MangaViewModel+ReadState.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel+ReadState.swift
@@ -286,7 +286,8 @@ extension MangaViewModel {
     }
 
     func deletedEntryCount() -> Int {
-        deletedEntries().count
+        // deletedEntries() はソート付きで重いため、カウントだけなら deletedIDs を使う
+        deletedIDs.count
     }
 
     func purgeExpiredSoftDeletes() {

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -129,11 +129,7 @@ final class MangaViewModel {
     }
 
     func totalEntryCount() -> Int {
-        let _ = refreshCounter
-        let descriptor = FetchDescriptor<MangaEntry>(
-            predicate: #Predicate { $0.deletedAt == nil }
-        )
-        return filterEntries(modelContext.fetchLogged(descriptor)).count
+        allEntries().count + hiddenEntries().count
     }
 
     /// タイムラインのアクティビティドットや日別集計に使う全 ReadingActivity。
@@ -237,7 +233,6 @@ final class MangaViewModel {
     // MARK: - Cache Invalidation
 
     func invalidateCacheIfStale() {
-        let _ = refreshCounter
         if cacheVersion != refreshCounter {
             cacheVersion = refreshCounter
             cachedEntries = nil

--- a/MangaLauncher/ViewModels/ReadingStatsProvider.swift
+++ b/MangaLauncher/ViewModels/ReadingStatsProvider.swift
@@ -30,43 +30,29 @@ struct ReadingStatsProvider {
         return modelContext.fetchLogged(descriptor)
     }
 
-    func currentStreak() -> Int {
+    /// 年間の streak（現在・最長）と最もアクティブな曜日をまとめて計算する。
+    /// 個別に呼ぶと365日分のフェッチが毎回走るため、一度にまとめて取得する。
+    struct YearlyStats {
+        let currentStreak: Int
+        let longestStreak: Int
+        let mostActiveDay: String?
+    }
+
+    func yearlyStats() -> YearlyStats {
         let counts = fetchActivityCounts(days: 365)
-        let calendar = Calendar.current
-        var streak = 0
-        var checkDate = calendar.startOfDay(for: Date())
+        return YearlyStats(
+            currentStreak: Self.computeCurrentStreak(from: counts),
+            longestStreak: Self.computeLongestStreak(from: counts),
+            mostActiveDay: Self.computeMostActiveDay(from: counts)
+        )
+    }
 
-        if counts[checkDate] == nil {
-            guard let prev = calendar.date(byAdding: .day, value: -1, to: checkDate) else { return 0 }
-            checkDate = prev
-        }
-
-        while counts[checkDate] != nil {
-            streak += 1
-            guard let prev = calendar.date(byAdding: .day, value: -1, to: checkDate) else { break }
-            checkDate = prev
-        }
-        return streak
+    func currentStreak() -> Int {
+        Self.computeCurrentStreak(from: fetchActivityCounts(days: 365))
     }
 
     func longestStreak() -> Int {
-        let counts = fetchActivityCounts(days: 365)
-        let sortedDates = counts.keys.sorted()
-        guard !sortedDates.isEmpty else { return 0 }
-
-        let calendar = Calendar.current
-        var longest = 1
-        var current = 1
-
-        for i in 1..<sortedDates.count {
-            if calendar.date(byAdding: .day, value: 1, to: sortedDates[i - 1]) == sortedDates[i] {
-                current += 1
-                longest = max(longest, current)
-            } else {
-                current = 1
-            }
-        }
-        return longest
+        Self.computeLongestStreak(from: fetchActivityCounts(days: 365))
     }
 
     func totalReadCount() -> Int {
@@ -89,7 +75,49 @@ struct ReadingStatsProvider {
     }
 
     func mostActiveDay() -> String? {
-        let counts = fetchActivityCounts(days: 365)
+        Self.computeMostActiveDay(from: fetchActivityCounts(days: 365))
+    }
+
+    // MARK: - Pure Computation Helpers
+
+    private static func computeCurrentStreak(from counts: [Date: Int]) -> Int {
+        let calendar = Calendar.current
+        var streak = 0
+        var checkDate = calendar.startOfDay(for: Date())
+
+        if counts[checkDate] == nil {
+            guard let prev = calendar.date(byAdding: .day, value: -1, to: checkDate) else { return 0 }
+            checkDate = prev
+        }
+
+        while counts[checkDate] != nil {
+            streak += 1
+            guard let prev = calendar.date(byAdding: .day, value: -1, to: checkDate) else { break }
+            checkDate = prev
+        }
+        return streak
+    }
+
+    private static func computeLongestStreak(from counts: [Date: Int]) -> Int {
+        let sortedDates = counts.keys.sorted()
+        guard !sortedDates.isEmpty else { return 0 }
+
+        let calendar = Calendar.current
+        var longest = 1
+        var current = 1
+
+        for i in 1..<sortedDates.count {
+            if calendar.date(byAdding: .day, value: 1, to: sortedDates[i - 1]) == sortedDates[i] {
+                current += 1
+                longest = max(longest, current)
+            } else {
+                current = 1
+            }
+        }
+        return longest
+    }
+
+    private static func computeMostActiveDay(from counts: [Date: Int]) -> String? {
         guard !counts.isEmpty else { return nil }
         let calendar = Calendar.current
         var weekdayCounts: [Int: Int] = [:]

--- a/MangaLauncher/Views/Heatmap/ReadingHeatmapView.swift
+++ b/MangaLauncher/Views/Heatmap/ReadingHeatmapView.swift
@@ -36,7 +36,9 @@ struct ReadingHeatmapView: View {
         .onAppear {
             reloadStats()
         }
-        .sheet(item: $selectedDate) { date in
+        .sheet(item: $selectedDate, onDismiss: {
+            reloadStats()
+        }) { date in
             DayActivitySheet(initialDate: date, viewModel: viewModel, activityDates: Set(activityCounts.filter { $0.value > 0 }.keys))
         }
     }

--- a/MangaLauncher/Views/Heatmap/ReadingHeatmapView.swift
+++ b/MangaLauncher/Views/Heatmap/ReadingHeatmapView.swift
@@ -13,6 +13,9 @@ struct ReadingHeatmapView: View {
     private var theme: ThemeStyle { ThemeManager.shared.style }
 
     @State private var activityCounts: [Date: Int] = [:]
+    @State private var yearlyStats: ReadingStatsProvider.YearlyStats?
+    @State private var totalReadCount: Int = 0
+    @State private var thisWeekReadCount: Int = 0
     @State private var selectedDate: Date?
 
     var body: some View {
@@ -31,26 +34,33 @@ struct ReadingHeatmapView: View {
         .navigationBarTitleDisplayMode(.inline)
         #endif
         .onAppear {
-            activityCounts = viewModel.stats.fetchActivityCounts(days: weeks * 7)
+            reloadStats()
         }
         .sheet(item: $selectedDate) { date in
             DayActivitySheet(initialDate: date, viewModel: viewModel, activityDates: Set(activityCounts.filter { $0.value > 0 }.keys))
         }
     }
 
+    private func reloadStats() {
+        activityCounts = viewModel.stats.fetchActivityCounts(days: weeks * 7)
+        yearlyStats = viewModel.stats.yearlyStats()
+        totalReadCount = viewModel.stats.totalReadCount()
+        thisWeekReadCount = viewModel.stats.thisWeekReadCount()
+    }
+
     // MARK: - Stats
 
     private var statsSection: some View {
-        let yearly = viewModel.stats.yearlyStats()
+        let stats = yearlyStats
         return VStack(spacing: 12) {
             HStack(spacing: 16) {
-                statCard(title: "連続", value: "\(yearly.currentStreak)", unit: "日")
-                statCard(title: "最長", value: "\(yearly.longestStreak)", unit: "日")
-                statCard(title: "累計", value: "\(viewModel.stats.totalReadCount())", unit: "話")
+                statCard(title: "連続", value: "\(stats?.currentStreak ?? 0)", unit: "日")
+                statCard(title: "最長", value: "\(stats?.longestStreak ?? 0)", unit: "日")
+                statCard(title: "累計", value: "\(totalReadCount)", unit: "話")
             }
             HStack(spacing: 16) {
-                statCard(title: "今週", value: "\(viewModel.stats.thisWeekReadCount())", unit: "話")
-                statCard(title: "よく読む曜日", value: yearly.mostActiveDay ?? "-", unit: "")
+                statCard(title: "今週", value: "\(thisWeekReadCount)", unit: "話")
+                statCard(title: "よく読む曜日", value: stats?.mostActiveDay ?? "-", unit: "")
             }
         }
     }

--- a/MangaLauncher/Views/Heatmap/ReadingHeatmapView.swift
+++ b/MangaLauncher/Views/Heatmap/ReadingHeatmapView.swift
@@ -41,15 +41,16 @@ struct ReadingHeatmapView: View {
     // MARK: - Stats
 
     private var statsSection: some View {
-        VStack(spacing: 12) {
+        let yearly = viewModel.stats.yearlyStats()
+        return VStack(spacing: 12) {
             HStack(spacing: 16) {
-                statCard(title: "連続", value: "\(viewModel.stats.currentStreak())", unit: "日")
-                statCard(title: "最長", value: "\(viewModel.stats.longestStreak())", unit: "日")
+                statCard(title: "連続", value: "\(yearly.currentStreak)", unit: "日")
+                statCard(title: "最長", value: "\(yearly.longestStreak)", unit: "日")
                 statCard(title: "累計", value: "\(viewModel.stats.totalReadCount())", unit: "話")
             }
             HStack(spacing: 16) {
                 statCard(title: "今週", value: "\(viewModel.stats.thisWeekReadCount())", unit: "話")
-                statCard(title: "よく読む曜日", value: viewModel.stats.mostActiveDay() ?? "-", unit: "")
+                statCard(title: "よく読む曜日", value: yearly.mostActiveDay ?? "-", unit: "")
             }
         }
     }

--- a/MangaShareExtension/ShareExtensionView.swift
+++ b/MangaShareExtension/ShareExtensionView.swift
@@ -71,8 +71,9 @@ struct ShareExtensionView: View {
     ]
 
     private var isValidURL: Bool {
-        guard let url = URL(string: url) else { return false }
-        return url.scheme != nil && !url.scheme!.isEmpty
+        guard let url = URL(string: url),
+              let scheme = url.scheme, !scheme.isEmpty else { return false }
+        return true
     }
 
     var body: some View {


### PR DESCRIPTION
## Summary
- `totalEntryCount()`: 全エントリをメモリにロードしてフィルタ→カウントしていたのを、キャッシュ済みの `allEntries().count + hiddenEntries().count` に置き換え
- `deletedEntryCount()`: ソート付き `deletedEntries()` を呼んでカウントだけ取っていたのを `deletedIDs.count` で即座に返すように変更
- `ReadingStatsProvider`: `currentStreak()` / `longestStreak()` / `mostActiveDay()` が個別に365日分のアクティビティをフェッチしていた問題を解消。計算ロジックを `static` メソッドに抽出し、`yearlyStats()` で1回のフェッチにまとめて計算できるように改善
- `ReadingHeatmapView`: 3つの stats メソッドの個別呼び出しを `yearlyStats()` に置き換え（365日分フェッチ 3回→1回）
- `incrementEpisode`: `Date()` が2回生成されていたのを1回に統一し、entry と activity のタイムスタンプの微妙なずれを防止
- `invalidateCacheIfStale()`: メソッド内の無意味な `let _ = refreshCounter` を除去（`@Observable` の observation tracking はView bodyの外では効果なし）
- `ShareExtensionView.isValidURL`: `url.scheme!` の force unwrap を安全なオプショナルバインディングに置換

## Test plan
- [ ] ビルド成功を確認（✅ `xcodebuild build` 通過済み）
- [ ] ホーム画面のエントリ表示が正常であること
- [ ] 読書アクティビティ画面の連続日数・最長日数・よく読む曜日が正しく表示されること
- [ ] エピソードのインクリメント操作が正常に動作すること
- [ ] 削除済みエントリのカウント表示が正しいこと
- [ ] Share Extension でURL入力時のバリデーションが正常であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)