### PR TITLE
性能改善: サムネイルキャッシュ・save()デバウンス・重計算メモ化

### DIFF
--- a/MangaLauncher/MangaLauncherApp.swift
+++ b/MangaLauncher/MangaLauncherApp.swift
@@ -145,6 +145,10 @@ struct MangaLauncherApp: App {
                     checkPendingOpenCatchUp()
                 }
                 .onChange(of: scenePhase) { _, newPhase in
+                    if newPhase != .active {
+                        // suspend 前にデバウンス中の Widget/バッジ/通知更新を確実に反映する
+                        viewModel.flushSaveSideEffects()
+                    }
                     if newPhase == .active {
                         startMigrationWaitIfNeeded()
                         checkPendingIntent()

--- a/MangaLauncher/ViewModels/MangaViewModel+ReadState.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel+ReadState.swift
@@ -230,17 +230,11 @@ extension MangaViewModel {
         hiddenIDs.remove(entry.id)
         let entryID = entry.id
         let activityDescriptor = FetchDescriptor<ReadingActivity>(predicate: #Predicate { $0.mangaEntryID == entryID })
-        if let activities = try? modelContext.fetch(activityDescriptor) {
-            for activity in activities { modelContext.delete(activity) }
-        }
+        for activity in modelContext.fetchLogged(activityDescriptor) { modelContext.delete(activity) }
         let commentDescriptor = FetchDescriptor<MangaComment>(predicate: #Predicate { $0.mangaEntryID == entryID })
-        if let comments = try? modelContext.fetch(commentDescriptor) {
-            for comment in comments { modelContext.delete(comment) }
-        }
+        for comment in modelContext.fetchLogged(commentDescriptor) { modelContext.delete(comment) }
         let linkDescriptor = FetchDescriptor<MangaLink>(predicate: #Predicate { $0.mangaEntryID == entryID })
-        if let links = try? modelContext.fetch(linkDescriptor) {
-            for link in links { modelContext.delete(link) }
-        }
+        for link in modelContext.fetchLogged(linkDescriptor) { modelContext.delete(link) }
         modelContext.delete(entry)
     }
 
@@ -257,7 +251,7 @@ extension MangaViewModel {
         }
         let day = entry.dayOfWeekRawValue
         let descriptor = FetchDescriptor<MangaEntry>(predicate: #Predicate { $0.dayOfWeekRawValue == day && $0.deletedAt == nil })
-        let maxOrder = (try? modelContext.fetch(descriptor))?.map(\.sortOrder).max() ?? -1
+        let maxOrder = modelContext.fetchLogged(descriptor).map(\.sortOrder).max() ?? -1
         entry.sortOrder = maxOrder + 1
     }
 
@@ -293,7 +287,7 @@ extension MangaViewModel {
     func purgeExpiredSoftDeletes() {
         guard let cutoff = Calendar.current.date(byAdding: .day, value: -30, to: Date()) else { return }
         let descriptor = FetchDescriptor<MangaEntry>(predicate: #Predicate { $0.deletedAt != nil })
-        guard let softDeleted = try? modelContext.fetch(descriptor) else { return }
+        let softDeleted = modelContext.fetchLogged(descriptor)
         let expired = softDeleted.filter { ($0.deletedAt ?? .distantFuture) < cutoff }
         guard !expired.isEmpty else { return }
         for entry in expired {

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -39,6 +39,10 @@ final class MangaViewModel {
     private(set) var modelContext: ModelContext
     @ObservationIgnored var didRunStartupMigrations = false
 
+    /// save() 後の外部反映 (Widget/バッジ/通知) のデバウンス用。
+    @ObservationIgnored private var saveSideEffectsTask: Task<Void, Never>?
+    @ObservationIgnored private var hasPendingSaveSideEffects = false
+
     init(modelContext: ModelContext) {
         self.modelContext = modelContext
         reloadHiddenIDs()
@@ -223,6 +227,36 @@ final class MangaViewModel {
             return
         }
         refreshCounter += 1
+        scheduleSaveSideEffects()
+    }
+
+    // MARK: - Save Side Effects (Widget / Badge / Notifications)
+
+    /// Widget リロード・バッジ更新・通知再スケジュールはいずれも外部プロセス向けの
+    /// 反映で即時性が不要な一方、通知再スケジュールは全7曜日分のフェッチを伴い重い。
+    /// CatchUp のスワイプ既読のように save() が連打される場面で毎回実行しないよう
+    /// 500ms デバウンスでまとめて実行する (DB 保存と UI 更新は save() で同期のまま)。
+    private func scheduleSaveSideEffects() {
+        hasPendingSaveSideEffects = true
+        saveSideEffectsTask?.cancel()
+        saveSideEffectsTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(500))
+            guard !Task.isCancelled else { return }
+            self?.performSaveSideEffectsNow()
+        }
+    }
+
+    /// scenePhase が .active 以外へ遷移するタイミングで App から呼ぶ。
+    /// アプリがすぐバックグラウンドへ行っても Widget/バッジ/通知が
+    /// 必ず最終状態に更新されることを保証する。pending が無ければ no-op。
+    func flushSaveSideEffects() {
+        guard hasPendingSaveSideEffects else { return }
+        saveSideEffectsTask?.cancel()
+        performSaveSideEffectsNow()
+    }
+
+    private func performSaveSideEffectsNow() {
+        hasPendingSaveSideEffects = false
         #if canImport(WidgetKit)
         WidgetCenter.shared.reloadAllTimelines()
         #endif

--- a/MangaLauncher/ViewModels/MangaViewModel.swift
+++ b/MangaLauncher/ViewModels/MangaViewModel.swift
@@ -150,7 +150,7 @@ final class MangaViewModel {
         let descriptor = FetchDescriptor<MangaEntry>(
             predicate: #Predicate { $0.isHidden == true && $0.deletedAt == nil }
         )
-        let entries = (try? modelContext.fetch(descriptor)) ?? []
+        let entries = modelContext.fetchLogged(descriptor)
         hiddenIDs = Set(entries.map(\.id))
     }
 
@@ -158,7 +158,7 @@ final class MangaViewModel {
         let descriptor = FetchDescriptor<MangaEntry>(
             predicate: #Predicate { $0.deletedAt != nil }
         )
-        let entries = (try? modelContext.fetch(descriptor)) ?? []
+        let entries = modelContext.fetchLogged(descriptor)
         deletedIDs = Set(entries.map(\.id))
     }
 

--- a/MangaLauncher/Views/CatchUp/CatchUpCardView.swift
+++ b/MangaLauncher/Views/CatchUp/CatchUpCardView.swift
@@ -35,7 +35,8 @@ struct CatchUpCardView: View {
 
     @ViewBuilder
     private var cardCover: some View {
-        if let imageData = entry.imageData, let image = imageData.toSwiftUIImage() {
+        if let imageData = entry.imageData,
+           let image = imageData.toCachedSwiftUIImage(id: entry.id.uuidString) {
             image
                 .resizable()
                 .scaledToFit()

--- a/MangaLauncher/Views/Heatmap/MangaLifetimeView.swift
+++ b/MangaLauncher/Views/Heatmap/MangaLifetimeView.swift
@@ -138,7 +138,8 @@ struct MangaLifetimeView: View {
     @ViewBuilder
     private func thumbnail(for entry: MangaEntry) -> some View {
         Group {
-            if let data = entry.imageData, let image = data.toSwiftUIImage() {
+            if let data = entry.imageData,
+               let image = data.toCachedSwiftUIImage(id: entry.id.uuidString, maxPixelSize: ThumbnailCache.smallMaxPixelSize) {
                 image.resizable().scaledToFill()
             } else {
                 Color.fromName(entry.iconColor)
@@ -434,7 +435,8 @@ struct LifetimeDetailSheet: View {
     @ViewBuilder
     private var entryThumbnail: some View {
         Group {
-            if let data = lifetime.entry.imageData, let image = data.toSwiftUIImage() {
+            if let data = lifetime.entry.imageData,
+               let image = data.toCachedSwiftUIImage(id: lifetime.entry.id.uuidString, maxPixelSize: ThumbnailCache.smallMaxPixelSize) {
                 image.resizable().scaledToFill()
             } else {
                 Color.fromName(lifetime.entry.iconColor)

--- a/MangaLauncher/Views/Heatmap/MangaLifetimeView.swift
+++ b/MangaLauncher/Views/Heatmap/MangaLifetimeView.swift
@@ -154,15 +154,11 @@ struct MangaLifetimeView: View {
     }
 
     private func openMangaURL(_ urlString: String) {
-        MangaURLOpener(
+        MangaURLOpener.make(
             browserMode: browserMode,
             openURL: openURL,
-            onSafariURL: { safariURL = $0 },
-            onQuickView: { viewModel.browserContext = $0 },
-            entryLookup: { url in
-                guard let e = viewModel.allEntries().first(where: { $0.url == url }) else { return nil }
-                return (e.name, e.publisher, e.imageData)
-            }
+            safariURL: $safariURL,
+            viewModel: viewModel
         ).open(urlString)
     }
 
@@ -323,15 +319,11 @@ struct LifetimeDetailSheet: View {
     }
 
     private func openDetailURL(_ urlString: String) {
-        MangaURLOpener(
+        MangaURLOpener.make(
             browserMode: browserMode,
             openURL: openURL,
-            onSafariURL: { safariURL = $0 },
-            onQuickView: { viewModel.browserContext = $0 },
-            entryLookup: { url in
-                guard let e = viewModel.allEntries().first(where: { $0.url == url }) else { return nil }
-                return (e.name, e.publisher, e.imageData)
-            }
+            safariURL: $safariURL,
+            viewModel: viewModel
         ).open(urlString)
     }
 

--- a/MangaLauncher/Views/Heatmap/ReadingHeatmapView.swift
+++ b/MangaLauncher/Views/Heatmap/ReadingHeatmapView.swift
@@ -321,7 +321,7 @@ private struct DayActivitySheet: View {
                             } label: {
                                 HStack(spacing: 12) {
                                     if let entry, let imageData = entry.imageData,
-                                       let image = imageData.toSwiftUIImage() {
+                                       let image = imageData.toCachedSwiftUIImage(id: entry.id.uuidString, maxPixelSize: ThumbnailCache.smallMaxPixelSize) {
                                         image
                                             .resizable()
                                             .aspectRatio(contentMode: .fill)

--- a/MangaLauncher/Views/Heatmap/ReadingHeatmapView.swift
+++ b/MangaLauncher/Views/Heatmap/ReadingHeatmapView.swift
@@ -269,11 +269,15 @@ struct ReadingHeatmapView: View {
         return calendar.component(.month, from: prevDate) != month
     }
 
-    private func monthLabel(for date: Date) -> String {
+    private static let monthLabelFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "ja_JP")
         formatter.dateFormat = "M月"
-        return formatter.string(from: date)
+        return formatter
+    }()
+
+    private func monthLabel(for date: Date) -> String {
+        Self.monthLabelFormatter.string(from: date)
     }
 }
 
@@ -411,15 +415,11 @@ private struct DayActivitySheet: View {
     }
 
     private func openMangaURL(_ urlString: String) {
-        MangaURLOpener(
+        MangaURLOpener.make(
             browserMode: browserMode,
             openURL: openURL,
-            onSafariURL: { safariURL = $0 },
-            onQuickView: { viewModel.browserContext = $0 },
-            entryLookup: { url in
-                guard let e = viewModel.allEntries().first(where: { $0.url == url }) else { return nil }
-                return (e.name, e.publisher, e.imageData)
-            }
+            safariURL: $safariURL,
+            viewModel: viewModel
         ).open(urlString)
     }
 

--- a/MangaLauncher/Views/Heatmap/ReadingHeatmapView.swift
+++ b/MangaLauncher/Views/Heatmap/ReadingHeatmapView.swift
@@ -17,6 +17,8 @@ struct ReadingHeatmapView: View {
     @State private var totalReadCount: Int = 0
     @State private var thisWeekReadCount: Int = 0
     @State private var selectedDate: Date?
+    @State private var gridMemo = VersionedMemo<[[Date?]]>()
+    @State private var lifetimeMemo = VersionedMemo<[MangaLifetime]>()
 
     var body: some View {
         ScrollView {
@@ -99,7 +101,8 @@ struct ReadingHeatmapView: View {
     // MARK: - Heatmap
 
     private var heatmapSection: some View {
-        let grid = buildGrid()
+        // グリッドは「今日の日付」にのみ依存する純関数なので日付単位でメモ化
+        let grid = gridMemo(version: Calendar.current.startOfDay(for: Date())) { buildGrid() }
         let maxCount = activityCounts.values.max() ?? 1
 
         return HStack(alignment: .top, spacing: 4) {
@@ -195,11 +198,24 @@ struct ReadingHeatmapView: View {
     // MARK: - Lifetime
 
     private var lifetimeSection: some View {
-        let lifetimes = LifetimeBuilder.build(
-            entries: viewModel.allEntries(),
-            activities: viewModel.allActivities(),
-            comments: viewModel.allComments()
-        )
+        // LifetimeBuilder.build は全 entries/activities/comments の突き合わせで重い。
+        // body でデータ変更に効く観測対象 (refreshCounter / pendingDelete / hidden / deleted)
+        // をバージョンとして読み続けることで、Observation によるライブ更新は維持しつつ、
+        // selectedDate 変化などデータと無関係な再レンダーでは再計算をスキップする。
+        let dataVersion: [AnyHashable] = [
+            viewModel.refreshCounter,
+            viewModel.pendingDeleteEntries.map(\.id),
+            viewModel.pendingDeleteComments.map(\.id),
+            viewModel.hiddenIDs,
+            viewModel.deletedIDs,
+        ]
+        let lifetimes = lifetimeMemo(version: dataVersion) {
+            LifetimeBuilder.build(
+                entries: viewModel.allEntries(),
+                activities: viewModel.allActivities(),
+                comments: viewModel.allComments()
+            )
+        }
         return MangaLifetimeView(lifetimes: lifetimes, viewModel: viewModel)
     }
 

--- a/MangaLauncher/Views/Library/HiddenEntriesView.swift
+++ b/MangaLauncher/Views/Library/HiddenEntriesView.swift
@@ -158,7 +158,8 @@ struct HiddenEntriesView: View {
             ScrollView {
                 MasonryLayout(entries: entries, availableWidth: geo.size.width - 32) { entry in
                     VStack(alignment: .leading, spacing: 6) {
-                        if let data = entry.imageData, let image = data.toSwiftUIImage() {
+                        if let data = entry.imageData,
+                           let image = data.toCachedSwiftUIImage(id: entry.id.uuidString) {
                             image
                                 .resizable()
                                 .scaledToFit()
@@ -203,7 +204,8 @@ struct HiddenEntriesView: View {
 
     @ViewBuilder
     private func entryThumbnail(_ entry: MangaEntry, size: CGFloat) -> some View {
-        if let data = entry.imageData, let image = data.toSwiftUIImage() {
+        if let data = entry.imageData,
+           let image = data.toCachedSwiftUIImage(id: entry.id.uuidString, maxPixelSize: ThumbnailCache.smallMaxPixelSize) {
             image
                 .resizable()
                 .scaledToFill()

--- a/MangaLauncher/Views/Library/LibraryCard.swift
+++ b/MangaLauncher/Views/Library/LibraryCard.swift
@@ -90,7 +90,8 @@ struct LibraryCard: View {
 
     @ViewBuilder
     private var cardImage: some View {
-        if let imageData = entry.imageData, let image = imageData.toSwiftUIImage() {
+        if let imageData = entry.imageData,
+           let image = imageData.toCachedSwiftUIImage(id: entry.id.uuidString) {
             image
                 .resizable()
                 .scaledToFill()

--- a/MangaLauncher/Views/Library/RecentlyDeletedView.swift
+++ b/MangaLauncher/Views/Library/RecentlyDeletedView.swift
@@ -129,7 +129,8 @@ struct RecentlyDeletedView: View {
     @ViewBuilder
     private func entryRow(_ entry: MangaEntry) -> some View {
         HStack(spacing: 12) {
-            if let data = entry.imageData, let image = data.toSwiftUIImage() {
+            if let data = entry.imageData,
+               let image = data.toCachedSwiftUIImage(id: entry.id.uuidString, maxPixelSize: ThumbnailCache.smallMaxPixelSize) {
                 image
                     .resizable()
                     .scaledToFill()

--- a/MangaLauncher/Views/Library/Timeline/TimelineRowView.swift
+++ b/MangaLauncher/Views/Library/Timeline/TimelineRowView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import PlatformKit
 
 /// TimelineView の 1 行。時刻ラベル + 縦線 + タイプアイコン + 内容カード。
 struct TimelineRowView: View {
@@ -92,7 +93,7 @@ struct TimelineRowView: View {
         Group {
             if let entry = item.entry,
                let data = entry.imageData,
-               let image = data.toSwiftUIImage() {
+               let image = data.toCachedSwiftUIImage(id: entry.id.uuidString, maxPixelSize: ThumbnailCache.smallMaxPixelSize) {
                 image
                     .resizable()
                     .scaledToFill()

--- a/MangaLauncher/Views/Library/Timeline/TimelineView.swift
+++ b/MangaLauncher/Views/Library/Timeline/TimelineView.swift
@@ -254,15 +254,11 @@ struct TimelineView: View {
     }
 
     private func openMangaURL(_ urlString: String) {
-        MangaURLOpener(
+        MangaURLOpener.make(
             browserMode: browserMode,
             openURL: openURL,
-            onSafariURL: { safariURL = $0 },
-            onQuickView: { viewModel.browserContext = $0 },
-            entryLookup: { url in
-                guard let e = viewModel.allEntries().first(where: { $0.url == url }) else { return nil }
-                return (e.name, e.publisher, e.imageData)
-            }
+            safariURL: $safariURL,
+            viewModel: viewModel
         ).open(urlString)
     }
 

--- a/MangaLauncher/Views/MangaCell/EntryIcon.swift
+++ b/MangaLauncher/Views/MangaCell/EntryIcon.swift
@@ -8,7 +8,8 @@ struct EntryIcon: View {
     private var theme: ThemeStyle { ThemeManager.shared.style }
 
     var body: some View {
-        if let imageData = entry.imageData, let image = imageData.toSwiftUIImage() {
+        if let imageData = entry.imageData,
+           let image = imageData.toCachedSwiftUIImage(id: entry.id.uuidString, maxPixelSize: ThumbnailCache.smallMaxPixelSize) {
             image
                 .resizable()
                 .scaledToFill()

--- a/MangaLauncher/Views/MangaCell/MangaGridCell.swift
+++ b/MangaLauncher/Views/MangaCell/MangaGridCell.swift
@@ -27,7 +27,8 @@ struct MangaGridCell: View {
         } else {
             VStack(alignment: .leading, spacing: 6) {
                 ZStack(alignment: .topTrailing) {
-                    if let imageData = entry.imageData, let image = imageData.toSwiftUIImage() {
+                    if let imageData = entry.imageData,
+                       let image = imageData.toCachedSwiftUIImage(id: entry.id.uuidString) {
                         image
                             .resizable()
                             .scaledToFit()

--- a/Packages/PlatformKit/Sources/PlatformKit/ThumbnailCache.swift
+++ b/Packages/PlatformKit/Sources/PlatformKit/ThumbnailCache.swift
@@ -1,0 +1,103 @@
+import SwiftUI
+import ImageIO
+
+#if canImport(UIKit)
+import UIKit
+
+/// Data → デコード済み UIImage のプロセス内キャッシュ。
+/// セルの body 内で毎回 `UIImage(data:)` フルデコードが走るのを避ける。
+/// キーはコンテンツアドレス方式(呼び出し側ID + サイズバケット + バイト数 + 内容ハッシュ)のため、
+/// 画像編集や CloudKit 同期で imageData が差し替わると自動的に別キーになり、明示的な無効化は不要。
+public final class ThumbnailCache: @unchecked Sendable {
+    public static let shared = ThumbnailCache()
+
+    private let cache: NSCache<NSString, UIImage> = {
+        let cache = NSCache<NSString, UIImage>()
+        cache.totalCostLimit = 100 * 1024 * 1024 // cost = ピクセル数 × 4byte 換算で約100MB
+        return cache
+    }()
+
+    public func image(id: String, data: Data, maxPixelSize: CGFloat?) -> UIImage? {
+        let key = cacheKey(id: id, data: data, maxPixelSize: maxPixelSize) as NSString
+        if let cached = cache.object(forKey: key) { return cached }
+        guard let image = decode(data, maxPixelSize: maxPixelSize) else { return nil }
+        let pixelWidth = image.size.width * image.scale
+        let pixelHeight = image.size.height * image.scale
+        cache.setObject(image, forKey: key, cost: Int(pixelWidth * pixelHeight) * 4)
+        return image
+    }
+
+    private func cacheKey(id: String, data: Data, maxPixelSize: CGFloat?) -> String {
+        let bucket = maxPixelSize.map { String(Int($0)) } ?? "full"
+        return "\(id)|\(bucket)|\(data.count)|\(contentToken(data))"
+    }
+
+    /// 先頭/末尾 1KB の FNV-1a ハッシュ。`Data.hashValue` は先頭 80 バイトしか見ず
+    /// JPEG ヘッダは酷似するため、内容変化の検出には使えない。
+    private func contentToken(_ data: Data) -> UInt64 {
+        var hash: UInt64 = 0xcbf2_9ce4_8422_2325
+        func mix(_ bytes: Data) {
+            for byte in bytes {
+                hash ^= UInt64(byte)
+                hash = hash &* 0x1_0000_0000_01b3
+            }
+        }
+        mix(data.prefix(1024))
+        if data.count > 1024 {
+            mix(data.suffix(1024))
+        }
+        return hash
+    }
+
+    /// maxPixelSize 指定時は ImageIO でダウンサンプルしつつ即時デコード。
+    /// nil はフルサイズデコード (保存時に 600px へ縮小済みのデータをそのまま使う)。
+    private func decode(_ data: Data, maxPixelSize: CGFloat?) -> UIImage? {
+        guard let maxPixelSize else { return UIImage(data: data) }
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxPixelSize,
+            kCGImageSourceShouldCacheImmediately: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+        ]
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil),
+              let cgImage = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else {
+            return UIImage(data: data)
+        }
+        return UIImage(cgImage: cgImage)
+    }
+}
+
+extension ThumbnailCache {
+    /// 表示サイズ ≤44pt の行サムネイル用バケット (44pt @3x = 132px < 160px)。
+    public static let smallMaxPixelSize: CGFloat = 160
+}
+
+extension Data {
+    /// `toSwiftUIImage()` のキャッシュ付き版。デコード結果を再利用するだけで描画結果は同一。
+    /// - Parameters:
+    ///   - id: 呼び出し側の安定ID (例: `entry.id.uuidString`)
+    ///   - maxPixelSize: 小さい行サムネイル表示なら `ThumbnailCache.smallMaxPixelSize`。
+    ///     nil はフルサイズデコード (アスペクト比がレイアウトを決めるグリッドセル用)
+    public func toCachedSwiftUIImage(id: String, maxPixelSize: CGFloat? = nil) -> Image? {
+        guard let uiImage = ThumbnailCache.shared.image(id: id, data: self, maxPixelSize: maxPixelSize) else {
+            return nil
+        }
+        return Image(uiImage: uiImage)
+    }
+}
+
+#else
+
+/// UIKit のないプラットフォーム用のプレースホルダ (定数参照だけ揃える)。
+public enum ThumbnailCache {
+    public static let smallMaxPixelSize: CGFloat = 160
+}
+
+extension Data {
+    /// UIKit のないプラットフォームではキャッシュせず既存経路にフォールバック。
+    public func toCachedSwiftUIImage(id: String, maxPixelSize: CGFloat? = nil) -> Image? {
+        toSwiftUIImage()
+    }
+}
+
+#endif

--- a/Packages/PlatformKit/Sources/PlatformKit/VersionedMemo.swift
+++ b/Packages/PlatformKit/Sources/PlatformKit/VersionedMemo.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// body 内の重い計算を「バージョンが変わった時だけ」再実行するためのメモ化ボックス。
+/// `@State` に保持して使う (参照型の中身書き換えは SwiftUI の再描画をトリガーしない)。
+///
+/// `@State`/`onAppear` へのキャッシュ移設と違い、body 内で version 値
+/// (例: viewModel.refreshCounter) を読み続けるため Observation による
+/// 「データ変更 → 再描画 → 再計算」のライブ更新挙動はそのまま維持される。
+/// 無関係な State 変化による再レンダーでのみ再計算をスキップする。
+public final class VersionedMemo<Value> {
+    private var version: AnyHashable?
+    private var value: Value?
+
+    public init() {}
+
+    public func callAsFunction(version: AnyHashable, compute: () -> Value) -> Value {
+        if let value, self.version == version {
+            return value
+        }
+        let newValue = compute()
+        self.version = version
+        self.value = newValue
+        return newValue
+    }
+}


### PR DESCRIPTION
## 概要

ユーザー可視の動作・見た目を一切変えずに、体感性能と保守性を改善する4コミット構成のPRです。#248 (テストターゲット復旧) と独立にマージ可能です。

## 変更内容 (コミット単位)

### 1. 小物の低リスク改善
- 生の `try? modelContext.fetch` を既存の `fetchLogged` ヘルパーに統一 (7箇所、全て `?? []` 等価パターン。エラーがログに残るようになる)
- `ReadingHeatmapView.monthLabel` の DateFormatter 都度生成を `static let` 化
- `MangaURLOpener.make` ファクトリと完全等価だったインライン構築4箇所を統一 (HiddenEntriesView / CatchUpView は entryLookup・onQuickView が等価でないため対象外)

### 2. サムネイルデコードキャッシュ (効果最大)
各セルが body 内で毎回 600px JPEG を `UIImage(data:)` フルデコードしていた問題を解消。
- PlatformKit に `ThumbnailCache` を新設 (NSCache、≈100MB上限、SPMなのでpbxproj変更なし)
- キーは **コンテンツアドレス方式** (id + サイズバケット + バイト数 + 先頭/末尾1KB FNV-1a) → クロップや CloudKit 同期で画像が差し替わると自動で別キー。無効化フック不要
- `small`(160px): 表示≤44ptの行サムネイル11箇所中7箇所 (44pt@3x=132px < 160px で表示解像度は維持)
- `full`: アスペクト比がレイアウトを決めるグリッド/カードはダウンサンプルせずデコード結果のみキャッシュ (1ピクセルも変わらない)
- ミス時は従来同様の**同期**デコード → 「空白→画像」のちらつきが出る非同期化は不採用
- キャッシュは UUID 文字列と Data 値のみ保持 → detached オブジェクト対策と無干渉

### 3. save() 外部反映のデバウンス
`save()` 毎に Widget 全リロード + バッジ更新 + 全7曜日フェッチの通知再スケジュールが走り、CatchUp スワイプ1枚ごとに約8フェッチ発生していた。
- DB保存と `refreshCounter`(UI更新) は同期のまま、外部反映3点のみ500msデバウンス
- scenePhase が `.active` 以外へ遷移時に `flushSaveSideEffects()` (冪等) → すぐバックグラウンドへ行っても Widget/バッジ/通知は必ず最終状態に更新

### 4. ヒートマップ画面の重計算メモ化
再レンダー毎に `LifetimeBuilder.build` (全データ突き合わせ) と `buildGrid()` (364要素生成) が実行されていた。
- `VersionedMemo` (PlatformKit) による version-keyed メモ化
- **body で refreshCounter / pendingDelete / hiddenIDs / deletedIDs を読み続ける**ため Observation のライブ更新 (CloudKit 同期→自動再計算) は完全維持。データと無関係な再レンダーのみスキップ
- `@State`/`onAppear` へのキャッシュ移設は Observation が切れるため不採用 (過去PR #247 の教訓)

## 検証

- `xcodebuild build` (generic/iOS): 各コミットで BUILD SUCCEEDED
- `xcodebuild test` (#248 をローカルマージした状態、iPhone 16 Pro / iOS 26.0): **105 tests, 20 suites, all passed**
- シミュレータ起動確認: オンボーディング / ホーム(空状態+曜日タブ) / 新規登録シート(画像プレビュー含む) が正常描画

### 実機での目視確認をお願いしたい点
1. ホームグリッドのスクロールと画像表示 (キャッシュ導入後も見た目不変か)
2. 画像クロップ保存 → セルに即反映されるか
3. CatchUp で数枚スワイプ → 即ホーム画面へ → ウィジェットとバッジが最新になるか
4. ヒートマップ → 日別シート開閉 → 統計が更新されるか

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hoa3P5tMFPTnUTeNKqtU2D